### PR TITLE
[DIT-3960] Add full ICU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ The Ditto CLI helps teams integrate [Ditto](https://dittowords.com/) into their 
 You can install the CLI from npm:
 
 ```bash
-# as a dev dependency (recommended)
+# as a dev dependency (**recommended**)
 npm install --save-dev @dittowords/cli
-
+****
 # as a global package
 npm install --global @dittowords/cli
 ```
@@ -35,11 +35,11 @@ Thanks for authenticating.
 We'll save the key to: /Users/{username}/.config/ditto
 ```
 
-Once you've successfully authenticated, you'll be asked to choose a source (a project or your component library) to pull data from:
+Once you've successfully authenticated, you'll be asked to choose a source (a project or your component library) to pull data **from**:
 
 ```
 Looks like there are no Ditto sources selected for your current directory: /Users/ditto
-
+****
 ? Choose the source you'd like to sync text from:
 - Ditto Component Library https://app.dittowords.com/components
 - NUX Onboarding Flow https://app.dittowords.com/doc/609e9981c313f8018d0c346a
@@ -231,6 +231,7 @@ The CLI outputs data from Ditto by writing files to disk in your `ditto/` direct
 | :---------: | :----------------: | :-----------------: |
 |    flat     |        JSON        |      Web apps       |
 | structured  |        JSON        |      Web apps       |
+|     icu     |        JSON        |      Web apps       |
 |   android   |        XML         | Native Android apps |
 | ios-strings |      STRINGS       |   Native iOS apps   |
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -3,13 +3,13 @@ import axios from "axios";
 import config from "./config";
 import consts from "./consts";
 
-export const create = (token?: string) => {
+export function createApiClient(token?: string) {
   return axios.create({
     baseURL: consts.API_HOST,
     headers: {
-      Authorization: `token ${token}`,
+      Authorization: `token ${
+        token || config.getToken(consts.CONFIG_FILE, consts.API_HOST)
+      }`,
     },
   });
-};
-
-export default create(config.getToken(consts.CONFIG_FILE, consts.API_HOST));
+}

--- a/lib/http/fetchComponents.ts
+++ b/lib/http/fetchComponents.ts
@@ -1,4 +1,4 @@
-import api from "../api";
+import { createApiClient } from "../api";
 
 export interface FetchComponentResponseComponent {
   name: string;
@@ -12,6 +12,7 @@ export interface FetchComponentResponse {
 }
 
 export async function fetchComponents(): Promise<FetchComponentResponse> {
+  const api = createApiClient();
   const { data } = await api.get<{
     [compApiId: string]: {
       name: string;

--- a/lib/http/fetchVariants.ts
+++ b/lib/http/fetchVariants.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig } from "axios";
-import api from "../api";
+import { createApiClient } from "../api";
 import { PullOptions } from "../pull";
 import { SourceInformation } from "../types";
 
@@ -7,6 +7,7 @@ export async function fetchVariants(
   source: SourceInformation,
   options: PullOptions = {}
 ) {
+  const api = createApiClient();
   if (!source.variants) {
     return null;
   }

--- a/lib/init/project.ts
+++ b/lib/init/project.ts
@@ -1,6 +1,6 @@
 import ora from "ora";
 
-import api from "../api";
+import { createApiClient } from "../api";
 import config from "../config";
 import consts from "../consts";
 import output from "../output";
@@ -38,16 +38,13 @@ async function askForAnotherToken() {
 }
 
 async function listProjects(token: Token, projectsAlreadySelected: Project[]) {
+  const api = createApiClient();
   const spinner = ora("Fetching sources in your workspace...");
   spinner.start();
 
   let response: AxiosResponse<{ id: string; name: string }[]>;
   try {
-    response = await api.get("/project-names", {
-      headers: {
-        Authorization: `token ${token}`,
-      },
-    });
+    response = await api.get("/project-names");
   } catch (e) {
     spinner.stop();
     throw e;

--- a/lib/init/token.ts
+++ b/lib/init/token.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 
 import { prompt } from "enquirer";
 
-import { create } from "../api";
+import { createApiClient } from "../api";
 import consts from "../consts";
 import output from "../output";
 import config from "../config";
@@ -28,7 +28,7 @@ export const needsToken = (configFile?: string, host = consts.API_HOST) => {
 
 // Returns true if valid, otherwise an error message.
 async function checkToken(token: string): Promise<any> {
-  const axios = create(token);
+  const axios = createApiClient(token);
   const endpoint = "/token-check";
 
   let resOrError;

--- a/lib/pull.test.ts
+++ b/lib/pull.test.ts
@@ -1,7 +1,6 @@
 import fs from "fs";
 import path from "path";
-import api from "./api";
-import config from "./config";
+import { createApiClient } from "./api";
 
 const testProjects = [
   {
@@ -14,7 +13,9 @@ const testProjects = [
 
 jest.mock("./api");
 
-const mockApi = api as jest.Mocked<typeof api>;
+const mockApi = createApiClient() as jest.Mocked<
+  ReturnType<typeof createApiClient>
+>;
 
 jest.mock("./consts", () => ({
   TEXT_DIR: ".testing",
@@ -116,7 +117,11 @@ describe("downloadAndSaveBase", () => {
     cleanOutputDir();
 
     mockApi.get.mockResolvedValueOnce({ data: [] });
-    const output = await downloadAndSaveBase(testProjects, "", undefined);
+    const output = await downloadAndSaveBase(
+      testProjects,
+      "" as any,
+      undefined
+    );
 
     expect(/saved to.*text\.json/.test(output)).toEqual(true);
     expect(output.match(/saved to/g)?.length).toEqual(1);

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 import ora from "ora";
 
-import api from "./api";
+import { createApiClient } from "./api";
 import config from "./config";
 import consts from "./consts";
 import output from "./output";
@@ -14,7 +14,12 @@ import { cleanFileName } from "./utils/cleanFileName";
 import { SourceInformation, Token, Project } from "./types";
 import { fetchVariants } from "./http/fetchVariants";
 
-type SupportedFormat = "flat" | "structured" | "android" | "ios-strings";
+type SupportedFormat =
+  | "flat"
+  | "structured"
+  | "android"
+  | "ios-strings"
+  | "icu";
 
 const SUPPORTED_FORMATS: SupportedFormat[] = [
   "flat",
@@ -23,18 +28,20 @@ const SUPPORTED_FORMATS: SupportedFormat[] = [
   "ios-strings",
 ];
 
-const JSON_FORMATS: SupportedFormat[] = ["flat", "structured"];
+const JSON_FORMATS: SupportedFormat[] = ["flat", "structured", "icu"];
 
 const FORMAT_EXTENSIONS = {
   flat: ".json",
   structured: ".json",
   android: ".xml",
   "ios-strings": ".strings",
+  icu: ".json",
 };
 
 const getFormatDataIsValid = {
   flat: (data: string) => data !== "{}",
   structured: (data: string) => data !== "{}",
+  icu: (data: string) => data !== "{}",
   android: (data: string) => data.includes("<string"),
   "ios-strings": (data: string) => !!data,
 };
@@ -85,6 +92,7 @@ async function downloadAndSaveVariant(
   richText: boolean | undefined,
   token?: Token
 ) {
+  const api = createApiClient();
   const params: Record<string, string | null> = { variant: variantApiId };
   if (format) params.format = format;
   if (status) params.status = status;
@@ -152,6 +160,7 @@ async function downloadAndSaveBase(
   token?: Token,
   options?: PullOptions
 ) {
+  const api = createApiClient();
   const params = { ...options?.meta };
   if (format) params.format = format;
   if (status) params.status = status;
@@ -210,6 +219,7 @@ async function downloadAndSave(
   token?: Token,
   options?: PullOptions
 ) {
+  const api = createApiClient();
   const {
     validProjects,
     format: formatFromSource,

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -26,6 +26,7 @@ const SUPPORTED_FORMATS: SupportedFormat[] = [
   "structured",
   "android",
   "ios-strings",
+  "icu",
 ];
 
 const JSON_FORMATS: SupportedFormat[] = ["flat", "structured", "icu"];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,7 +20,7 @@ export interface ConfigYAML {
     };
     projects?: Project[];
   };
-  format?: "flat" | "structured" | "android-xml" | "ios-strings";
+  format?: "flat" | "structured" | "android-xml" | "ios-strings" | "icu";
   status?: string;
   variants?: boolean;
   richText?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "scripts": {


### PR DESCRIPTION
## Overview
Adds explicit support for new ICU format and fixes some problems inherent to the previous implementation of the API client.

## Context
https://linear.app/dittowords/issue/DIT-3960/update-cli-readme-w-icu-format

## Test Plan
### ICU
- [x] Set `format` to `icu` in `config.yml`, execute `pull`, and confirm that strings are outputted in ICU
### Token initialization
- [x] Remove `~/.config/ditto`
- [x] Run `yarn start` and paste your token at the prompt
- [x] Confirm that strings are pulled without any errors
