### PR TITLE
Fix regex escape for replacing

### DIFF
--- a/lib/replace.ts
+++ b/lib/replace.ts
@@ -21,7 +21,11 @@ async function replaceJSXTextInFile(
     JSXText(path) {
       const { searchString, replaceWith } = replacement;
 
-      const regex = new RegExp(searchString, "gi");
+      const searchStringEscaped = searchString.replace(
+        /[.*+?^${}()|[\]\\]/g,
+        "\\$&"
+      );
+      const regex = new RegExp(searchStringEscaped, "gi");
       if (regex.test(path.node.value)) {
         // Ignore if not on a line number that we want to replace.
         if (
@@ -34,7 +38,7 @@ async function replaceJSXTextInFile(
 
         const splitValues = splitByCaseInsensitive(
           path.node.value,
-          searchString
+          searchStringEscaped
         );
         const nodes: (t.JSXElement | t.JSXText)[] = [];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "scripts": {


### PR DESCRIPTION
## Overview

The replace function was failing for a component with text `?`. This should escape all regex characters.
