### PR TITLE
Handle revoked api keys

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -30,6 +30,15 @@ function justTheHost(host) {
   return url.parse(host).hostname;
 }
 
+function deleteToken(file, host) {
+  const data = readData(file);
+  const hostParsed = justTheHost(host);
+  data[hostParsed] = [];
+  data[hostParsed][0] = {};
+  data[hostParsed][0].token = '';
+  writeData(file, data);
+}
+
 function saveToken(file, host, token) {
   const data = readData(file);
   const hostParsed = justTheHost(host);
@@ -67,6 +76,7 @@ module.exports = {
   writeData,
   justTheHost,
   saveToken,
+  deleteToken,
   getToken,
   save,
 };

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -55,15 +55,12 @@ async function getProjects(token) {
         Authorization: `token ${token}`,
       },
     });
-    spinner.stop();
-    return projects.data.map((item) => `${item.name} ${output.subtle(item.url)}`);
   } catch (e) {
     spinner.stop();
-    if (e.response && e.response.status === 404) {
-      await askForAnotherToken();
-      await collectAndSaveProject();
-    }
+    throw e;
   }
+  spinner.stop();
+  return projects.data.map((item) => `${item.name} ${output.subtle(item.url)}`);
 }
 
 function parseResponse(response) {
@@ -78,7 +75,6 @@ async function collectProject(token, initialize) {
     console.log(message);
   }
   const projects = await getProjects(token);
-
   const prompt = new AutoComplete({
     name: 'project',
     message: initialize ? "Choose the project you'd like to sync text from" : 'Choose a different project',
@@ -95,12 +91,17 @@ async function collectAndSaveProject(initialize = false) {
     const token = config.getToken(consts.CONFIG_FILE, consts.API_HOST);
     const project = await collectProject(token, initialize);
   
-    console.log(`Thanks for choosing a project.  We'll save this info to: ${output.info(consts.PROJECT_CONFIG_FILE)}`);
+    console.log(`Thanks for choosing a project. We'll save this info to: ${output.info(consts.PROJECT_CONFIG_FILE)}`);
     output.nl();
   
     saveProject(consts.PROJECT_CONFIG_FILE, project.name, project.id);
   } catch (e) {
-    quit();
+    if (e.response && e.response.status === 404) {
+      await askForAnotherToken();
+      await collectAndSaveProject();
+    } else {
+      quit();
+    }
   }
 }
 

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -8,6 +8,13 @@ const api = require('../api').default;
 const config = require('../config');
 const consts = require('../consts');
 const output = require('../output');
+const { collectAndSaveToken } = require('../init/token');
+
+function quit() {
+  console.log('\nExiting Ditto CLI...');
+  process.exitCode = 2;
+  process.exit();
+}
 
 function saveProject(file, name, id) {
   const data = config.readData(file, { projects: [] });
@@ -32,21 +39,31 @@ function needsProject(configFile) {
   return { exists: true, name: data.projects[0].name, id: data.projects[0].id };
 }
 
-async function getProjects(token = null) {
+async function askForAnotherToken() {
+  config.deleteToken(consts.CONFIG_FILE, consts.API_HOST);
+  const message = "Looks like the API key you have saved no longer works. Please enter another one."
+  await collectAndSaveToken(message);
+}
+
+async function getProjects(token) {
   const spinner = ora("Fetching projects in your workspace...");
   spinner.start();
   let projects = [];
-  if (token) {
+  try {
     projects = await api.get('/projects', {
       headers: {
         Authorization: `token ${token}`,
       },
     });
-  } else {
-    projects = await api.get('/projects');
+    spinner.stop();
+    return projects.data.map((item) => `${item.name} ${output.subtle(item.url)}`);
+  } catch (e) {
+    spinner.stop();
+    if (e.response && e.response.status === 404) {
+      await askForAnotherToken();
+      await collectAndSaveProject();
+    }
   }
-  spinner.stop();
-  return projects.data.map((item) => `${item.name} ${output.subtle(item.url)}`);
 }
 
 function parseResponse(response) {
@@ -54,7 +71,7 @@ function parseResponse(response) {
   return { name, id };
 }
 
-async function collectProject(token = null, initialize) {
+async function collectProject(token, initialize) {
   const path = process.cwd();
   if (initialize) {
     const message = `Looks like there's no Ditto project associated with your current directory: ${output.info(path)}.`;
@@ -74,12 +91,17 @@ async function collectProject(token = null, initialize) {
 }
 
 async function collectAndSaveProject(initialize = false) {
-  const token = config.getToken(consts.CONFIG_FILE, consts.API_HOST);
-  const project = await collectProject(token, initialize);
-  console.log(`Thanks for choosing a project.  We'll save this info to: ${output.info(consts.PROJECT_CONFIG_FILE)}`);
-  output.nl();
-
-  saveProject(consts.PROJECT_CONFIG_FILE, project.name, project.id);
+  try {
+    const token = config.getToken(consts.CONFIG_FILE, consts.API_HOST);
+    const project = await collectProject(token, initialize);
+  
+    console.log(`Thanks for choosing a project.  We'll save this info to: ${output.info(consts.PROJECT_CONFIG_FILE)}`);
+    output.nl();
+  
+    saveProject(consts.PROJECT_CONFIG_FILE, project.name, project.id);
+  } catch (e) {
+    quit();
+  }
 }
 
 module.exports = { needsProject, collectAndSaveProject };

--- a/lib/init/token.js
+++ b/lib/init/token.js
@@ -26,10 +26,10 @@ async function checkToken(token) {
     if (error.code === 'ENOTFOUND') {
       return output.errorText(`Can't connect to API: ${output.url(error.hostname)}`);
     }
-    if (error.response.status === 401) {
+    if (error.response.status === 401 || error.response.status === 404) {
       return output.errorText("This API key isn't valid. Please try another.");
     }
-    return output.warnText("We're having trouble reaching the Ditto API: ", error);
+    return output.warnText("We're having trouble reaching the Ditto API.");
   }).catch(() => output.errorText("Sorry! We're having trouble reaching the Ditto API."));
 
   if (typeof resOrError === 'string') return resOrError;
@@ -39,11 +39,11 @@ async function checkToken(token) {
   return output.errorText("This API key isn't valid. Please try another.");
 }
 
-async function collectToken() {
+async function collectToken(message) {
   const blue = output.info;
   const apiUrl = output.url('https://beta.dittowords.com/account/user');
   const breadcrumbs = `${blue('User')}`;
-  const tokenDescription = `To get started, you'll need your Ditto API key. You can find this at: ${apiUrl} > ${breadcrumbs} under "${chalk.bold('API Keys')}".`;
+  const tokenDescription = message || `To get started, you'll need your Ditto API key. You can find this at: ${apiUrl} > ${breadcrumbs} under "${chalk.bold('API Keys')}".`;
   console.log(tokenDescription);
 
   const response = await prompt({
@@ -55,13 +55,23 @@ async function collectToken() {
   return response.token;
 }
 
-async function collectAndSaveToken() {
-  const token = await collectToken();
-  console.log(`Thanks for authenticating.  We'll save the key to: ${output.info(consts.CONFIG_FILE)}`);
-  output.nl();
+function quit() {
+  console.log('API key was not saved.');
+  process.exitCode = 2;
+  process.exit();
+}
 
-  config.saveToken(consts.CONFIG_FILE, consts.API_HOST, token);
-  return token;
+async function collectAndSaveToken(message = null) {
+  try {
+    const token = await collectToken(message);
+    console.log(`Thanks for authenticating.  We'll save the key to: ${output.info(consts.CONFIG_FILE)}`);
+    output.nl();
+
+    config.saveToken(consts.CONFIG_FILE, consts.API_HOST, token);
+    return token;
+  } catch (error) {
+    quit();
+  }
 }
 
 module.exports = { needsToken, collectAndSaveToken };

--- a/lib/output.js
+++ b/lib/output.js
@@ -6,7 +6,7 @@ const info = (msg) => chalk.blueBright(msg);
 const success = (msg) => chalk.green(msg);
 const url = (msg) => chalk.blueBright.underline(msg);
 const subtle = (msg) => chalk.grey(msg);
-const write = (msg) => console.log(chalk.white(msg));
+const write = (msg) => chalk.white(msg);
 const nl = () => console.log('\n');
 
 module.exports = {

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -46,7 +46,7 @@ async function downloadAndSave(projectConfig, token) {
     }
     if (e.response && e.response.status === 403) {
       error = "The requested project doesn't have Developer Mode enabled";
-      msg = `${output.errorText(error)}.\nLearn more about Developer Mode here: ${output.info('https://www.dittowords.com/docs/ditto-developer-mode')}.`;
+      msg = `${output.errorText(error)}.\nPlease choose a different project using the ${output.info('project')} command, or turn on Developer Mode for this project. Learn more here: ${output.subtle('https://www.dittowords.com/docs/ditto-developer-mode')}.`;
       return console.log(msg);
     }
     if (e.response && e.response.status === 400) {

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -7,6 +7,13 @@ const api = require('./api').default;
 const config = require('./config');
 const consts = require('./consts');
 const output = require('./output');
+const { collectAndSaveToken } = require('./init/token');
+
+async function askForAnotherToken() {
+  config.deleteToken(consts.CONFIG_FILE, consts.API_HOST);
+  const message = "Looks like the API key you have saved no longer works. Please enter another one."
+  await collectAndSaveToken(message);
+}
 
 async function downloadAndSave(projectConfig, token) {
   const projectName = projectConfig.projects[0].name;
@@ -22,16 +29,25 @@ async function downloadAndSave(projectConfig, token) {
     });
     fs.writeFileSync(consts.TEXT_FILE, JSON.stringify(res.data, null, 2));
     msg = `Fetching the latest text from ${output.info(projectName)}... ${output.success('done')}. \nSuccessfully saved to ${output.info(consts.TEXT_FILE)}.`;
+    spinner.stop();
+    return console.log(msg);
   } catch (e) {
+    spinner.stop();
     let error = e.message;
-    if (e.response && e.response.status === 401) {
-      error = output.info("Looks like you don't have access to the specified project.");
+    if (e.response && e.response.status === 404) {
+      await askForAnotherToken();
+      pull();
+      return;
     }
-    msg = output.errorText(`We hit an error fetching text from the project: ${error}`);
+    if (e.response && e.response.status === 401) {
+      error = output.errorText("you don't have access to the specified project.");
+    }
+    if (e.response && e.response.status === 400) {
+      error = output.errorText("project not found");
+    }
+    msg = `We hit an error fetching text from the project: ${output.errorText(error)}.\nChoose another using the ${output.info('project')} command.`;
+    return console.log(msg);
   }
-  spinner.stop();
-
-  return console.log(msg);
 }
 
 function pull() {

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -51,8 +51,6 @@ async function downloadAndSave(projectConfig, token) {
     }
     if (e.response && e.response.status === 400) {
       error = "project not found";
-      msg = `We hit an error fetching text from the project: ${output.errorText(error)}.\nChoose another using the ${output.info('project')} command.`;
-    return console.log(msg);
     }
     msg = `We hit an error fetching text from the project: ${output.errorText(error)}.\nChoose another using the ${output.info('project')} command.`;
     return console.log(msg);

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -40,7 +40,7 @@ async function downloadAndSave(projectConfig, token) {
       return;
     }
     if (e.response && e.response.status === 401) {
-      error = output.errorText("you don't have access to the specified project.");
+      error = output.errorText("you don't have access to the selected project");
     }
     if (e.response && e.response.status === 400) {
       error = output.errorText("project not found");

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -40,10 +40,19 @@ async function downloadAndSave(projectConfig, token) {
       return;
     }
     if (e.response && e.response.status === 401) {
-      error = output.errorText("you don't have access to the selected project");
+      error = "You don't have access to the selected project";
+      msg = `${output.errorText(error)}.\nChoose another using the ${output.info('project')} command, or update your API key.`;
+      return console.log(msg);
+    }
+    if (e.response && e.response.status === 403) {
+      error = "The requested project doesn't have Developer Mode enabled";
+      msg = `${output.errorText(error)}.\nLearn more about Developer Mode here: ${output.info('https://www.dittowords.com/docs/ditto-developer-mode')}.`;
+      return console.log(msg);
     }
     if (e.response && e.response.status === 400) {
-      error = output.errorText("project not found");
+      error = "project not found";
+      msg = `We hit an error fetching text from the project: ${output.errorText(error)}.\nChoose another using the ${output.info('project')} command.`;
+    return console.log(msg);
     }
     msg = `We hit an error fetching text from the project: ${output.errorText(error)}.\nChoose another using the ${output.info('project')} command.`;
     return console.log(msg);

--- a/lib/select-project.js
+++ b/lib/select-project.js
@@ -3,6 +3,12 @@ const config = require('./config');
 const output = require('./output');
 const consts = require('./consts');
 
+function quit() {
+  console.log('Project selection was not updated.');
+  process.exitCode = 2;
+  process.exit();
+}
+
 const selectProject = async () => {
   const projectConfig = config.readData(consts.PROJECT_CONFIG_FILE);
   const { name, id } = projectConfig.projects[0];
@@ -13,9 +19,7 @@ const selectProject = async () => {
     if (error && error.response && error.response.status === 400) {
       console.log('\nSorry, there was an error fetching the projects in your workspace.');
     }
-    console.log('Project selection was not updated.');
-    process.exitCode = 2;
-    process.exit();
+    quit();
   }
 };
 


### PR DESCRIPTION
## Overview
Updates to handle revoked API keys: when key that's saved can't be found in our database, clear existing one from from `.config/ditto` file and prompt the user to enter a new one.
Updates to handle errors returned by `/projects/:id` (specifically, if requested project doesn't have dev mode on).

## Context
- associated Ditto API PR: https://github.com/dittowords/ditto-app/pull/306

## Screenshots
- run `pull` command with revoked key, enter new one -> pull executed
![image](https://user-images.githubusercontent.com/19499117/109726481-ac730880-7b67-11eb-82dc-08539cea5426.png)

- run `project` command with revoked key (and then quit before enter new one) -> displays message
![image](https://user-images.githubusercontent.com/19499117/109726408-8fd6d080-7b67-11eb-91ae-171fe7d06d32.png)

- requested project doesn't have dev mode on:
![image](https://user-images.githubusercontent.com/19499117/109905648-f2a59600-7c53-11eb-803b-0b2bed1f6637.png)


## Test Plan
- Tested locally (local CLI and local API): https://www.notion.so/dittov3/handle-revoke-keys-Ditto-CLI-Testing-0a8ce467dbea43ed9cc053e8e9023c6f
- Once merged into CLI, will test again with staging API and published CLI