### PR TITLE
Speed improvement for generate-suggestions

### DIFF
--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -70,6 +70,10 @@ const COMMANDS: CommandConfig<Command>[] = [
       "-d, --directory [value]": {
         description: "Directory to search for text",
       },
+      "-f, --files [value]": {
+        description: "Files to search for text (will override -d)",
+        processor: (value: string) => value.split(","),
+      },
     },
   },
   {
@@ -167,6 +171,7 @@ const executeCommand = async (
     case "generate-suggestions": {
       return generateSuggestions({
         ...(options.directory ? { directory: options.directory } : {}),
+        ...(options.files ? { files: options.files } : {}),
       });
     }
     case "replace": {

--- a/lib/generate-suggestions.test.ts
+++ b/lib/generate-suggestions.test.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
-import { findTextInJSXFiles } from "./generate-suggestions";
+import { findComponentsInJSXFiles } from "./generate-suggestions";
 
 describe("findTextInJSXFiles", () => {
   async function createTempFile(filename, content) {
@@ -15,9 +15,7 @@ describe("findTextInJSXFiles", () => {
   }
 
   it("should return an empty obj when no files are found", async () => {
-    const result = await findTextInJSXFiles(".", {
-      text: "searchString",
-    } as any);
+    const result = await findComponentsInJSXFiles(".", {});
 
     expect(result).toEqual({});
   });
@@ -26,9 +24,14 @@ describe("findTextInJSXFiles", () => {
     const file1 = await createTempFile("file1.jsx", "<div>No match</div>");
     const file2 = await createTempFile("file2.tsx", "<div>No match</div>");
 
-    const result = await findTextInJSXFiles(".", {
-      text: "searchString",
-    } as any);
+    const result = await findComponentsInJSXFiles(".", {
+      acomponent: {
+        name: "A Component",
+        text: "A Component",
+        status: "NONE",
+        folder: null,
+      },
+    });
 
     expect(result).toEqual({});
 
@@ -43,21 +46,35 @@ describe("findTextInJSXFiles", () => {
     );
 
     const expectedResult = {
-      [file1]: [
-        {
-          lineNumber: 1,
-          preview: "<div>Test searchString and another searchString</div>",
+      "search-string": {
+        apiId: "search-string",
+        folder: null,
+        name: "Search String",
+        occurrences: {
+          [file1]: [
+            {
+              lineNumber: 1,
+              preview: "<div>Test searchString and another searchString</div>",
+            },
+            {
+              lineNumber: 1,
+              preview: "<div>Test searchString and another searchString</div>",
+            },
+          ],
         },
-        {
-          lineNumber: 1,
-          preview: "<div>Test searchString and another searchString</div>",
-        },
-      ],
+        status: "NONE",
+        text: "searchString",
+      },
     };
 
-    const result = await findTextInJSXFiles(".", {
-      text: "searchString",
-    } as any);
+    const result = await findComponentsInJSXFiles(".", {
+      "search-string": {
+        name: "Search String",
+        text: "searchString",
+        status: "NONE",
+        folder: null,
+      },
+    });
 
     expect(result).toEqual(expectedResult);
 

--- a/lib/generate-suggestions.test.ts
+++ b/lib/generate-suggestions.test.ts
@@ -15,7 +15,10 @@ describe("findTextInJSXFiles", () => {
   }
 
   it("should return an empty obj when no files are found", async () => {
-    const result = await findComponentsInJSXFiles(".", {});
+    const result = await findComponentsInJSXFiles({
+      directory: ".",
+      components: {},
+    });
 
     expect(result).toEqual({});
   });
@@ -24,12 +27,15 @@ describe("findTextInJSXFiles", () => {
     const file1 = await createTempFile("file1.jsx", "<div>No match</div>");
     const file2 = await createTempFile("file2.tsx", "<div>No match</div>");
 
-    const result = await findComponentsInJSXFiles(".", {
-      acomponent: {
-        name: "A Component",
-        text: "A Component",
-        status: "NONE",
-        folder: null,
+    const result = await findComponentsInJSXFiles({
+      directory: ".",
+      components: {
+        acomponent: {
+          name: "A Component",
+          text: "A Component",
+          status: "NONE",
+          folder: null,
+        },
       },
     });
 
@@ -67,16 +73,84 @@ describe("findTextInJSXFiles", () => {
       },
     };
 
-    const result = await findComponentsInJSXFiles(".", {
-      "search-string": {
-        name: "Search String",
-        text: "searchString",
-        status: "NONE",
-        folder: null,
+    const result = await findComponentsInJSXFiles({
+      directory: ".",
+      components: {
+        "search-string": {
+          name: "Search String",
+          text: "searchString",
+          status: "NONE",
+          folder: null,
+        },
       },
     });
 
     expect(result).toEqual(expectedResult);
+
+    await deleteTempFile(file1);
+  });
+
+  it("-f flag works", async () => {
+    const file1 = await createTempFile(
+      "file1.jsx",
+      `<div>Test searchString and another searchString</div>`
+    );
+
+    const expectedResult = {
+      "search-string": {
+        apiId: "search-string",
+        folder: null,
+        name: "Search String",
+        occurrences: {
+          [file1]: [
+            {
+              lineNumber: 1,
+              preview: "<div>Test searchString and another searchString</div>",
+            },
+            {
+              lineNumber: 1,
+              preview: "<div>Test searchString and another searchString</div>",
+            },
+          ],
+        },
+        status: "NONE",
+        text: "searchString",
+      },
+    };
+
+    const result = await findComponentsInJSXFiles({
+      directory: ".",
+      files: ["file1.jsx"],
+      components: {
+        "search-string": {
+          name: "Search String",
+          text: "searchString",
+          status: "NONE",
+          folder: null,
+        },
+      },
+    });
+
+    expect(result).toEqual(expectedResult);
+
+    try {
+      const result2 = await findComponentsInJSXFiles({
+        directory: ".",
+        files: ["file2.jsx"],
+        components: {
+          "search-string": {
+            name: "Search String",
+            text: "searchString",
+            status: "NONE",
+            folder: null,
+          },
+        },
+      });
+
+      expect(false).toEqual(true);
+    } catch {
+      expect(true).toEqual(true);
+    }
 
     await deleteTempFile(file1);
   });

--- a/lib/generate-suggestions.ts
+++ b/lib/generate-suggestions.ts
@@ -23,8 +23,6 @@ interface Occurrence {
 
 async function generateSuggestions(flags: { directory?: string }) {
   const components = await fetchComponents();
-
-  console.log("debug3");
   const directory = flags.directory || ".";
 
   const results: { [apiId: string]: Result } = await findComponentsInJSXFiles(

--- a/lib/generate-suggestions.ts
+++ b/lib/generate-suggestions.ts
@@ -131,4 +131,4 @@ function replaceAt(
   );
 }
 
-export { findComponentsInJSXFiles as findTextInJSXFiles, generateSuggestions };
+export { findComponentsInJSXFiles, generateSuggestions };

--- a/lib/generate-suggestions.ts
+++ b/lib/generate-suggestions.ts
@@ -53,8 +53,6 @@ async function findComponentsInJSXFiles(
           plugins: ["jsx", "typescript"],
         });
 
-        const occurrences: Occurrence[] = [];
-
         traverse(ast, {
           JSXText(path) {
             for (const [compApiId, component] of Object.entries(components)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "scripts": {

--- a/testfiles/test1.jsx
+++ b/testfiles/test1.jsx
@@ -2,15 +2,15 @@ import React from "react";
 function HelloWorld() {
   return (
     <div>
-      <p>hello world</p>
+      <p>hello!</p>
       <p>Some additional text.</p>
-      <p>hello world</p>
+      <p>hello!</p>
       <p>More additional text.</p>
-      <p>ahhh hello world iaewofjaowiejfoiwjfoffj</p>
+      <p>ahhh hello! iaewofjaowiejfoiwjfoffj</p>
       <p>Even more additional text.</p>
-      <p>hello world</p>
+      <p>hello!</p>
       <p>Final additional text.</p>
-      <p>hello world</p>
+      <p>hello!</p>
       <p>good bye</p>
     </div>
   );


### PR DESCRIPTION
## Overview
Improved the speed of generating suggestions by no longer opening each file for each component. Now we iterate the components for each file.

## Screenshots
Running on the ditto codebase

Previous:
<img width="672" alt="Screen Shot 2023-05-30 at 2 07 47 PM" src="https://github.com/dittowords/cli/assets/15795866/4be27888-0681-4943-972c-2a41fc9e55dd">

New:
<img width="661" alt="Screen Shot 2023-05-30 at 2 07 07 PM" src="https://github.com/dittowords/cli/assets/15795866/731e00e4-867d-42b9-a753-c32e7464c7a6">


## Test Plan

Testing successfully completed in <env> via:

- [ ] Verify `generate-suggestions` still works correctly