### PR TITLE
Add status filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ If you run the CLI in a directory that does not contain a `ditto/` folder, the f
   format: flat
   ```
 
+  ##### `status`
+
+  If included, results will only include data with the passed in status value. Excluding this value will result in no filtering. Acceptable values are `NONE`, `WIP`, `REVIEW`, `FINAL`, and `DEV`.
+
+  More information about statuses can be found [here](https://www.dittowords.com/docs/tips-for-collaborating).
+
+  ```yml
+  staus: FINAL
+  ```
+
   **Full Example**
 
   ```yml
@@ -161,6 +171,7 @@ If you run the CLI in a directory that does not contain a `ditto/` folder, the f
   components: true
   variants: true
   format: flat
+  status: FINAL
   ```
 
 - #### JSON Files

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -161,7 +161,8 @@ function dedupeProjectName(projectNames: Set<string>, projectName: string) {
  * - the `variants` and `format` config options
  */
 function parseSourceInformation() {
-  const { projects, components, variants, format } = readProjectConfigData();
+  const { projects, components, variants, format, status } =
+    readProjectConfigData();
 
   const projectNames = new Set<string>();
   const validProjects: Project[] = [];
@@ -196,6 +197,7 @@ function parseSourceInformation() {
     shouldFetchComponentLibrary,
     variants: variants || false,
     format,
+    status,
   };
 }
 

--- a/lib/pull.test.ts
+++ b/lib/pull.test.ts
@@ -116,7 +116,7 @@ describe("downloadAndSaveBase", () => {
     cleanOutputDir();
 
     mockApi.get.mockResolvedValueOnce({ data: [] });
-    const output = await downloadAndSaveBase(testProjects, "");
+    const output = await downloadAndSaveBase(testProjects, "", undefined);
 
     expect(/saved to.*text\.json/.test(output)).toEqual(true);
     expect(output.match(/saved to/g)?.length).toEqual(1);
@@ -127,7 +127,7 @@ describe("downloadAndSaveBase", () => {
     cleanOutputDir();
 
     mockApi.get.mockResolvedValue({ data: [] });
-    const output = await downloadAndSaveBase(testProjects, "flat");
+    const output = await downloadAndSaveBase(testProjects, "flat", undefined);
     expect(/saved to.*Project 1\.json/.test(output)).toEqual(true);
     expect(/saved to.*Project 2\.json/.test(output)).toEqual(true);
     expect(output.match(/saved to/g)?.length).toEqual(2);
@@ -138,7 +138,11 @@ describe("downloadAndSaveBase", () => {
     cleanOutputDir();
 
     mockApi.get.mockResolvedValue({ data: [] });
-    const output = await downloadAndSaveBase(testProjects, "structured");
+    const output = await downloadAndSaveBase(
+      testProjects,
+      "structured",
+      undefined
+    );
 
     expect(/saved to.*Project 1\.json/.test(output)).toEqual(true);
     expect(/saved to.*Project 2\.json/.test(output)).toEqual(true);
@@ -150,7 +154,11 @@ describe("downloadAndSaveBase", () => {
     cleanOutputDir();
 
     mockApi.get.mockResolvedValue({ data: "hello" });
-    const output = await downloadAndSaveBase(testProjects, "android");
+    const output = await downloadAndSaveBase(
+      testProjects,
+      "android",
+      undefined
+    );
 
     expect(/saved to.*Project 1\.xml/.test(output)).toEqual(true);
     expect(/saved to.*Project 2\.xml/.test(output)).toEqual(true);
@@ -162,7 +170,11 @@ describe("downloadAndSaveBase", () => {
     cleanOutputDir();
 
     mockApi.get.mockResolvedValue({ data: "hello" });
-    const output = await downloadAndSaveBase(testProjects, "ios-strings");
+    const output = await downloadAndSaveBase(
+      testProjects,
+      "ios-strings",
+      undefined
+    );
 
     expect(/saved to.*Project 1\.strings/.test(output)).toEqual(true);
     expect(/saved to.*Project 2\.strings/.test(output)).toEqual(true);

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -52,6 +52,7 @@ async function downloadAndSaveVariant(
   variantApiId: string | null,
   projects: Project[],
   format: string | undefined,
+  status: string | undefined,
   token?: Token
 ) {
   const params: Record<string, string | null> = {
@@ -59,6 +60,9 @@ async function downloadAndSaveVariant(
   };
   if (format) {
     params.format = format;
+  }
+  if (status) {
+    params.status = status;
   }
 
   if (format && NON_DEFAULT_FORMATS.includes(format)) {
@@ -115,6 +119,7 @@ async function downloadAndSaveVariant(
 async function downloadAndSaveVariants(
   projects: Project[],
   format: string | undefined,
+  status: string | undefined,
   token?: Token,
   options?: PullOptions
 ) {
@@ -129,9 +134,9 @@ async function downloadAndSaveVariants(
   });
 
   const messages = await Promise.all([
-    downloadAndSaveVariant(null, projects, format, token),
+    downloadAndSaveVariant(null, projects, format, status, token),
     ...variants.map(({ apiID }: { apiID: string }) =>
-      downloadAndSaveVariant(apiID, projects, format, token)
+      downloadAndSaveVariant(apiID, projects, format, status, token)
     ),
   ]);
 
@@ -141,6 +146,7 @@ async function downloadAndSaveVariants(
 async function downloadAndSaveBase(
   projects: Project[],
   format: string | undefined,
+  status: string | undefined,
   token?: Token,
   options?: PullOptions
 ) {
@@ -151,6 +157,9 @@ async function downloadAndSaveBase(
   };
   if (format) {
     params.format = format;
+  }
+  if (status) {
+    params.status = status;
   }
 
   if (format && NON_DEFAULT_FORMATS.includes(format)) {
@@ -324,8 +333,13 @@ async function downloadAndSave(
   token?: Token,
   options?: PullOptions
 ) {
-  const { validProjects, variants, format, shouldFetchComponentLibrary } =
-    sourceInformation;
+  const {
+    validProjects,
+    variants,
+    format,
+    shouldFetchComponentLibrary,
+    status,
+  } = sourceInformation;
 
   let msg = `\nFetching the latest text from ${sourcesToText(
     validProjects,
@@ -351,8 +365,12 @@ async function downloadAndSave(
 
     const meta = options ? options.meta : {};
     msg += variants
-      ? await downloadAndSaveVariants(validProjects, format, token, { meta })
-      : await downloadAndSaveBase(validProjects, format, token, { meta });
+      ? await downloadAndSaveVariants(validProjects, format, status, token, {
+          meta,
+        })
+      : await downloadAndSaveBase(validProjects, format, status, token, {
+          meta,
+        });
 
     msg += generateJsDriver(validProjects, variants, format);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,6 +9,7 @@ export interface ConfigYAML {
   components?: boolean;
   projects?: Project[];
   format?: string;
+  status?: string;
   variants?: boolean;
 }
 
@@ -18,6 +19,7 @@ export interface SourceInformation {
   shouldFetchComponentLibrary: boolean;
   variants: boolean;
   format: string | undefined;
+  status: string | undefined;
 }
 
 export type Token = string | undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "scripts": {


### PR DESCRIPTION
## Overview
This pull request adds a new optional config value called `status` which will filter text items/components when running `ditto pull`.

## Test Plan
Create a workspace with the following:
- Workspace components with variants and various statuses
- A project with text items that have variants and various statuses

Verify expected values with the following config values:
- [ ] components: true, variants: true, status: FINAL
- [ ] components: true, variants: false, status: FINAL
- [ ] components: true, variants: false
- [ ] components: true, variants: true