### PR TITLE
Fix typos crashing `project add` and `pull` commands

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -110,7 +110,7 @@ function dedupeProjectName(projectNames, projectName) {
 function parseSourceInformation() {
   const { projects, components, variants, format } = readData();
 
-  const projectNames = {};
+  const projectNames = new Set();
   const validProjects = [];
 
   let componentLibraryInProjects = false;

--- a/lib/utils/getSelectedProjects.js
+++ b/lib/utils/getSelectedProjects.js
@@ -29,7 +29,7 @@ function getSelectedProjects(configFile = PROJECT_CONFIG_FILE) {
     return [];
   }
 
-  return contentjson.projects.filter(({ name, id }) => name && id);
+  return contentJson.projects.filter(({ name, id }) => name && id);
 }
 
 module.exports = getSelectedProjects;


### PR DESCRIPTION
## Overview
- Defines `projectNames` as a `Set` to match the code that was already refactored to expect `Set` methods. This bug was causing the `pull` command to crash when projects other than the component library were specified.
- Fixes a casing typo on `contentJson` that was causing the `project add` command to crash.

<!--- What does this PR do? --->

## Context
Fixes bugs introduced by https://github.com/dittowords/cli/pull/22, reported in https://github.com/dittowords/cli/issues/23.
<!--- Any context about why you are creating this PR? Notion doc, screenshot, conversation, etc. --->