### PR TITLE
Support pulling and saving multi-project text data

### DIFF
--- a/bin/ditto.js
+++ b/bin/ditto.js
@@ -6,7 +6,7 @@ require('v8-compile-cache');
 
 const { init, needsInit } = require('../lib/init/init');
 const pull = require('../lib/pull');
-const selectProject = require('../lib/select-project');
+const addProject = require('../lib/add-project');
 
 /**
  * Catch and report unexpected error.
@@ -61,7 +61,7 @@ const checkInit = async (command) => {
         break;
       case 'project':
       case 'project add':
-        selectProject();
+        addProject();
         break;
       case 'project remove':
         // TODO: implement me

--- a/bin/ditto.js
+++ b/bin/ditto.js
@@ -6,7 +6,9 @@ require('v8-compile-cache');
 
 const { init, needsInit } = require('../lib/init/init');
 const pull = require('../lib/pull');
+
 const addProject = require('../lib/add-project');
+const removeProject = require('../lib/remove-project');
 
 /**
  * Catch and report unexpected error.
@@ -64,8 +66,7 @@ const checkInit = async (command) => {
         addProject();
         break;
       case 'project remove':
-        // TODO: implement me
-        console.error(`Error: 'project remove' has not been implemented`);
+        removeProject();
         break;
       case 'none':
         setupCommands();

--- a/bin/ditto.js
+++ b/bin/ditto.js
@@ -46,12 +46,11 @@ const setupCommands = () => {
 };
 
 const checkInit = async (command) => {
-  if (needsInit()) {
+  if (needsInit() && command !== 'project remove') {
     try {
       await init();
-      if (command === 'pull') {
+      if (command === 'pull') 
         main(); // re-run to actually pull text now that init is finished
-      }
     } catch (error) {
       quit();
     }

--- a/bin/ditto.js
+++ b/bin/ditto.js
@@ -25,10 +25,23 @@ const setupCommands = () => {
     .command('pull')
     .description('Sync copy from Ditto into working directory')
     .action(() => checkInit('pull'));
-  program
+    
+  const projectDescription = 'Add a Ditto project to sync copy from'
+  const projectCommand = program
     .command('project')
-    .description('Select Ditto project to sync copy from')
+    .description(projectDescription)
     .action(() => checkInit('project'));
+
+  projectCommand
+    .command('add')
+    .description(projectDescription)
+    .action(() => checkInit('project'));
+    
+  projectCommand
+    .command('remove')
+    // TODO: write better description
+    .description('Remove a Ditto project that copy is currently synced from')
+    .action(() => checkInit('project remove'));
 };
 
 const checkInit = async (command) => {
@@ -48,6 +61,10 @@ const checkInit = async (command) => {
         break;
       case 'project':
         selectProject();
+        break;
+      case 'project remove':
+        // TODO: implement me
+        console.error(`Error: 'project remove' has not been implemented`);
         break;
       case 'none':
         setupCommands();

--- a/bin/ditto.js
+++ b/bin/ditto.js
@@ -41,8 +41,7 @@ const setupCommands = () => {
     
   projectCommand
     .command('remove')
-    // TODO: write better description
-    .description('Remove a Ditto project that copy is currently synced from')
+    .description('Stop syncing copy from a Ditto project')
     .action(() => checkInit('project remove'));
 };
 

--- a/bin/ditto.js
+++ b/bin/ditto.js
@@ -16,7 +16,7 @@ const removeProject = require('../lib/remove-project');
  * @returns {void}
  */
 function quit() {
-  console.log('\nExiting Ditto CLI...');
+  console.log('\nExiting Ditto CLI...\n');
   process.exitCode = 2;
   process.exit();
 }

--- a/bin/ditto.js
+++ b/bin/ditto.js
@@ -60,6 +60,7 @@ const checkInit = async (command) => {
         pull();
         break;
       case 'project':
+      case 'project add':
         selectProject();
         break;
       case 'project remove':

--- a/lib/add-project.js
+++ b/lib/add-project.js
@@ -1,7 +1,6 @@
 const { collectAndSaveProject } = require('./init/project');
-const config = require('./config');
-const output = require('./output');
-const consts = require('./consts');
+const projectsToText = require('./utils/projectsToText');
+const getSelectedProjects = require('./utils/getSelectedProjects');
 
 function quit() {
   console.log('Project selection was not updated.');
@@ -10,10 +9,10 @@ function quit() {
 }
 
 const selectProject = async () => {
-  const projectConfig = config.readData(consts.PROJECT_CONFIG_FILE);
-  const { name, id } = projectConfig.projects[0];
+  const projects = getSelectedProjects();
+
   try {
-    console.log("\nYou're currently set up to sync text from the following project: " + output.info(name) + " " + output.subtle('https://beta.dittowords.com/doc/' + id));
+    console.log(`\nYou're currently set up to sync text from the following projects: ${projectsToText(projects)}`);
     await collectAndSaveProject(false);
   } catch (error) {
     if (error && error.response && error.response.status === 400) {

--- a/lib/add-project.js
+++ b/lib/add-project.js
@@ -8,7 +8,7 @@ function quit() {
   process.exit();
 }
 
-const selectProject = async () => {
+const addProject = async () => {
   const projects = getSelectedProjects();
 
   try {
@@ -22,4 +22,4 @@ const selectProject = async () => {
   }
 };
 
-module.exports = selectProject;
+module.exports = addProject;

--- a/lib/add-project.js
+++ b/lib/add-project.js
@@ -15,9 +15,7 @@ const addProject = async () => {
     console.log(`\nYou're currently set up to sync text from the following projects: ${projectsToText(projects)}`);
     await collectAndSaveProject(false);
   } catch (error) {
-    if (error && error.response && error.response.status === 400) {
-      console.log('\nSorry, there was an error fetching the projects in your workspace.');
-    }
+    console.log(`\nSorry, there was an error adding a project to your workspace: `, error);
     quit();
   }
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,6 +21,7 @@ function readData(file, defaultData = {}) {
 }
 
 function writeData(file, data) {
+  createFileIfMissing(file);
   const yamlStr = yaml.safeDump(data);
   fs.writeFileSync(file, yamlStr, 'utf8');
 }

--- a/lib/init/init.js
+++ b/lib/init/init.js
@@ -2,12 +2,13 @@
 // expected to be run once per project.
 const boxen = require('boxen');
 const chalk = require('chalk');
+const getSelectedProjects = require('../utils/getSelectedProjects');
 const projectsToText = require('../utils/projectsToText');
 
 const { needsProjects, collectAndSaveProject } = require('./project');
 const { needsToken, collectAndSaveToken } = require('./token');
 
-const needsInit = () => (needsToken() || !(needsProjects()).exists);
+const needsInit = () => needsToken() || needsProjects();
 
 function welcome() {
   const msg = chalk.white(`${chalk.bold('Welcome to the',
@@ -22,10 +23,9 @@ async function init() {
   if (needsToken()) {
     await collectAndSaveToken();
   }
-  const savedProjectInfo = needsProjects();
-  if (savedProjectInfo.exists) {
-    const { projects } = savedProjectInfo;
-    console.log(`You're currently set up to sync text from the following projects: ${projectsToText(projects)}\n`);
+  const selectedProjects = getSelectedProjects();
+  if (selectedProjects.length) {
+    console.log(`You're currently set up to sync text from the following projects: ${projectsToText(selectedProjects)}\n`);
   } else {
     await collectAndSaveProject(true);
   }

--- a/lib/init/init.js
+++ b/lib/init/init.js
@@ -2,7 +2,7 @@
 // expected to be run once per project.
 const boxen = require('boxen');
 const chalk = require('chalk');
-const listProjects = require('../utils/listProjects');
+const projectsToText = require('../utils/projectsToText');
 
 const { needsProjects, collectAndSaveProject } = require('./project');
 const { needsToken, collectAndSaveToken } = require('./token');
@@ -25,7 +25,7 @@ async function init() {
   const savedProjectInfo = needsProjects();
   if (savedProjectInfo.exists) {
     const { projects } = savedProjectInfo;
-    console.log(`You're currently set up to sync text from the following projects: ${listProjects(projects)}\n`);
+    console.log(`You're currently set up to sync text from the following projects: ${projectsToText(projects)}\n`);
   } else {
     await collectAndSaveProject(true);
   }

--- a/lib/init/init.js
+++ b/lib/init/init.js
@@ -2,7 +2,7 @@
 // expected to be run once per project.
 const boxen = require('boxen');
 const chalk = require('chalk');
-const output = require('../output');
+const listProjects = require('../utils/listProjects');
 
 const { needsProjects, collectAndSaveProject } = require('./project');
 const { needsToken, collectAndSaveToken } = require('./token');
@@ -25,20 +25,7 @@ async function init() {
   const savedProjectInfo = needsProjects();
   if (savedProjectInfo.exists) {
     const { projects } = savedProjectInfo;
-
-    console.log(
-      "You're currently set up to sync text from the following projects: " +
-      projects.reduce((outputString, { name, id }) => 
-        outputString + (
-          "\n" +
-          "- " + output.info(name) +
-          " " +
-          output.subtle('https://beta.dittowords.com/doc/' + id)
-        ), ""
-      )
-    );
-
-    console.log('\n');
+    console.log(`You're currently set up to sync text from the following projects: ${listProjects(projects)}\n`);
   } else {
     await collectAndSaveProject(true);
   }

--- a/lib/init/init.js
+++ b/lib/init/init.js
@@ -4,10 +4,10 @@ const boxen = require('boxen');
 const chalk = require('chalk');
 const output = require('../output');
 
-const { needsProject, collectAndSaveProject } = require('./project');
+const { needsProjects, collectAndSaveProject } = require('./project');
 const { needsToken, collectAndSaveToken } = require('./token');
 
-const needsInit = () => (needsToken() || !(needsProject()).exists);
+const needsInit = () => (needsToken() || !(needsProjects()).exists);
 
 function welcome() {
   const msg = chalk.white(`${chalk.bold('Welcome to the',
@@ -22,10 +22,22 @@ async function init() {
   if (needsToken()) {
     await collectAndSaveToken();
   }
-  const savedProjectInfo = needsProject();
+  const savedProjectInfo = needsProjects();
   if (savedProjectInfo.exists) {
-    const { name, id } = savedProjectInfo;
-    console.log("\nYou're currently set up to sync text from the following project: " + output.info(name) + " " + output.subtle('https://beta.dittowords.com/doc/' + id));
+    const { projects } = savedProjectInfo;
+
+    console.log(
+      "You're currently set up to sync text from the following projects: " +
+      projects.reduce((outputString, { name, id }) => 
+        outputString + (
+          "\n" +
+          "- " + output.info(name) +
+          " " +
+          output.subtle('https://beta.dittowords.com/doc/' + id)
+        ), ""
+      )
+    );
+
     console.log('\n');
   } else {
     await collectAndSaveProject(true);

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -70,7 +70,7 @@ async function collectProject(token, initialize) {
     projects && 
     projects.length
   )) {
-    console.log("No unselected projects were found in your workspace.");
+    console.log("You're currently syncing all projects in your workspace.");
     return null;
   }
 

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -9,7 +9,7 @@ const getSelectedProjects = require('../utils/getSelectedProjects');
 const promptForProject = require('../utils/promptForProject');
 
 function quit() {
-  console.log('\nExiting Ditto CLI...');
+  console.log('\nExiting Ditto CLI...\n');
   process.exitCode = 2;
   process.exit();
 }
@@ -70,7 +70,7 @@ async function collectProject(token, initialize) {
     projects && 
     projects.length
   )) {
-    console.log("\nNo unselected projects were found in your workspace.");
+    console.log("No unselected projects were found in your workspace.");
     return null;
   }
 

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -79,7 +79,7 @@ async function collectProject(token, initialize) {
     projects && 
     projects.length
   )) {
-    console.log("\nNo new selectable projects were found in your workspace.");
+    console.log("\nNo unselected projects were found in your workspace.");
     return null;
   }
 

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -22,7 +22,7 @@ function saveProject(file, name, id) {
   config.writeData(file, data);
 }
 
-function needsProject(configFile) {
+function needsProjects(configFile) {
   const file = configFile || consts.PROJECT_CONFIG_FILE;
   if (!fs.existsSync(file)) return { exists: false };
   let data;
@@ -33,10 +33,16 @@ function needsProject(configFile) {
       return { exists: false };
     }
   }
-  if (!data.projects) return { exists: false };
-  if (!data.projects[0].name) return { exists: false };
-  if (!data.projects[0].id) return { exists: false };
-  return { exists: true, name: data.projects[0].name, id: data.projects[0].id };
+
+  const { projects } = data;
+
+  if (!projects) 
+    return { exists: false };
+
+  if (projects.some(({ name, id }) => !(name && id)))  
+    return { exists: false }
+
+  return { exists: true, projects };
 }
 
 async function askForAnotherToken() {
@@ -105,4 +111,4 @@ async function collectAndSaveProject(initialize = false) {
   }
 }
 
-module.exports = { needsProject, collectAndSaveProject };
+module.exports = { needsProjects, collectAndSaveProject };

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -34,14 +34,14 @@ async function askForAnotherToken() {
   await collectAndSaveToken(message);
 }
 
-async function getProjects(token, projectsAlreadySelected) {
+async function listProjects(token, projectsAlreadySelected) {
   const spinner = ora("Fetching projects in your workspace...");
   spinner.start();
 
   let projects = [];
 
   try {
-    projects = await api.get('/projects', {
+    projects = await api.get('/list-projects', {
       headers: {
         Authorization: `token ${token}`,
       },
@@ -64,7 +64,7 @@ async function collectProject(token, initialize) {
   }
 
   const projectsAlreadySelected = getSelectedProjects();
-  const projects = await getProjects(token, projectsAlreadySelected);
+  const projects = await listProjects(token, projectsAlreadySelected);
 
   if (!(
     projects && 

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -9,10 +9,7 @@ const consts = require('../consts');
 const output = require('../output');
 const { collectAndSaveToken } = require('../init/token');
 const getSelectedProjects = require('../utils/getSelectedProjects');
-<<<<<<< HEAD
 const promptForProject = require('../utils/promptForProject');
-=======
->>>>>>> 3299f85cca9498ff9c0895a21dc5b407bfca1771
 
 function quit() {
   console.log('\nExiting Ditto CLI...');
@@ -30,24 +27,15 @@ function saveProject(file, name, id) {
 }
 
 function needsProjects(configFile) {
-  const file = configFile || consts.PROJECT_CONFIG_FILE;
-  if (!fs.existsSync(file)) return { exists: false };
-  let data;
-  try {
-    data = config.readData(file);
-  } catch (e) {
-    if (e instanceof YAMLException) {
-      return { exists: false };
-    }
-  }
+  const projects = getSelectedProjects(configFile);
 
-  const { projects } = data;
-
-  if (!projects) 
-    return { exists: false };
-
-  if (projects.some(({ name, id }) => !(name && id)))  
+  if (!(
+    projects && 
+    projects.length &&
+    !projects.some(({ name, id }) => !(name && id))
+  )) {
     return { exists: false }
+  }
 
   return { exists: true, projects };
 }
@@ -75,18 +63,10 @@ async function getProjects(token, projectsAlreadySelected) {
     throw e;
   }
 
-  const projectIdsAlreadySelected = projectsAlreadySelected.map(({ id }) => id);
-  const projectsUnselected = projects.data.filter(({ id }) => !projectIdsAlreadySelected.includes(id));
-
   spinner.stop();
-<<<<<<< HEAD
-=======
 
-  return projectsUnselected.map((item) => `${item.name} ${output.subtle(item.url)}`);
-}
->>>>>>> 3299f85cca9498ff9c0895a21dc5b407bfca1771
-
-  return projectsUnselected.map((item) => `${item.name} ${output.subtle(item.url)}`);
+  return projects.data
+    .filter(({ id }) => !projectsAlreadySelected.some(project => project.id === id));
 }
 
 async function collectProject(token, initialize) {
@@ -103,25 +83,7 @@ async function collectProject(token, initialize) {
     projects && 
     projects.length
   )) {
-    console.log("\nNo other selectable projects were found in your workspace.");
-    return null;
-  }
-
-  const prompt = new AutoComplete({
-    name: 'project',
-    message: initialize ? "Choose the project you'd like to sync text from" : 'Add a project',
-    limit: 10,
-    choices: projects,
-  });
-
-  const projectsAlreadySelected = getSelectedProjects();
-  const projects = await getProjects(token, projectsAlreadySelected);
-
-  if (!(
-    projects && 
-    projects.length
-  )) {
-    console.log("\nNo other selectable projects were found in your workspace.");
+    console.log("\nNo new selectable projects were found in your workspace.");
     return null;
   }
 
@@ -135,14 +97,16 @@ async function collectAndSaveProject(initialize = false) {
   try {
     const token = config.getToken(consts.CONFIG_FILE, consts.API_HOST);
     const project = await collectProject(token, initialize);
-
     if (!project) {
       quit();
       return;
     }
   
-    console.log(`Thanks for adding a project. We'll save this info to: ${output.info(consts.PROJECT_CONFIG_FILE)}`);
-    output.nl();
+    console.log(
+      '\n' +
+      `Thanks for adding ${output.info(project.name)} to your selected projects.\n` + 
+      `We saved your updated configuration to: ${output.info(consts.PROJECT_CONFIG_FILE)}\n`
+    );
   
     saveProject(consts.PROJECT_CONFIG_FILE, project.name, project.id);
   } catch (e) {

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -25,16 +25,7 @@ function saveProject(file, name, id) {
 
 function needsProjects(configFile) {
   const projects = getSelectedProjects(configFile);
-
-  if (!(
-    projects && 
-    projects.length &&
-    !projects.some(({ name, id }) => !(name && id))
-  )) {
-    return { exists: false }
-  }
-
-  return { exists: true, projects };
+  return !(projects && projects.length);
 }
 
 async function askForAnotherToken() {

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -9,6 +9,7 @@ const config = require('../config');
 const consts = require('../consts');
 const output = require('../output');
 const { collectAndSaveToken } = require('../init/token');
+const getSelectedProjects = require('../utils/getSelectedProjects');
 
 function quit() {
   console.log('\nExiting Ditto CLI...');
@@ -17,9 +18,12 @@ function quit() {
 }
 
 function saveProject(file, name, id) {
-  const data = config.readData(file, { projects: [] });
-  data.projects = [{ name, id }];
-  config.writeData(file, data);
+  const projects = [
+    ...getSelectedProjects(),
+    { name, id }
+  ];
+
+  config.writeData(file, { projects });
 }
 
 function needsProjects(configFile) {
@@ -51,10 +55,12 @@ async function askForAnotherToken() {
   await collectAndSaveToken(message);
 }
 
-async function getProjects(token) {
+async function getProjects(token, projectsAlreadySelected) {
   const spinner = ora("Fetching projects in your workspace...");
   spinner.start();
+
   let projects = [];
+
   try {
     projects = await api.get('/projects', {
       headers: {
@@ -65,8 +71,13 @@ async function getProjects(token) {
     spinner.stop();
     throw e;
   }
+
+  const projectIdsAlreadySelected = projectsAlreadySelected.map(({ id }) => id);
+  const projectsUnselected = projects.data.filter(({ id }) => !projectIdsAlreadySelected.includes(id));
+
   spinner.stop();
-  return projects.data.map((item) => `${item.name} ${output.subtle(item.url)}`);
+
+  return projectsUnselected.map((item) => `${item.name} ${output.subtle(item.url)}`);
 }
 
 function parseResponse(response) {
@@ -80,10 +91,21 @@ async function collectProject(token, initialize) {
     const message = `Looks like there's no Ditto project associated with your current directory: ${output.info(path)}.`;
     console.log(message);
   }
-  const projects = await getProjects(token);
+
+  const projectsAlreadySelected = getSelectedProjects();
+  const projects = await getProjects(token, projectsAlreadySelected);
+
+  if (!(
+    projects && 
+    projects.length
+  )) {
+    console.log("\nNo other selectable projects were found in your workspace.");
+    return null;
+  }
+
   const prompt = new AutoComplete({
     name: 'project',
-    message: initialize ? "Choose the project you'd like to sync text from" : 'Choose a different project',
+    message: initialize ? "Choose the project you'd like to sync text from" : 'Add a project',
     limit: 10,
     choices: projects,
   });
@@ -96,8 +118,13 @@ async function collectAndSaveProject(initialize = false) {
   try {
     const token = config.getToken(consts.CONFIG_FILE, consts.API_HOST);
     const project = await collectProject(token, initialize);
+
+    if (!project) {
+      quit();
+      return;
+    }
   
-    console.log(`Thanks for choosing a project. We'll save this info to: ${output.info(consts.PROJECT_CONFIG_FILE)}`);
+    console.log(`Thanks for adding a project. We'll save this info to: ${output.info(consts.PROJECT_CONFIG_FILE)}`);
     output.nl();
   
     saveProject(consts.PROJECT_CONFIG_FILE, project.name, project.id);

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -69,8 +69,7 @@ async function getProjects(token, projectsAlreadySelected) {
 async function collectProject(token, initialize) {
   const path = process.cwd();
   if (initialize) {
-    const message = `Looks like there's no Ditto project associated with your current directory: ${output.info(path)}.`;
-    console.log(message);
+    console.log(`Looks like are no Ditto projects selected for your current directory: ${output.info(path)}.`);
   }
 
   const projectsAlreadySelected = getSelectedProjects();

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -1,24 +1,21 @@
-const ora = require('ora');
+const ora = require("ora");
 
-const api = require('../api').default;
-const config = require('../config');
-const consts = require('../consts');
-const output = require('../output');
-const { collectAndSaveToken } = require('../init/token');
-const getSelectedProjects = require('../utils/getSelectedProjects');
-const promptForProject = require('../utils/promptForProject');
+const api = require("../api").default;
+const config = require("../config");
+const consts = require("../consts");
+const output = require("../output");
+const { collectAndSaveToken } = require("../init/token");
+const getSelectedProjects = require("../utils/getSelectedProjects");
+const promptForProject = require("../utils/promptForProject");
 
 function quit() {
-  console.log('\nExiting Ditto CLI...\n');
+  console.log("\nExiting Ditto CLI...\n");
   process.exitCode = 2;
   process.exit();
 }
 
 function saveProject(file, name, id) {
-  const projects = [
-    ...getSelectedProjects(),
-    { name, id }
-  ];
+  const projects = [...getSelectedProjects(), { name, id }];
 
   config.writeData(file, { projects });
 }
@@ -30,7 +27,8 @@ function needsProjects(configFile) {
 
 async function askForAnotherToken() {
   config.deleteToken(consts.CONFIG_FILE, consts.API_HOST);
-  const message = "Looks like the API key you have saved no longer works. Please enter another one."
+  const message =
+    "Looks like the API key you have saved no longer works. Please enter another one.";
   await collectAndSaveToken(message);
 }
 
@@ -41,7 +39,7 @@ async function listProjects(token, projectsAlreadySelected) {
   let projects = [];
 
   try {
-    projects = await api.get('/list-projects', {
+    projects = await api.get("/project-names", {
       headers: {
         Authorization: `token ${token}`,
       },
@@ -53,30 +51,34 @@ async function listProjects(token, projectsAlreadySelected) {
 
   spinner.stop();
 
-  return projects.data
-    .filter(({ id }) => !projectsAlreadySelected.some(project => project.id === id));
+  return projects.data.filter(
+    ({ id }) => !projectsAlreadySelected.some((project) => project.id === id)
+  );
 }
 
 async function collectProject(token, initialize) {
   const path = process.cwd();
   if (initialize) {
-    console.log(`Looks like are no Ditto projects selected for your current directory: ${output.info(path)}.`);
+    console.log(
+      `Looks like are no Ditto projects selected for your current directory: ${output.info(
+        path
+      )}.`
+    );
   }
 
   const projectsAlreadySelected = getSelectedProjects();
   const projects = await listProjects(token, projectsAlreadySelected);
 
-  if (!(
-    projects && 
-    projects.length
-  )) {
+  if (!(projects && projects.length)) {
     console.log("You're currently syncing all projects in your workspace.");
     return null;
   }
 
-  return promptForProject({ 
+  return promptForProject({
     projects,
-    message: initialize ? "Choose the project you'd like to sync text from" : 'Add a project'
+    message: initialize
+      ? "Choose the project you'd like to sync text from"
+      : "Add a project",
   });
 }
 
@@ -88,15 +90,20 @@ async function collectAndSaveProject(initialize = false) {
       quit();
       return;
     }
-  
+
     console.log(
-      '\n' +
-      `Thanks for adding ${output.info(project.name)} to your selected projects.\n` + 
-      `We saved your updated configuration to: ${output.info(consts.PROJECT_CONFIG_FILE)}\n`
+      "\n" +
+        `Thanks for adding ${output.info(
+          project.name
+        )} to your selected projects.\n` +
+        `We saved your updated configuration to: ${output.info(
+          consts.PROJECT_CONFIG_FILE
+        )}\n`
     );
-  
+
     saveProject(consts.PROJECT_CONFIG_FILE, project.name, project.id);
   } catch (e) {
+    console.log(e);
     if (e.response && e.response.status === 404) {
       await askForAnotherToken();
       await collectAndSaveProject();

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -2,7 +2,6 @@ const fs = require('fs');
 
 const ora = require('ora');
 const { YAMLException } = require('js-yaml');
-const { AutoComplete } = require('enquirer');
 
 const api = require('../api').default;
 const config = require('../config');
@@ -10,6 +9,7 @@ const consts = require('../consts');
 const output = require('../output');
 const { collectAndSaveToken } = require('../init/token');
 const getSelectedProjects = require('../utils/getSelectedProjects');
+const promptForProject = require('../utils/promptForProject');
 
 function quit() {
   console.log('\nExiting Ditto CLI...');
@@ -80,11 +80,6 @@ async function getProjects(token, projectsAlreadySelected) {
   return projectsUnselected.map((item) => `${item.name} ${output.subtle(item.url)}`);
 }
 
-function parseResponse(response) {
-  const [, name, id] = response.split(/^(.*)\s.*http.*\/(\w+).*$/);
-  return { name, id };
-}
-
 async function collectProject(token, initialize) {
   const path = process.cwd();
   if (initialize) {
@@ -103,15 +98,10 @@ async function collectProject(token, initialize) {
     return null;
   }
 
-  const prompt = new AutoComplete({
-    name: 'project',
-    message: initialize ? "Choose the project you'd like to sync text from" : 'Add a project',
-    limit: 10,
-    choices: projects,
+  return promptForProject({ 
+    projects,
+    message: initialize ? "Choose the project you'd like to sync text from" : 'Add a project'
   });
-
-  const response = await prompt.run();
-  return parseResponse(response);
 }
 
 async function collectAndSaveProject(initialize = false) {

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -1,7 +1,4 @@
-const fs = require('fs');
-
 const ora = require('ora');
-const { YAMLException } = require('js-yaml');
 
 const api = require('../api').default;
 const config = require('../config');

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -1,13 +1,13 @@
 const fs = require('fs');
 
 const ora = require('ora');
-const { Select } = require('enquirer');
 
 const api = require('./api').default;
 const config = require('./config');
 const consts = require('./consts');
 const output = require('./output');
 const { collectAndSaveToken } = require('./init/token');
+const projectsToText = require('./utils/projectsToText');
 
 async function askForAnotherToken() {
   config.deleteToken(consts.CONFIG_FILE, consts.API_HOST);
@@ -15,35 +15,20 @@ async function askForAnotherToken() {
   await collectAndSaveToken(message);
 }
 
-function formatProjectNames(projectNames) {
-  if (projectNames.length <= 1) {
-    return projectNames[0];
-  }
-
-  if (projectNames.length === 2) {
-    return `${projectNames[0]} and ${projectNames[1]}`;
-  }
-
-  const names = projectNames.slice(0, projectNames.length - 1);
-  const lastName = projectNames[projectNames.length - 1];
-
-  return `${names.join(", ")} and ${lastName}`
-}
-
 async function downloadAndSave(projectConfig, token) {
+  const { projects } = projectConfig;
   const projectNames = [];
   const projectIds = [];
 
-  projectConfig.projects.forEach(({ name, id }) => {
+  projects.forEach(({ name, id }) => {
     projectNames.push(name);
     projectIds.push(id);
   });
 
-  const formattedProjectNames = formatProjectNames(projectNames);
-  const spinner = ora(`Fetching the latest text from ${formattedProjectNames}...`);
-  spinner.start();
+  let msg = `\nFetching the latest text from your selected projects: ${projectsToText(projects)}\n`;
 
-  let msg;
+  const spinner = ora(msg);
+  spinner.start();
 
   try {
     const res = await api.get(`/projects`, {
@@ -53,7 +38,7 @@ async function downloadAndSave(projectConfig, token) {
       },
     });
     fs.writeFileSync(consts.TEXT_FILE, JSON.stringify(res.data, null, 2));
-    msg = `Fetching the latest text from ${output.info(formattedProjectNames)}... ${output.success('done')}. \nSuccessfully saved to ${output.info(consts.TEXT_FILE)}.`;
+    msg += `\n${output.success('Done')}! \nSuccessfully saved to ${output.info(consts.TEXT_FILE)}.`;
     spinner.stop();
     return console.log(msg);
   } catch (e) {

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -31,7 +31,7 @@ async function downloadAndSave(projectConfig, token) {
   spinner.start();
 
   try {
-    const res = await api.get(`/sync`, {
+    const res = await api.get(`/projects`, {
       params: { projectIds },
       headers: {
         Authorization: `token ${token}`,

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -15,20 +15,45 @@ async function askForAnotherToken() {
   await collectAndSaveToken(message);
 }
 
+function formatProjectNames(projectNames) {
+  if (projectNames.length <= 1) {
+    return projectNames[0];
+  }
+
+  if (projectNames.length === 2) {
+    return `${projectNames[0]} and ${projectNames[1]}`;
+  }
+
+  const names = projectNames.slice(0, projectNames.length - 1);
+  const lastName = projectNames[projectNames.length - 1];
+
+  return `${names.join(", ")} and ${lastName}`
+}
+
 async function downloadAndSave(projectConfig, token) {
-  const projectName = projectConfig.projects[0].name;
-  const spinner = ora(`Fetching the latest text from ${projectName}...`);
+  const projectNames = [];
+  const projectIds = [];
+
+  projectConfig.projects.forEach(({ name, id }) => {
+    projectNames.push(name);
+    projectIds.push(id);
+  });
+
+  const formattedProjectNames = formatProjectNames(projectNames);
+  const spinner = ora(`Fetching the latest text from ${formattedProjectNames}...`);
   spinner.start();
-  const projectId = projectConfig.projects[0].id;
+
   let msg;
+
   try {
-    const res = await api.get(`/projects/${projectId}`, {
+    const res = await api.get(`/projects`, {
+      params: { projectIds },
       headers: {
         Authorization: `token ${token}`,
       },
     });
     fs.writeFileSync(consts.TEXT_FILE, JSON.stringify(res.data, null, 2));
-    msg = `Fetching the latest text from ${output.info(projectName)}... ${output.success('done')}. \nSuccessfully saved to ${output.info(consts.TEXT_FILE)}.`;
+    msg = `Fetching the latest text from ${output.info(formattedProjectNames)}... ${output.success('done')}. \nSuccessfully saved to ${output.info(consts.TEXT_FILE)}.`;
     spinner.stop();
     return console.log(msg);
   } catch (e) {
@@ -40,19 +65,19 @@ async function downloadAndSave(projectConfig, token) {
       return;
     }
     if (e.response && e.response.status === 401) {
-      error = "You don't have access to the selected project";
-      msg = `${output.errorText(error)}.\nChoose another using the ${output.info('project')} command, or update your API key.`;
+      error = "You don't have access to the selected projects";
+      msg = `${output.errorText(error)}.\nChoose others using the ${output.info('project')} command, or update your API key.`;
       return console.log(msg);
     }
     if (e.response && e.response.status === 403) {
-      error = "The requested project doesn't have Developer Mode enabled";
-      msg = `${output.errorText(error)}.\nPlease choose a different project using the ${output.info('project')} command, or turn on Developer Mode for this project. Learn more here: ${output.subtle('https://www.dittowords.com/docs/ditto-developer-mode')}.`;
+      error = "One or more of the requested projects don't have Developer Mode enabled";
+      msg = `${output.errorText(error)}.\nPlease choose different projects using the ${output.info('project')} command, or turn on Developer Mode for all selected projects. Learn more here: ${output.subtle('https://www.dittowords.com/docs/ditto-developer-mode')}.`;
       return console.log(msg);
     }
     if (e.response && e.response.status === 400) {
-      error = "project not found";
+      error = "projects not found";
     }
-    msg = `We hit an error fetching text from the project: ${output.errorText(error)}.\nChoose another using the ${output.info('project')} command.`;
+    msg = `We hit an error fetching text from the projects: ${output.errorText(error)}.\nChoose others using the ${output.info('project')} command.`;
     return console.log(msg);
   }
 }

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -38,7 +38,7 @@ async function downloadAndSave(projectConfig, token) {
       },
     });
     fs.writeFileSync(consts.TEXT_FILE, JSON.stringify(res.data, null, 2));
-    msg += `\n${output.success('Done')}! \nSuccessfully saved to ${output.info(consts.TEXT_FILE)}.`;
+    msg += `\n${output.success('Done')}! \nSuccessfully saved to ${output.info(consts.TEXT_FILE)}.\n`;
     spinner.stop();
     return console.log(msg);
   } catch (e) {

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -38,7 +38,7 @@ async function downloadAndSave(projectConfig, token) {
       },
     });
     fs.writeFileSync(consts.TEXT_FILE, JSON.stringify(res.data, null, 2));
-    msg += `\n${output.success('Done')}! \nSuccessfully saved to ${output.info(consts.TEXT_FILE)}.\n`;
+    msg += `${output.success('Done')}! \nSuccessfully saved to ${output.info(consts.TEXT_FILE)}.\n`;
     spinner.stop();
     return console.log(msg);
   } catch (e) {

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -31,7 +31,7 @@ async function downloadAndSave(projectConfig, token) {
   spinner.start();
 
   try {
-    const res = await api.get(`/projects`, {
+    const res = await api.get(`/sync`, {
       params: { projectIds },
       headers: {
         Authorization: `token ${token}`,

--- a/lib/remove-project.js
+++ b/lib/remove-project.js
@@ -28,7 +28,7 @@ async function removeProject() {
   );
 
   console.log(
-    `${output.info(projectToRemove.name)} has been removed from your selected projects. ` + 
+    `\n${output.info(projectToRemove.name)} has been removed from your selected projects. ` + 
     `\nWe saved your updated configuration to: ${output.info(consts.PROJECT_CONFIG_FILE)}` +
     "\n"
   );

--- a/lib/remove-project.js
+++ b/lib/remove-project.js
@@ -1,0 +1,27 @@
+const config = require('./config');
+const consts = require('./consts');
+const output = require('./output');
+const getSelectedProjects = require("./utils/getSelectedProjects");
+const promptForProject = require("./utils/promptForProject");
+
+async function removeProject() {
+  const projects = getSelectedProjects();
+  const projectToRemove = await promptForProject({ 
+    projects,
+    message: "Select a project to remove"
+  })
+
+  config.writeData(
+    consts.PROJECT_CONFIG_FILE,
+    { projects: projects.filter(({ id }) => id !== projectToRemove.id)}
+  );
+
+  console.log(
+    "\n" +
+    `${output.info(projectToRemove.name)} has been removed from your selected projects. ` + 
+    `\nWe saved your updated configuration to: ${output.info(consts.PROJECT_CONFIG_FILE)}` +
+    "\n"
+  );
+}
+
+module.exports = removeProject;

--- a/lib/remove-project.js
+++ b/lib/remove-project.js
@@ -28,7 +28,6 @@ async function removeProject() {
   );
 
   console.log(
-    "\n" +
     `${output.info(projectToRemove.name)} has been removed from your selected projects. ` + 
     `\nWe saved your updated configuration to: ${output.info(consts.PROJECT_CONFIG_FILE)}` +
     "\n"

--- a/lib/remove-project.js
+++ b/lib/remove-project.js
@@ -6,6 +6,14 @@ const promptForProject = require("./utils/promptForProject");
 
 async function removeProject() {
   const projects = getSelectedProjects();
+  if (!projects.length) {
+    console.log(
+      "\n" + 
+      "We couldn't find any projects to remove.\n" +
+      `Try adding one with: ${output.info("ditto-cli project add")}\n`);
+    return;
+  }
+
   const projectToRemove = await promptForProject({ 
     projects,
     message: "Select a project to remove"

--- a/lib/remove-project.js
+++ b/lib/remove-project.js
@@ -9,7 +9,7 @@ async function removeProject() {
   if (!projects.length) {
     console.log(
       "\n" + 
-      "We couldn't find any projects to remove.\n" +
+      "No projects found in your workspace.\n" +
       `Try adding one with: ${output.info("ditto-cli project add")}\n`);
     return;
   }

--- a/lib/remove-project.js
+++ b/lib/remove-project.js
@@ -17,7 +17,10 @@ async function removeProject() {
   const projectToRemove = await promptForProject({ 
     projects,
     message: "Select a project to remove"
-  })
+  });
+  if (!projectToRemove) 
+    return;
+  
 
   config.writeData(
     consts.PROJECT_CONFIG_FILE,

--- a/lib/utils/getSelectedProjects.js
+++ b/lib/utils/getSelectedProjects.js
@@ -3,9 +3,26 @@ const yaml = require('js-yaml');
 
 const { PROJECT_CONFIG_FILE } = require('../consts');
 
-function getSelectedProjects() {
-  const contentYaml = fs.readFileSync(PROJECT_CONFIG_FILE, 'utf8');
-  const contentJson = yaml.safeLoad(contentYaml);
+function yamlToJson(_yaml) {
+  try {
+    return yaml.safeLoad(_yaml);
+  }
+  catch (e) {
+    if (e instanceof YAMLException) {
+      return "";
+    }
+    else {
+      throw e;
+    }
+  }
+}
+
+function getSelectedProjects(configFile = PROJECT_CONFIG_FILE) {
+  if (!fs.existsSync(configFile)) 
+    return [];
+
+  const contentYaml = fs.readFileSync(configFile, 'utf8');
+  const contentJson = yamlToJson(contentYaml);
 
   if (!(
     contentJson &&

--- a/lib/utils/getSelectedProjects.js
+++ b/lib/utils/getSelectedProjects.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+const { PROJECT_CONFIG_FILE } = require('../consts');
+
+function getSelectedProjects() {
+  const contentYaml = fs.readFileSync(PROJECT_CONFIG_FILE, 'utf8');
+  const contentJson = yaml.safeLoad(contentYaml);
+
+  if (!(
+    contentJson &&
+    contentJson.projects
+  )) {
+    return [];
+  }
+
+  return contentJson.projects;
+}
+
+module.exports = getSelectedProjects;

--- a/lib/utils/getSelectedProjects.js
+++ b/lib/utils/getSelectedProjects.js
@@ -17,6 +17,10 @@ function yamlToJson(_yaml) {
   }
 }
 
+/**
+ * Returns an array containing all valid projects ({ id, name })
+ * currently contained in the project config file.
+ */
 function getSelectedProjects(configFile = PROJECT_CONFIG_FILE) {
   if (!fs.existsSync(configFile)) 
     return [];
@@ -31,7 +35,7 @@ function getSelectedProjects(configFile = PROJECT_CONFIG_FILE) {
     return [];
   }
 
-  return contentJson.projects;
+  return contentJson.projects.filter(({ name, id }) => name && id);
 }
 
 module.exports = getSelectedProjects;

--- a/lib/utils/listProjects.js
+++ b/lib/utils/listProjects.js
@@ -1,0 +1,14 @@
+const output = require('../output');
+
+function listProjects(projects) {
+  return projects.reduce((outputString, { name, id }) => 
+    outputString + (
+      "\n" +
+      "- " + output.info(name) +
+      " " +
+      output.subtle('https://beta.dittowords.com/doc/' + id)
+    ), ""
+  )
+}
+
+module.exports = listProjects;

--- a/lib/utils/projectsToText.js
+++ b/lib/utils/projectsToText.js
@@ -1,6 +1,6 @@
 const output = require('../output');
 
-function listProjects(projects) {
+function projectsToText(projects) {
   return projects.reduce((outputString, { name, id }) => 
     outputString + (
       "\n" +
@@ -8,7 +8,7 @@ function listProjects(projects) {
       " " +
       output.subtle('https://beta.dittowords.com/doc/' + id)
     ), ""
-  )
+  ) + "\n"
 }
 
-module.exports = listProjects;
+module.exports = projectsToText;

--- a/lib/utils/promptForProject.js
+++ b/lib/utils/promptForProject.js
@@ -1,0 +1,21 @@
+const { AutoComplete } = require('enquirer');
+
+function parseResponse(response) {
+  const [, name, id] = response.split(/^(.*)\s.*http.*\/(\w+).*$/);
+  return { name, id };
+}
+
+async function promptForProject({ message, projects, limit = 10 }) {
+  const prompt = new AutoComplete({
+    name: 'project',
+    message,
+    limit,
+    choices: projects,
+  });
+
+  const response = await prompt.run();
+
+  return parseResponse(response);
+}
+
+module.exports = promptForProject;

--- a/lib/utils/promptForProject.js
+++ b/lib/utils/promptForProject.js
@@ -9,6 +9,10 @@ function formatProjectChoice(project) {
 }
 
 function parseResponse(response) {
+  if (!response) {
+    return null;
+  }
+
   const [, name, id] = response.split(/^(.*)\s.*http.*\/(\w+).*$/);
 
   if (id === 'all') {
@@ -29,7 +33,16 @@ async function promptForProject({ message, projects, limit = 10 }) {
     choices,
   });
 
-  const response = await prompt.run();
+  let response;
+
+  try {
+    response = await prompt.run();
+  }
+  // this catch handles the case where someone presses
+  // Ctrl + C to kill the AutoComplete process
+  catch (e) {
+    response = null;
+  }
 
   return parseResponse(response);
 }

--- a/lib/utils/promptForProject.js
+++ b/lib/utils/promptForProject.js
@@ -1,16 +1,27 @@
 const { AutoComplete } = require('enquirer');
 
+const output = require('../output');
+
+function formatProjectChoice(project) {
+  return project.name + " " + output.subtle(
+    project.url || `https://beta.dittowords.com/doc/${project.id}`
+  ) 
+}
+
 function parseResponse(response) {
   const [, name, id] = response.split(/^(.*)\s.*http.*\/(\w+).*$/);
   return { name, id };
 }
 
 async function promptForProject({ message, projects, limit = 10 }) {
+  output.nl();
+
+  const choices = projects.map(formatProjectChoice);
   const prompt = new AutoComplete({
     name: 'project',
     message,
     limit,
-    choices: projects,
+    choices,
   });
 
   const response = await prompt.run();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "repository": {


### PR DESCRIPTION
**Associated PR (blocks this one)**: https://github.com/dittowords/ditto-app/pull/394

## Overview
<!--- What does this PR do? --->
This PR adds support to the CLI for:
- adding new projects to `ditto/config.yaml`
- removing existing projects to `ditto/config.yaml`
- pulling the text data from multiple projects to be stored in `text.json`

Other changes of note:
- `ditto-cli project` now behaves the same as `ditto-cli project add`

## Context
<!--- Any context about why you are creating this PR? Notion doc, screenshot, conversation, etc. --->
Developers using our CLI currently have to `cd` into subdirectories and `pull` multiple times when they have more than one Ditto project associated with a code repository they're working in. Adding the ability to `pull` multiple Ditto projects into a single `text.json` file in the root of the project will:
- cut down manual actions by forcing developers to `pull` only once
- save time by enabling developers to search through a single file when looking for text snippets or frame ids

This [Notion doc](https://www.notion.so/dittov3/Pulling-Multiple-Files-via-CLI-3437c51c811844e1a1a579bf23d3e5e8) contains the spec and additional details.

## Screenshots
<!--- Include some screenshots of any visual changes you made to make it easier for the reviewer to understand what changes were made --->
![image](https://user-images.githubusercontent.com/19500384/120556170-fe1e6f80-c3b0-11eb-9bf8-0ec0ab25f11e.png)
![image](https://user-images.githubusercontent.com/19500384/120560478-a2a3b000-c3b7-11eb-9844-fb7a233a6dc6.png)


## Test Plan
TODO
Testing successfully completed in <env> via: