### PR TITLE
[DIT-4197] Add files flag to generate-suggestions

### DIFF
--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -70,6 +70,10 @@ const COMMANDS: CommandConfig<Command>[] = [
       "-d, --directory [value]": {
         description: "Directory to search for text",
       },
+      "-f, --files [value]": {
+        description: "Files to search for text (will override -d)",
+        processor: (value: string) => value.split(","),
+      },
     },
   },
   {
@@ -167,6 +171,7 @@ const executeCommand = async (
     case "generate-suggestions": {
       return generateSuggestions({
         ...(options.directory ? { directory: options.directory } : {}),
+        ...(options.files ? { files: options.files } : {}),
       });
     }
     case "replace": {

--- a/lib/generate-suggestions.test.ts
+++ b/lib/generate-suggestions.test.ts
@@ -15,7 +15,10 @@ describe("findTextInJSXFiles", () => {
   }
 
   it("should return an empty obj when no files are found", async () => {
-    const result = await findComponentsInJSXFiles(".", {});
+    const result = await findComponentsInJSXFiles({
+      directory: ".",
+      components: {},
+    });
 
     expect(result).toEqual({});
   });
@@ -24,12 +27,15 @@ describe("findTextInJSXFiles", () => {
     const file1 = await createTempFile("file1.jsx", "<div>No match</div>");
     const file2 = await createTempFile("file2.tsx", "<div>No match</div>");
 
-    const result = await findComponentsInJSXFiles(".", {
-      acomponent: {
-        name: "A Component",
-        text: "A Component",
-        status: "NONE",
-        folder: null,
+    const result = await findComponentsInJSXFiles({
+      directory: ".",
+      components: {
+        acomponent: {
+          name: "A Component",
+          text: "A Component",
+          status: "NONE",
+          folder: null,
+        },
       },
     });
 
@@ -67,16 +73,84 @@ describe("findTextInJSXFiles", () => {
       },
     };
 
-    const result = await findComponentsInJSXFiles(".", {
-      "search-string": {
-        name: "Search String",
-        text: "searchString",
-        status: "NONE",
-        folder: null,
+    const result = await findComponentsInJSXFiles({
+      directory: ".",
+      components: {
+        "search-string": {
+          name: "Search String",
+          text: "searchString",
+          status: "NONE",
+          folder: null,
+        },
       },
     });
 
     expect(result).toEqual(expectedResult);
+
+    await deleteTempFile(file1);
+  });
+
+  it("-f flag works", async () => {
+    const file1 = await createTempFile(
+      "file1.jsx",
+      `<div>Test searchString and another searchString</div>`
+    );
+
+    const expectedResult = {
+      "search-string": {
+        apiId: "search-string",
+        folder: null,
+        name: "Search String",
+        occurrences: {
+          [file1]: [
+            {
+              lineNumber: 1,
+              preview: "<div>Test searchString and another searchString</div>",
+            },
+            {
+              lineNumber: 1,
+              preview: "<div>Test searchString and another searchString</div>",
+            },
+          ],
+        },
+        status: "NONE",
+        text: "searchString",
+      },
+    };
+
+    const result = await findComponentsInJSXFiles({
+      directory: ".",
+      files: ["file1.jsx"],
+      components: {
+        "search-string": {
+          name: "Search String",
+          text: "searchString",
+          status: "NONE",
+          folder: null,
+        },
+      },
+    });
+
+    expect(result).toEqual(expectedResult);
+
+    try {
+      const result2 = await findComponentsInJSXFiles({
+        directory: ".",
+        files: ["file2.jsx"],
+        components: {
+          "search-string": {
+            name: "Search String",
+            text: "searchString",
+            status: "NONE",
+            folder: null,
+          },
+        },
+      });
+
+      expect(false).toEqual(true);
+    } catch {
+      expect(true).toEqual(true);
+    }
 
     await deleteTempFile(file1);
   });

--- a/testfiles/test1.jsx
+++ b/testfiles/test1.jsx
@@ -2,15 +2,15 @@ import React from "react";
 function HelloWorld() {
   return (
     <div>
-      <p>hello world</p>
+      <p>hello!</p>
       <p>Some additional text.</p>
-      <p>hello world</p>
+      <p>hello!</p>
       <p>More additional text.</p>
-      <p>ahhh hello world iaewofjaowiejfoiwjfoffj</p>
+      <p>ahhh hello! iaewofjaowiejfoiwjfoffj</p>
       <p>Even more additional text.</p>
-      <p>hello world</p>
+      <p>hello!</p>
       <p>Final additional text.</p>
-      <p>hello world</p>
+      <p>hello!</p>
       <p>good bye</p>
     </div>
   );


### PR DESCRIPTION
## Overview
Adds a new flag to the `generate-suggestions` command to specify specific files to search through (comma separated list). Will override the directory flag.


## Test Plan

Testing successfully completed in <env> via:

- [x] Verify `generate-suggestions` continues to work without any flags
- [x] Verify `generate-suggestions` works with the directory flag (-d)
- [x] verify `generate-suggestions` works with the files flag (-f)
