### PR TITLE
[DIT-4687] Update CLI empty file detection logic to exclude variant metadata, fix tests

### DIFF
--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -37,9 +37,8 @@ const FORMAT_EXTENSIONS = {
 
 const getJsonFormatIsValid = (data: string) => {
   try {
-    return (
-      Object.keys(JSON.parse(data)).filter((k) => !k.startsWith("__variant"))
-        .length > 0
+    return Object.keys(JSON.parse(data)).some(
+      (k) => !k.startsWith("__variant")
     );
   } catch {
     return false;

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -13,6 +13,7 @@ import { generateJsDriver } from "./utils/generateJsDriver";
 import { cleanFileName } from "./utils/cleanFileName";
 import { SourceInformation, Token, Project, SupportedFormat } from "./types";
 import { fetchVariants } from "./http/fetchVariants";
+import { kMaxLength } from "buffer";
 
 const SUPPORTED_FORMATS: SupportedFormat[] = [
   "flat",
@@ -34,12 +35,24 @@ const FORMAT_EXTENSIONS = {
   icu: ".json",
 };
 
-const getFormatDataIsValid = {
-  flat: (data: string) => data !== "{}",
-  structured: (data: string) => data !== "{}",
-  icu: (data: string) => data !== "{}",
+const getJsonFormatIsValid = (data: string) => {
+  try {
+    return (
+      Object.keys(JSON.parse(data)).filter((k) => !k.startsWith("__variant"))
+        .length > 0
+    );
+  } catch {
+    return false;
+  }
+};
+
+// exported for test usage only
+export const getFormatDataIsValid = {
+  flat: getJsonFormatIsValid,
+  structured: getJsonFormatIsValid,
+  icu: getJsonFormatIsValid,
   android: (data: string) => data.includes("<string"),
-  "ios-strings": (data: string) => !!data,
+  "ios-strings": (data: string) => data.includes(`" = "`),
   "ios-stringsdict": (data: string) => data.includes("<key>"),
 };
 


### PR DESCRIPTION
## Overview
Updates per-filetype logic that determines whether or not API data should be written to disk to handle variant metadata.

Also fixes miscellaneous `pull.test.ts` tests that have been broken for quite some time.

## Context
https://linear.app/dittowords/issue/DIT-4687/update-cli-empty-file-detection-logic-to-exclude-variant-metadata

Also fixes DIT-4116

## Test Plan
### Fix for empty files
1. Create two variants in your workspace
2. Apply one of the variants to one or more components 
3. Set your test CLI config as follows:
```yaml
sources:
  components: 
    enabled: true
variants: true
```
4. Run `yarn start pull` in the CLI directory
5. Confirm that a file is written to disk for the variant that is used
6. Confirm that a file is NOT written to disk for the unused variant

### Fix for tests
- [ ] `yarn jest` passes (one or two tests of the tests I didn't modify are a bit flaky, so run a couple of times if it fails on the first try)