### PR TITLE
[DIT-4239] Add command to show component-folders

### DIFF
--- a/lib/component-folders.ts
+++ b/lib/component-folders.ts
@@ -1,0 +1,9 @@
+import { fetchComponentFolders } from "./http/fetchComponentFolders";
+
+async function showComponentFolders() {
+  const folders = await fetchComponentFolders();
+
+  console.log(folders);
+}
+
+export { showComponentFolders };

--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -15,6 +15,7 @@ import { replace } from "./replace";
 import { generateSuggestions } from "./generate-suggestions";
 
 import processMetaOption from "./utils/processMetaOption";
+import { showComponentFolders } from "./component-folders";
 
 function getVersion(): string {
   const packageJsonPath = path.join(__dirname, "..", "package.json");
@@ -30,6 +31,7 @@ type Command =
   | "project"
   | "project add"
   | "project remove"
+  | "component-folders"
   | "generate-suggestions"
   | "replace";
 
@@ -60,6 +62,11 @@ const COMMANDS: CommandConfig<Command>[] = [
         description: "Stop syncing copy from a Ditto project",
       },
     ],
+  },
+  {
+    name: "component-folders",
+    description:
+      "Show what component folders exist in your workspace. More information about component folders can be found here: https://www.dittowords.com/docs/component-folders.",
   },
   {
     name: "generate-suggestions",
@@ -169,11 +176,16 @@ const executeCommand = async (
     case "project remove": {
       return removeProject();
     }
+    case "component-folders": {
+      return showComponentFolders();
+    }
     case "generate-suggestions": {
       return generateSuggestions({
         ...(options.directory ? { directory: options.directory } : {}),
         ...(options.files ? { files: options.files } : {}),
-        ...(options.componentFolder ? { componentFolder: options.componentFolder } : {}),
+        ...(options.componentFolder
+          ? { componentFolder: options.componentFolder }
+          : {}),
       });
     }
     case "replace": {

--- a/lib/http/fetchComponentFolders.ts
+++ b/lib/http/fetchComponentFolders.ts
@@ -1,0 +1,16 @@
+import { createApiClient } from "../api";
+
+interface FetchComponentFoldersResponse {
+  [id: string]: string;
+}
+
+export async function fetchComponentFolders(): Promise<FetchComponentFoldersResponse> {
+  const api = createApiClient();
+
+  const { data } = await api.get<FetchComponentFoldersResponse>(
+    "/component-folders",
+    {}
+  );
+
+  return data;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "main": "bin/index.js",
   "scripts": {


### PR DESCRIPTION
## Overview
Simple command that calls `/component-folders` and prints out an object of folder names and corresponding api ids.

## Test Plan

Testing successfully completed in <env> via:

- [ ] `--help` shows `component-folders` command
- [ ] `component-folders` displays an object of existing folders in your workspace