### PR TITLE
Log error when failing token check

### DIFF
--- a/lib/init/token.ts
+++ b/lib/init/token.ts
@@ -45,9 +45,10 @@ async function checkToken(token: string): Promise<any> {
       }
       return output.warnText("We're having trouble reaching the Ditto API.");
     })
-    .catch(() =>
-      output.errorText("Sorry! We're having trouble reaching the Ditto API.")
-    );
+    .catch((e) => {
+      output.errorText(e);
+      output.errorText("Sorry! We're having trouble reaching the Ditto API.");
+    });
   if (typeof resOrError === "string") return resOrError;
 
   if (resOrError.status === 200) return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "scripts": {


### PR DESCRIPTION
## Overview
Small change to log the error when `/token-check` fails. This should catch and log cert errors that some users may encounter.

This PR may change depending on how we handle self-signed cert errors.