### PR TITLE
[DIT-3310] Revamp file output & add component folder support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 testing/tmp
 ditto
 bin/
+.env

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -9,7 +9,7 @@ import { Project, ConfigYAML } from "./types";
 
 export const DEFAULT_CONFIG_JSON: ConfigYAML = {
   sources: {
-    components: true,
+    components: { enabled: true },
   },
   variants: true,
   format: "flat",
@@ -237,6 +237,7 @@ function parseSourceInformation(file?: string) {
     hasTopLevelProjectsField: !!projectsRoot,
     hasTopLevelComponentsField: !!componentsRoot,
     hasComponentLibraryInProjects,
+    componentFolders: sources?.components?.folders || null,
   };
 }
 

--- a/lib/http/fetchVariants.ts
+++ b/lib/http/fetchVariants.ts
@@ -1,0 +1,30 @@
+import { AxiosRequestConfig } from "axios";
+import api from "../api";
+import { PullOptions } from "../pull";
+import { SourceInformation } from "../types";
+
+export async function fetchVariants(
+  source: SourceInformation,
+  options: PullOptions = {}
+) {
+  if (!source.variants) {
+    return null;
+  }
+
+  const { shouldFetchComponentLibrary, validProjects } = source;
+
+  const config: AxiosRequestConfig = {
+    params: { ...options?.meta },
+  };
+
+  // if we're not syncing from the component library, then we pass the project ids
+  // to limit the list of returned variants to only those that are relevant for the
+  // specified projects
+  if (validProjects.length && !shouldFetchComponentLibrary) {
+    config.params.projectIds = validProjects.map(({ id }) => id);
+  }
+
+  const { data } = await api.get<{ apiID: string }[]>("/variants", config);
+
+  return data;
+}

--- a/lib/init/project.ts
+++ b/lib/init/project.ts
@@ -16,7 +16,9 @@ import { quit } from "../utils/quit";
 
 function saveProject(file: string, name: string, id: string) {
   if (id === "components") {
-    config.writeProjectConfigData(file, { sources: { components: true } });
+    config.writeProjectConfigData(file, {
+      sources: { components: { enabled: true } },
+    });
     return;
   }
 

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -209,12 +209,15 @@ async function downloadAndSave(
 ) {
   const {
     validProjects,
-    format,
+    format: formatFromSource,
     shouldFetchComponentLibrary,
     status,
     richText,
     componentFolders,
   } = source;
+
+  let format =
+    formatFromSource && formatFromSource !== "full" ? formatFromSource : "flat";
 
   let msg = "";
   const spinner = ora(msg);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,9 +5,19 @@ export interface Project {
   fileName?: string;
 }
 
+export type Source = Project;
+
+interface ComponentFolder {
+  id: string;
+  name: string;
+}
+
 export interface ConfigYAML {
   sources?: {
-    components?: boolean;
+    components?: {
+      enabled?: boolean;
+      folders?: ComponentFolder[];
+    };
     projects?: Project[];
   };
   format?: "flat" | "structured" | "android-xml" | "ios-strings";
@@ -30,6 +40,7 @@ export interface SourceInformation {
   format: string | undefined;
   status: string | undefined;
   richText: boolean | undefined;
+  componentFolders: ComponentFolder[] | null;
 }
 
 export type Token = string | undefined;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "strictNullChecks": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "strict": true
   },
   "include": ["lib/ditto.ts"]
 }


### PR DESCRIPTION
## Overview
- Support specifying a list of component folders that should be filtered by
- Refactor file output structure to always be `{source_name}__{variant_name}.{extension}`. This is a major win for simplification, and is only possible as a breaking change and without supporting the `full` format.

## Context
https://linear.app/dittowords/issue/DIT-3310/cli

## Test Plan
- [x] Component library is still synced when `sources.components` is set to `true`
- [x] Component library is still synced when `sources.components` is set to `{ enabled: true }`
- [x] Syncing without `format` defined pulls copy in a `flat` format (carryover from last PR)
- [ ] Setting `sources.components.folders` to a list of `{id: string; name: string}` and pulling causes only components in those folders to be pulled
- [ ] Independent of your configuration, files are always written with the same output structure:
  - [ ] `variants`: `true` or `false`
  - [ ] `format`: `flat`, `structured`, `android`, `ios-strings`
  - [ ] `sources.components`: `true` or undefined
  - [ ] `sources.projects`: list of `{id:string; name:string}` or undefined