### PR TITLE
[DIT-4270] Support pulling multiple formats at once

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -188,6 +188,7 @@ function dedupeProjectName(projectNames: Set<string>, projectName: string) {
  */
 function parseSourceInformation(file?: string) {
   const {
+    mode,
     sources,
     variants,
     format,
@@ -225,6 +226,7 @@ function parseSourceInformation(file?: string) {
   const hasSourceData = !!validProjects.length || shouldFetchComponentLibrary;
 
   return {
+    mode,
     hasSourceData,
     validProjects,
     shouldFetchComponentLibrary,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -188,7 +188,6 @@ function dedupeProjectName(projectNames: Set<string>, projectName: string) {
  */
 function parseSourceInformation(file?: string) {
   const {
-    mode,
     sources,
     variants,
     format,
@@ -226,7 +225,6 @@ function parseSourceInformation(file?: string) {
   const hasSourceData = !!validProjects.length || shouldFetchComponentLibrary;
 
   return {
-    mode,
     hasSourceData,
     validProjects,
     shouldFetchComponentLibrary,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,7 +21,6 @@ export type SupportedFormat =
   | "icu";
 
 export interface ConfigYAML {
-  mode?: "ios";
   sources?: {
     components?: {
       enabled?: boolean;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -42,12 +42,11 @@ export interface ConfigYAML {
 }
 
 export interface SourceInformation {
-  mode?: "ios";
   hasSourceData: boolean;
   validProjects: Project[];
   shouldFetchComponentLibrary: boolean;
   variants: boolean;
-  format: string | undefined;
+  format: string | string[] | undefined;
   status: string | undefined;
   richText: boolean | undefined;
   componentFolders: ComponentFolder[] | null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,6 +21,7 @@ export type SupportedFormat =
   | "icu";
 
 export interface ConfigYAML {
+  mode?: "ios";
   sources?: {
     components?: {
       enabled?: boolean;
@@ -41,6 +42,7 @@ export interface ConfigYAML {
 }
 
 export interface SourceInformation {
+  mode?: "ios";
   hasSourceData: boolean;
   validProjects: Project[];
   shouldFetchComponentLibrary: boolean;


### PR DESCRIPTION
## Overview
Adds support for optionally specifying a list of formats in the `format` property.

<img width="493" alt="image" src="https://github.com/dittowords/cli/assets/19500384/d2f5130a-3266-40f7-93a9-e0496d6ac484">
<img width="986" alt="image" src="https://github.com/dittowords/cli/assets/19500384/1b9cad79-5170-4175-b8b8-b3a990503761">

## Context
https://linear.app/dittowords/issue/DIT-4270/pull-down-strings-and-stringsdict

## Test Plan
- [x] In `config.yml`, confirm you can pull a single format like `format: flat`
- [x] In `config.yml`, confirm you can pull multiple formats like
```yml
format:
  - ios-strings
  - ios-stringsdict
```