### PR TITLE
Allow users to override the output directory

### DIFF
--- a/lib/consts.js
+++ b/lib/consts.js
@@ -1,6 +1,7 @@
 const homedir = require("os").homedir();
-
 const path = require("path");
+
+const TEXT_DIR = process.env.DITTO_TEXT_DIR || "ditto"
 
 module.exports.API_HOST =
   process.env.DITTO_API_HOST || "https://api.dittowords.com";
@@ -9,5 +10,5 @@ module.exports.CONFIG_FILE =
 module.exports.PROJECT_CONFIG_FILE = path.normalize(
   path.join("ditto", "config.yml")
 );
-module.exports.TEXT_FILE = path.normalize(path.join("ditto", "text.json"));
-module.exports.TEXT_DIR = path.normalize("ditto");
+module.exports.TEXT_DIR = TEXT_DIR
+module.exports.TEXT_FILE = path.normalize(path.join(TEXT_DIR, "text.json"));


### PR DESCRIPTION
## Overview

Allows users to override the text output directory using DITTO_TEXT_DIR env variable

## Context

often with typescript/etc, modules cannot resolve paths at the repo root or outside of the `src` or equivalent directory