### PR TITLE
Add generate-suggestions command

### DIFF
--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -10,6 +10,7 @@ import { quit } from "./utils/quit";
 import addProject from "./add-project";
 import removeProject from "./remove-project";
 import { replace } from "./replace";
+import { generateSuggestions } from "./generate-suggestions";
 
 import processMetaOption from "./utils/processMetaOption";
 
@@ -18,6 +19,7 @@ type Command =
   | "project"
   | "project add"
   | "project remove"
+  | "generate-suggestions"
   | "replace";
 
 const COMMANDS = [
@@ -38,6 +40,10 @@ const COMMANDS = [
         description: "Stop syncing copy from a Ditto project",
       },
     ],
+  },
+  {
+    name: "generate-suggestions",
+    description: "Find text that can be potentially replaced with Ditto text",
   },
   {
     name: "replace",
@@ -105,6 +111,9 @@ const executeCommand = async (
     }
     case "project remove": {
       return removeProject();
+    }
+    case "generate-suggestions": {
+      return generateSuggestions();
     }
     case "replace": {
       return replace(options);

--- a/lib/generate-suggestions.test.ts
+++ b/lib/generate-suggestions.test.ts
@@ -1,0 +1,65 @@
+import fs from "fs/promises";
+import path from "path";
+import { findTextInJSXFiles } from "./generate-suggestions";
+
+describe("findTextInJSXFiles", () => {
+  async function createTempFile(filename, content) {
+    const filePath = path.join(".", filename);
+    await fs.writeFile(filePath, content);
+    return filePath;
+  }
+
+  async function deleteTempFile(filename) {
+    const filePath = path.join(".", filename);
+    await fs.unlink(filePath);
+  }
+
+  it("should return an empty array when no files are found", async () => {
+    const result = await findTextInJSXFiles(".", "searchString");
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return an empty array when searchString is not found in any file", async () => {
+    const file1 = await createTempFile("file1.jsx", "<div>No match</div>");
+    const file2 = await createTempFile("file2.tsx", "<div>No match</div>");
+
+    const result = await findTextInJSXFiles(".", "searchString");
+
+    expect(result).toEqual([]);
+
+    await deleteTempFile(file1);
+    await deleteTempFile(file2);
+  });
+
+  it("should return an array with correct occurrences when searchString is found", async () => {
+    const file1 = await createTempFile(
+      "file1.jsx",
+      `<div>Test searchString and another searchString</div>`
+    );
+
+    const expectedResult = [
+      {
+        file: file1,
+        occurrences: [
+          {
+            lineNumber: 1,
+            preview:
+              "<div>Test {{searchString}} and another searchString</div>",
+          },
+          {
+            lineNumber: 1,
+            preview:
+              "<div>Test searchString and another {{searchString}}</div>",
+          },
+        ],
+      },
+    ];
+
+    const result = await findTextInJSXFiles(".", "searchString");
+
+    expect(result).toEqual(expectedResult);
+
+    await deleteTempFile(file1);
+  });
+});

--- a/lib/generate-suggestions.ts
+++ b/lib/generate-suggestions.ts
@@ -33,7 +33,9 @@ async function findTextInJSXFiles(
   searchString: string
 ): Promise<FindResults> {
   const result: { file: string; occurrences: Occurence[] }[] = [];
-  const files = glob.sync(`${path}/**/*.+(jsx|tsx)`);
+  const files = glob.sync(`${path}/**/*.+(jsx|tsx)`, {
+    ignore: "**/node_modules/**",
+  });
 
   for (const file of files) {
     const code = await fs.readFile(file, "utf-8");

--- a/lib/generate-suggestions.ts
+++ b/lib/generate-suggestions.ts
@@ -1,0 +1,96 @@
+import fs from "fs-extra";
+import glob from "glob";
+import { parse } from "@babel/parser";
+import traverse from "@babel/traverse";
+
+import { fetchComponents } from "./http/fetchComponents";
+
+async function generateSuggestions() {
+  const components = await fetchComponents();
+  const results: {
+    [compApiId: string]: FindResults;
+  } = {};
+
+  for (const [compApiId, component] of Object.entries(components)) {
+    if (!results[compApiId]) {
+      results[compApiId] = [];
+    }
+    const result = await findTextInJSXFiles(".", component.text);
+    results[compApiId] = [...results[compApiId], ...result];
+  }
+  console.log(JSON.stringify(results, null, 2));
+}
+
+interface Occurence {
+  lineNumber: number;
+  preview: string;
+}
+
+type FindResults = { file: string; occurrences: Occurence[] }[];
+
+async function findTextInJSXFiles(
+  path: string,
+  searchString: string
+): Promise<FindResults> {
+  const result: { file: string; occurrences: Occurence[] }[] = [];
+  const files = glob.sync(`${path}/**/*.+(jsx|tsx)`);
+
+  for (const file of files) {
+    const code = await fs.readFile(file, "utf-8");
+    const ast = parse(code, {
+      sourceType: "module",
+      plugins: ["jsx", "typescript"],
+    });
+
+    const occurrences: Occurence[] = [];
+
+    traverse(ast, {
+      JSXText(path) {
+        if (path.node.value.includes(searchString)) {
+          const regex = new RegExp(searchString, "g");
+          let match;
+          while ((match = regex.exec(path.node.value)) !== null) {
+            const lines = path.node.value.slice(0, match.index).split("\n");
+
+            if (!path.node.loc) {
+              continue;
+            }
+
+            const lineNumber = path.node.loc.start.line + lines.length - 1;
+
+            const codeLines = code.split("\n");
+            const line = codeLines[lineNumber - 1];
+            const preview = replaceAt(
+              line,
+              match.index,
+              searchString,
+              `{{${searchString}}}`
+            );
+
+            occurrences.push({ lineNumber, preview });
+          }
+        }
+      },
+    });
+
+    if (occurrences.length > 0) {
+      result.push({ file, occurrences });
+    }
+  }
+
+  return result;
+}
+
+function replaceAt(
+  str: string,
+  index: number,
+  searchString: string,
+  replacement: string
+) {
+  return (
+    str.substring(0, index) +
+    str.substring(index, str.length).replace(searchString, replacement)
+  );
+}
+
+export { findTextInJSXFiles, generateSuggestions };

--- a/lib/generate-suggestions.ts
+++ b/lib/generate-suggestions.ts
@@ -18,6 +18,8 @@ async function generateSuggestions() {
     const result = await findTextInJSXFiles(".", component.text);
     results[compApiId] = [...results[compApiId], ...result];
   }
+
+  // Display results to user
   console.log(JSON.stringify(results, null, 2));
 }
 

--- a/lib/http/fetchComponents.ts
+++ b/lib/http/fetchComponents.ts
@@ -1,0 +1,14 @@
+import api from "../api";
+
+export async function fetchComponents() {
+  const { data } = await api.get<{
+    [compApiId: string]: {
+      name: string;
+      text: string;
+      status: "NONE" | "WIP" | "REVIEW" | "FINAL";
+      folder: "string" | null;
+    };
+  }>("/components", {});
+
+  return data;
+}

--- a/lib/replace.test.ts
+++ b/lib/replace.test.ts
@@ -1,16 +1,16 @@
-import * as fs from "fs";
+import fs from "fs/promises";
 import { parseOptions, replaceJSXTextInFile } from "./replace"; // Assuming the function is exported in a separate file
 
 // Helper function to create a temporary file
-async function createTempJSXFile(content: string): Promises<string> {
+async function createTempJSXFile(content: string): Promise<string> {
   const tempFile = "tempFile.jsx";
-  await fs.promises.writeFile(tempFile, content);
+  await fs.writeFile(tempFile, content);
   return tempFile;
 }
 
 // Helper function to delete the temporary file
 async function deleteTempFile(filePath: string): Promise<void> {
-  await fs.promises.unlink(filePath);
+  await fs.unlink(filePath);
 }
 
 describe("parseOptions", () => {
@@ -69,7 +69,7 @@ describe("replaceJSXTextInFile", () => {
 
     await replaceJSXTextInFile(tempFile, { searchString, replaceWith });
 
-    const transformedCode = await fs.promises.readFile(tempFile, "utf-8");
+    const transformedCode = await fs.readFile(tempFile, "utf-8");
     expect(transformedCode).toContain(
       `<div>Hello, <DittoComponent componentId="${replaceWith}" /></div>`
     );
@@ -82,7 +82,7 @@ describe("replaceJSXTextInFile", () => {
 
     await replaceJSXTextInFile(tempFile, { searchString, replaceWith });
 
-    const transformedCode = await fs.promises.readFile(tempFile, "utf-8");
+    const transformedCode = await fs.readFile(tempFile, "utf-8");
     expect(transformedCode).toContain(
       `<div>HeLLo, <DittoComponent componentId="${replaceWith}" /></div>`
     );
@@ -95,7 +95,7 @@ describe("replaceJSXTextInFile", () => {
 
     await replaceJSXTextInFile(tempFile, { searchString, replaceWith });
 
-    const transformedCode = await fs.promises.readFile(tempFile, "utf-8");
+    const transformedCode = await fs.readFile(tempFile, "utf-8");
     expect(transformedCode).toContain("<div>Hello, world!</div>");
   });
 });

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "enquirer": "^2.3.6",
     "faker": "^5.1.0",
     "fs-extra": "^11.1.1",
+    "glob": "^9.3.4",
     "js-yaml": "^4.1.0",
     "ora": "^5.0.0",
     "v8-compile-cache": "^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,6 +1875,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
@@ -2673,6 +2680,16 @@ glob@^7.1.3, glob@^7.1.4:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^9.3.4:
+  version "9.3.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-9.3.4.tgz#e75dee24891a80c25cc7ee1dd327e126b98679af"
+  integrity sha512-qaSc49hojMOv1EPM4EuyITjDSgSKI0rthoHnvE81tcOi1SCVndHko7auqxdQ14eiQG2NDBJBE86+2xIrbIvrbA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    minimatch "^8.0.2"
+    minipass "^4.2.4"
+    path-scurry "^1.6.1"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -3509,6 +3526,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^7.14.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+
 make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -3559,6 +3581,18 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^8.0.2:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.3.tgz#0415cb9bb0c1d8ac758c8a673eb1d288e13f5e75"
+  integrity sha512-tEEvU9TkZgnFDCtpnrEYnPsjT7iUx42aXfs4bzmQ5sMA09/6hZY0jeZcGkXyDagiBOvkUjNo8Viom+Me6+2x7g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minipass@^4.0.2, minipass@^4.2.4:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.5.tgz#9e0e5256f1e3513f8c34691dd68549e85b2c8ceb"
+  integrity sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==
 
 ms@2.1.2:
   version "2.1.2"
@@ -3747,6 +3781,14 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^1.6.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.6.3.tgz#4eba7183d64ef88b63c7d330bddc3ba279dc6c40"
+  integrity sha512-RAmB+n30SlN+HnNx6EbcpoDy9nwdpcGPnEKrJnu6GZoDWBdIjo1UQMVtW2ybtC7LC2oKLcMq8y5g8WnKLiod9g==
+  dependencies:
+    lru-cache "^7.14.1"
+    minipass "^4.0.2"
 
 picocolors@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Overview
This PR adds a new `generate-suggestions` command which will scan through the current repository for strings that match Ditto components. The files must be either `jsx` or `tsx`.
Note: The `generate-suggestions` command is not officially supported by Ditto yet.

Usage: ditto-cli generate-suggestions

Sample output:
<img width="640" alt="image" src="https://user-images.githubusercontent.com/15795866/230211594-a977a46b-f2b5-49aa-ab77-5c3c098d23d9.png">


## Test Plan

Testing successfully completed in <env> via:

- [ ] run ditto-cli generate-suggestions with a dummy jsx file and verify it finds any text that has a 100% match with existing Ditto components.
