### PR TITLE
[DIT-571] Only write variant files for projects that have them

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ If you run the CLI in a directory that does not contain a `ditto/` folder, the f
 
   An automatically generated driver file that simplifies the process of passing text data to Ditto JavaScript SDKs. This file has a standardized format that is always the same independent of the CLI configuration used to generate it.
 
+  **Since this file is designed to be consumed by other internal Ditto libraries, it is not recommended that you depend on it - its format may change between major releases.**
+
   ```ts
   interface DriverFile {
     [projectId: string]: {

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -88,6 +88,11 @@ async function downloadAndSaveVariant(variantApiId, projects, format, token) {
           headers: { Authorization: `token ${token}` },
         });
 
+        // only write files that have data
+        if (!Object.keys(data).length) {
+          return "";
+        }
+
         const filename = name + ("__" + (variantApiId || "base")) + ".json";
         const filepath = path.join(consts.TEXT_DIR, filename);
 
@@ -106,6 +111,11 @@ async function downloadAndSaveVariant(variantApiId, projects, format, token) {
       headers: { Authorization: `token ${token}` },
     });
 
+    // only write files that have data
+    if (!Object.keys(data).length) {
+      return "";
+    }
+
     const filename = `${variantApiId || "base"}.json`;
     const filepath = path.join(consts.TEXT_DIR, filename);
 
@@ -119,6 +129,9 @@ async function downloadAndSaveVariant(variantApiId, projects, format, token) {
 
 async function downloadAndSaveVariants(projects, format, token) {
   const { data: variants } = await api.get("/variants", {
+    params: {
+      projectIds: projects.map(({ id }) => id),
+    },
     headers: { Authorization: `token ${token}` },
   });
 

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -10,7 +10,18 @@ const output = require("./output");
 const { collectAndSaveToken } = require("./init/token");
 const projectsToText = require("./utils/projectsToText");
 
-const SUPPORTED_FORMATS = ["flat", "structured"];
+const NON_DEFAULT_FORMATS = ["flat", "structured"];
+
+const DEFAULT_FORMAT_KEYS = ["projects", "exported_at"];
+const hasVariantData = (data) => {
+  const hasTopLevelKeys =
+    Object.keys(data).filter((key) => !DEFAULT_FORMAT_KEYS.includes(key))
+      .length > 0;
+
+  const hasProjectKeys = data.projects && Object.keys(data.projects).length > 0;
+
+  return hasTopLevelKeys || hasProjectKeys;
+};
 
 async function askForAnotherToken() {
   config.deleteToken(consts.CONFIG_FILE, consts.API_HOST);
@@ -80,7 +91,7 @@ async function downloadAndSaveVariant(variantApiId, projects, format, token) {
     params.format = format;
   }
 
-  if (["flat", "structured"].includes(format)) {
+  if (NON_DEFAULT_FORMATS.includes(format)) {
     const savedMessages = await Promise.all(
       projects.map(async ({ id, name }) => {
         const { data } = await api.get(`/projects/${id}`, {
@@ -88,8 +99,7 @@ async function downloadAndSaveVariant(variantApiId, projects, format, token) {
           headers: { Authorization: `token ${token}` },
         });
 
-        // only write files that have data
-        if (!Object.keys(data).length) {
+        if (!hasVariantData(data)) {
           return "";
         }
 
@@ -111,8 +121,7 @@ async function downloadAndSaveVariant(variantApiId, projects, format, token) {
       headers: { Authorization: `token ${token}` },
     });
 
-    // only write files that have data
-    if (!Object.keys(data).length) {
+    if (!hasVariantData(data)) {
       return "";
     }
 
@@ -151,7 +160,7 @@ async function downloadAndSaveBase(projects, format, token) {
     params.format = format;
   }
 
-  if (SUPPORTED_FORMATS.includes(format)) {
+  if (NON_DEFAULT_FORMATS.includes(format)) {
     const savedMessages = await Promise.all(
       projects.map(async ({ id, name }) => {
         const { data } = await api.get(`/projects/${id}`, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "1.2.4-beta",
+  "version": "2.0.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "scripts": {


### PR DESCRIPTION
## Overview
Prior to this PR, files would always be written for every variant in the workspace if `variants: true` was specified. This PR changes that behavior so that variant files are only written for projects that actually contain values for a given variant.

https://github.com/dittowords/ditto-app/pull/687 is a companion PR to this one, but its functionality is not required for this PR to be tested - it only reduces the number of requests that need to be made.
<!--- What does this PR do? --->

## Context
https://linear.app/dittowords/issue/DIT-571/cli-only-output-variant-files-for-variants-with-values-in-specified
<!--- Any context about why you are creating this PR? Notion doc, screenshot, conversation, etc. --->

## Screenshots
before:
![image](https://user-images.githubusercontent.com/19500384/139333679-b0a9ee42-87df-4c49-8bac-05f6c8f698b6.png)

after:
![image](https://user-images.githubusercontent.com/19500384/139333728-7733db67-70af-4988-b457-e97d2e4f1dc8.png)

## Test Plan
-  [x] Pull with `variants: true` and confirm that no blank files are generated