### PR TITLE
Add version option to CLI

### DIFF
--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -4,6 +4,8 @@ import { program } from "commander";
 // to use V8's code cache to speed up instantiation time
 import "v8-compile-cache";
 
+import packageJson from "../package.json";
+
 import { init, needsTokenOrSource } from "./init/init";
 import { pull } from "./pull";
 import { quit } from "./utils/quit";
@@ -13,6 +15,8 @@ import { replace } from "./replace";
 import { generateSuggestions } from "./generate-suggestions";
 
 import processMetaOption from "./utils/processMetaOption";
+
+const VERSION = packageJson.version;
 
 type Command =
   | "pull"
@@ -81,6 +85,7 @@ const setupOptions = () => {
     "-m, --meta <data...>",
     "Include arbitrary data in requests to the Ditto API. Ex: -m githubActionRequest:true trigger:manual"
   );
+  program.version(VERSION, "-v, --version", "Output the current version");
 };
 
 const executeCommand = async (

--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -3,8 +3,8 @@
 import { program } from "commander";
 // to use V8's code cache to speed up instantiation time
 import "v8-compile-cache";
-
-import packageJson from "../package.json";
+import fs from "fs";
+import path from "path";
 
 import { init, needsTokenOrSource } from "./init/init";
 import { pull } from "./pull";
@@ -16,7 +16,16 @@ import { generateSuggestions } from "./generate-suggestions";
 
 import processMetaOption from "./utils/processMetaOption";
 
-const VERSION = packageJson.version;
+function getVersion(): string {
+  const packageJsonPath = path.join(__dirname, "..", "package.json");
+  const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
+  const packageJson = JSON.parse(packageJsonContent) as { version: string };
+  const version = packageJson.version;
+
+  return version;
+}
+
+const VERSION = getVersion();
 
 type Command =
   | "pull"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "3.1.0-alpha.0",
+  "version": "3.2.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request adds a new feature to the ditto-cli command-line tool, allowing users to view the current version of the application by using the -v or --version flag. The version number is retrieved from the package.json file, ensuring that it stays up-to-date with the actual package version.

Changes:

- Import package.json in the main script to access the version number.
- Define a VERSION constant that retrieves the version number from the imported package.json.
- Update the setupOptions() function to use the version() method of the Commander program, which overrides the built-in version option.

These changes make it easier for users to quickly check the installed version of the ditto-cli tool, facilitating better debugging and ensuring they are using the correct version.