### PR TITLE
[DIT-271] Fix error when running `project add` on full YAML file

### DIFF
--- a/bin/ditto.js
+++ b/bin/ditto.js
@@ -15,9 +15,9 @@ const removeProject = require('../lib/remove-project');
  * @param {any} error The thrown error object.
  * @returns {void}
  */
-function quit() {
+function quit(exitCode = 2) {
   console.log('\nExiting Ditto CLI...\n');
-  process.exitCode = 2;
+  process.exitCode = exitCode;
   process.exit();
 }
 

--- a/lib/add-project.js
+++ b/lib/add-project.js
@@ -2,9 +2,9 @@ const { collectAndSaveProject } = require('./init/project');
 const projectsToText = require('./utils/projectsToText');
 const getSelectedProjects = require('./utils/getSelectedProjects');
 
-function quit() {
+function quit(exitCode = 2) {
   console.log('Project selection was not updated.');
-  process.exitCode = 2;
+  process.exitCode = exitCode;
   process.exit();
 }
 

--- a/lib/init/project.js
+++ b/lib/init/project.js
@@ -8,9 +8,9 @@ const { collectAndSaveToken } = require("../init/token");
 const getSelectedProjects = require("../utils/getSelectedProjects");
 const promptForProject = require("../utils/promptForProject");
 
-function quit() {
+function quit(exitCode = 2) {
   console.log("\nExiting Ditto CLI...\n");
-  process.exitCode = 2;
+  process.exitCode = exitCode;
   process.exit();
 }
 
@@ -87,7 +87,7 @@ async function collectAndSaveProject(initialize = false) {
     const token = config.getToken(consts.CONFIG_FILE, consts.API_HOST);
     const project = await collectProject(token, initialize);
     if (!project) {
-      quit();
+      quit(0);
       return;
     }
 

--- a/lib/init/token.js
+++ b/lib/init/token.js
@@ -55,9 +55,9 @@ async function collectToken(message) {
   return response.token;
 }
 
-function quit() {
+function quit(exitCode = 2) {
   console.log('API key was not saved.');
-  process.exitCode = 2;
+  process.exitCode = exitCode;
   process.exit();
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "repository": {


### PR DESCRIPTION
## Overview
<!--- What does this PR do? --->
The CLI was incorrectly returning a status code of 2 (signaling that something went wrong with the execution of the program) when a user attempts to add a project to a YAML file already containing all of the projects in the workspace.

This PR fixes that to return a status code of 0 in that instance; status code 2 should only be used when the program encounters an error causing it to exit early.

## Context
<!--- Any context about why you are creating this PR? Notion doc, screenshot, conversation, etc. --->
Linear ticket:
https://linear.app/dittowords/issue/DIT-271/fix-ditto-cli-error-from-adding-project-to-yaml-file

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/19500384/129983403-9bea78b0-0c93-46e9-95a8-df6a340170fa.png)
![image](https://user-images.githubusercontent.com/19500384/129983540-96e28ee2-b8a8-4e84-a0b6-2c2bd0abefef.png)

After:
![image](https://user-images.githubusercontent.com/19500384/129983457-17c336e0-fe40-4cf2-80d8-98b744e1555e.png)
![image](https://user-images.githubusercontent.com/19500384/129983571-90862309-aa9d-4d19-9ed2-9b4ce461ca49.png)


## Test Plan
- [ ] Add all projects in workspace to YAML file
- [ ] Run `npx ditto-cli project add`
- [ ] Confirm no error

For some reason I couldn't get the error to throw by running the CLI directly (note that in Jason's original report it was NPM itself that was throwing the error based on the status code); I instead created a test project with this in `package.json`:
```json
  "scripts": {
    "prepare": "DITTO_API_HOST=http://localhost:3001 npx ditto-cli project"
  }
  ```
  
  Then running `yarn install` or `npm install` reproduces the error. To test the local branch, you can replace the above with:
  ```json
  "scripts": {
    "prepare": "DITTO_API_HOST=http://localhost:3001 node ~/projects/ditto-cli/bin/ditto.js"
  }
  ```
  
You obviously don't need `DITTO_API_HOST` set if you're testing against production, although in that case it'll be a little tricker to get ALL of the workspace projects into the yaml file