### PR TITLE
Support passing API token via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ After selecting a project, a configuration file will automatically be created at
 
 Once you've successfully authenticated and a config file has been created, you’re ready to start fetching copy! You can set up the CLI in multiple directories by running `ditto-cli` and choosing an initial project to sync from.
 
+## API Keys
+
+The CLI will not prompt for an API key if a value is provided in the environment variable `DITTO_API_KEY`.
+
+If the `DITTO_API_KEY` environment variable is not set, then the CLI will attempt to parse a token from a file at the
+path `~/.config/ditto`. If this file does not exist or does not contain a valid API key, then the CLI will prompt
+for one.
+
+We don't recommend editing the file manually; if you need to remove a saved API key and put another one in its place,
+it's better to fully delete the file and then re-run the CLI so that a new key is prompted for.
+
 ## Commands
 
 ### `pull`

--- a/lib/config.js
+++ b/lib/config.js
@@ -58,7 +58,7 @@ function saveToken(file, host, token) {
 }
 
 function getTokenFromEnv() {
-  return process.env.DITTO_API_TOKEN;
+  return process.env.DITTO_API_KEY;
 }
 
 function getToken(file, host) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -57,7 +57,16 @@ function saveToken(file, host, token) {
   writeData(file, data);
 }
 
+function getTokenFromEnv() {
+  return process.env.DITTO_API_TOKEN;
+}
+
 function getToken(file, host) {
+  const tokenFromEnv = getTokenFromEnv();
+  if (tokenFromEnv) {
+    return tokenFromEnv;
+  }
+
   const data = readData(file);
   const hostEntry = data[justTheHost(host)];
   if (!hostEntry) return undefined;
@@ -154,6 +163,7 @@ module.exports = {
   saveToken,
   deleteToken,
   getToken,
+  getTokenFromEnv,
   save,
   parseSourceInformation,
 };

--- a/lib/init/token.js
+++ b/lib/init/token.js
@@ -10,6 +10,10 @@ const output = require("../output");
 const config = require("../config");
 
 function needsToken(configFile, host = consts.API_HOST) {
+  if (config.getTokenFromEnv()) {
+    return false;
+  }
+
   const file = configFile || consts.CONFIG_FILE;
   if (!fs.existsSync(file)) return true;
   const configData = config.readData(file);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "scripts": {


### PR DESCRIPTION
## Overview
Support passing an API token via an environment variable `DITTO_API_KEY`.

If environment variable is set, it will be used with precedence over any tokens stored in `~/.config/ditto`.
<!--- What does this PR do? --->

## Context
Interacting with the Ditto CLI from CI environments or deployed applications will be made way easier by allowing the environment variable as an alternative to the current config file approach.

## Test Plan
- [ ] Test all commands with the existing approach, where the API token is stored in `~/.config/ditto`:
>- [ ] no command (should just display help)
>- [ ] `project`
>- [ ] `project add`
>- [ ] `project remove`
>- [ ] `pull`
- [ ] Test all commands with the the new approach by deleting `~/.config/ditto` and passing the API token in `DITTO_API_KEY` (commands should work without being prompted for a token):
>- [ ] no command (should just display help)
>- [ ] `project`
>- [ ] `project add`
>- [ ] `project remove`
>- [ ] `pull`
