### PR TITLE
change ditto download folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 testing/tmp
-.ditto
+ditto

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ You can submit issues or even make pull requests.
 
 ## Usage
 
-* `ditto-cli` this will initialize your environment to work with Ditto if needed.
+* `DEBUG=true ditto-cli
+DEBUG=true DITTO_API_HOST=http://localhost:1234 ditto-cli
+DITTO_API_HOST=http://localhost:1234 ditto-cli` this will initialize your environment to work with Ditto if needed.
 * `ditto-cli help` this will show you help.
 * `ditto-cli pull` pull copy into working directory
 
@@ -26,12 +28,12 @@ You can submit issues or even make pull requests.
 
 The pull command is the workhorse of `ditto-cli`:
 
-* It pulls the text from the project defined in `.ditto/config.yml`.
+* It pulls the text from the project defined in `ditto/config.yml`.
 * We will prompt to overwrite if a file exists (unless we have set a default).
 
 ## Build Process
 
-We recommend using `.gitignore` for `.ditto/texts.json`.
+We recommend using `.gitignore` for `ditto/texts.json`.
 This file is generated and potentially always changing and the commit history can be extensive and perhaps boring:
 
 > Add updated file from Ditto

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -4,5 +4,5 @@ const path = require('path');
 
 module.exports.API_HOST = process.env.DITTO_API_HOST || 'https://api.dittowords.com';
 module.exports.CONFIG_FILE = process.env.DITTO_CONFIG_FILE || path.join(homedir, '.config', 'ditto');
-module.exports.PROJECT_CONFIG_FILE = path.normalize(path.join('.ditto', 'config.yml'));
-module.exports.TEXT_FILE = path.normalize(path.join('.ditto', 'text.json'));
+module.exports.PROJECT_CONFIG_FILE = path.normalize(path.join('ditto', 'config.yml'));
+module.exports.TEXT_FILE = path.normalize(path.join('ditto', 'text.json'));

--- a/lib/init/project.test.js
+++ b/lib/init/project.test.js
@@ -20,7 +20,7 @@ const configMissingId = path.join(__dirname, '../../testing/fixtures/project-con
 const configLegit = path.join(__dirname, '../../testing/fixtures/project-config-working.yml');
 
 describe('saveProject', () => {
-  const configFile = path.join(fakeProjectDir, '.ditto/config.yml');
+  const configFile = path.join(fakeProjectDir, 'ditto/config.yml');
   const projectName = 'My Amazing Project';
   const projectId = '5f284259ce1d451b2eb2e23c';
 
@@ -43,7 +43,7 @@ describe('saveProject', () => {
 });
 
 describe('needsProject()', () => {
-  const configFile = path.join(fakeProjectDir, '.ditto/config.yml');
+  const configFile = path.join(fakeProjectDir, 'ditto/config.yml');
   it('is true if there is no existing config file', () => {
     expect(needsProject(configFile)).toBeTruthy();
   });


### PR DESCRIPTION
## Overview
- change download location from `/.ditto` to `/ditto`

## Test Plan
Testing successfully completed in localhost via:
- [x] `DEBUG=true DITTO_API_HOST=http://localhost:3001 node ./bin/ditto.js`
![image](https://user-images.githubusercontent.com/7476817/108757478-bd37d480-74fe-11eb-940a-203429c77684.png)
- [x] confirm file has been saved to expected location
![image](https://user-images.githubusercontent.com/7476817/108757548-d17bd180-74fe-11eb-9a53-8329ca1f4b5e.png)
