### PR TITLE
Add rich text parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ If you run the CLI in a directory that does not contain a `ditto/` folder, the f
   status: FINAL
   ```
 
+  #### `richText`
+
+  If included, results will have rich text versions of each piece of text requested. This rich text will be in HTML format. You can read more about Ditto's rich text feature [here](https://www.dittowords.com/docs/rich-text).
+
   **Full Example**
 
   ```yml

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -161,7 +161,7 @@ function dedupeProjectName(projectNames: Set<string>, projectName: string) {
  * - the `variants` and `format` config options
  */
 function parseSourceInformation() {
-  const { projects, components, variants, format, status } =
+  const { projects, components, variants, format, status, richText } =
     readProjectConfigData();
 
   const projectNames = new Set<string>();
@@ -198,6 +198,7 @@ function parseSourceInformation() {
     variants: variants || false,
     format,
     status,
+    richText,
   };
 }
 

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -53,6 +53,7 @@ async function downloadAndSaveVariant(
   projects: Project[],
   format: string | undefined,
   status: string | undefined,
+  richText: boolean | undefined,
   token?: Token
 ) {
   const params: Record<string, string | null> = {
@@ -63,6 +64,9 @@ async function downloadAndSaveVariant(
   }
   if (status) {
     params.status = status;
+  }
+  if (richText) {
+    params.includeRichText = richText.toString();
   }
 
   if (format && NON_DEFAULT_FORMATS.includes(format)) {
@@ -120,6 +124,7 @@ async function downloadAndSaveVariants(
   projects: Project[],
   format: string | undefined,
   status: string | undefined,
+  richText: boolean | undefined,
   token?: Token,
   options?: PullOptions
 ) {
@@ -134,9 +139,9 @@ async function downloadAndSaveVariants(
   });
 
   const messages = await Promise.all([
-    downloadAndSaveVariant(null, projects, format, status, token),
+    downloadAndSaveVariant(null, projects, format, status, richText, token),
     ...variants.map(({ apiID }: { apiID: string }) =>
-      downloadAndSaveVariant(apiID, projects, format, status, token)
+      downloadAndSaveVariant(apiID, projects, format, status, richText, token)
     ),
   ]);
 
@@ -147,6 +152,7 @@ async function downloadAndSaveBase(
   projects: Project[],
   format: string | undefined,
   status: string | undefined,
+  richText: boolean | undefined,
   token?: Token,
   options?: PullOptions
 ) {
@@ -160,6 +166,9 @@ async function downloadAndSaveBase(
   }
   if (status) {
     params.status = status;
+  }
+  if (richText) {
+    params.includeRichText = richText.toString();
   }
 
   if (format && NON_DEFAULT_FORMATS.includes(format)) {
@@ -339,6 +348,7 @@ async function downloadAndSave(
     format,
     shouldFetchComponentLibrary,
     status,
+    richText,
   } = sourceInformation;
 
   let msg = `\nFetching the latest text from ${sourcesToText(
@@ -365,12 +375,26 @@ async function downloadAndSave(
 
     const meta = options ? options.meta : {};
     msg += variants
-      ? await downloadAndSaveVariants(validProjects, format, status, token, {
-          meta,
-        })
-      : await downloadAndSaveBase(validProjects, format, status, token, {
-          meta,
-        });
+      ? await downloadAndSaveVariants(
+          validProjects,
+          format,
+          status,
+          richText,
+          token,
+          {
+            meta,
+          }
+        )
+      : await downloadAndSaveBase(
+          validProjects,
+          format,
+          status,
+          richText,
+          token,
+          {
+            meta,
+          }
+        );
 
     msg += generateJsDriver(validProjects, variants, format);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,6 +11,7 @@ export interface ConfigYAML {
   format?: string;
   status?: string;
   variants?: boolean;
+  richText?: boolean;
 }
 
 export interface SourceInformation {
@@ -20,6 +21,7 @@ export interface SourceInformation {
   variants: boolean;
   format: string | undefined;
   status: string | undefined;
+  richText: boolean | undefined;
 }
 
 export type Token = string | undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "scripts": {


### PR DESCRIPTION
## Overview
Adds the ability to pull down rich text data. This uses the `includeRichText` API parameter that is yet to be released, so we should hold off on testing and merging this PR until that is out.


## Test Plan

Testing successfully completed in <env> via:

- [ ] Test structured format without the `richText` parameter and verify no rich text appears
- [ ] Test structured format with `richText=true` and verify rich text appears
