### PR TITLE
Change `ditto-cli` to `ditto`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,25 +12,26 @@ Install the Ditto CLI globally by doing the following:
 npm install -g @dittowords/cli
 ```
 
-Then, run `ditto-cli` to finish setting up. You’ll be prompted to:
+Then, run `ditto` to finish setting up. You’ll be prompted to:
 
 1. Provide your API key (found at [https://beta.dittowords.com/account/user](https://beta.dittowords.com/account/user) under **API Keys**).
 2. Choose a Ditto project in your workspace to pull copy from. Only projects with **developer mode** enabled are accessible via the API.
 
-Once you successfully provide that information, you’re ready to start fetching copy! You can set up the CLI in multiple directories by running the `ditto-cli` command and choosing a project to sync from.
+Once you successfully provide that information, you’re ready to start fetching copy! You can set up the CLI in multiple directories by running the `ditto` command and choosing a project to sync from.
 
 ## Commands
 
 ### `pull`
 
-**Usage:** `ditto-cli pull`
+**Usage:** `ditto pull`
+
 **Action:** To pull the latest text from the linked project into `ditto/text.json`.
 
 The text will be pulled down as a structured JSON with IDs, and will locally overwrite what was previously in the file.
 
 ### `project`
 
-**Usage:** `ditto-cli project`
+**Usage:** `ditto project`
 
 **Action:** To change the Ditto project you want to pull copy from in the current directory. Running this will allow you to select a project from a list of projects in your workspace that have developer mode enabled.
 

--- a/bin/ditto.js
+++ b/bin/ditto.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// This is the main entry point for the ditto-cli command.
+// This is the main entry point for the ditto command.
 const { program } = require('commander');
 // to use V8's code cache to speed up instantiation time
 require('v8-compile-cache');
@@ -20,7 +20,7 @@ function quit() {
 }
 
 const setupCommands = () => {
-  program.name('ditto-cli');
+  program.name('ditto');
   program
     .command('pull')
     .description('Sync copy from Ditto into working directory')
@@ -60,7 +60,7 @@ const checkInit = async (command) => {
 };
 
 const main = async () => {
-  if (process.argv.length <= 2 && process.argv[1].includes('ditto-cli')) {
+  if (process.argv.length <= 2 && process.argv[1].includes('ditto')) {
     await checkInit('none');
   } else {
     setupCommands();

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "api"
   ],
   "bin": {
-    "ditto-cli": "./bin/ditto.js"
+    "ditto": "./bin/ditto.js"
   },
   "devDependencies": {
     "@babel/core": "^7.11.4",


### PR DESCRIPTION
## Overview
Update commands (and README) with `ditto` instead of `ditto-cli`