### PR TITLE
[DIT-4720] (v4) Component support overhaul

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -3,13 +3,12 @@ import path from "path";
 import url from "url";
 import yaml from "js-yaml";
 
-import output from "./output";
 import consts from "./consts";
 import { Project, ConfigYAML, SourceInformation } from "./types";
 
 export const DEFAULT_CONFIG_JSON: ConfigYAML = {
   sources: {
-    components: { enabled: true },
+    components: true,
   },
   variants: true,
   format: "flat",
@@ -220,8 +219,20 @@ function parseSourceInformation(file?: string): SourceInformation {
     validProjects.push(project);
   });
 
-  const shouldFetchComponentLibrary = Boolean(sources?.components?.enabled);
+  const shouldFetchComponentLibrary = Boolean(sources?.components);
+  const componentRoot =
+    typeof sources?.components === "object"
+      ? sources.components.root
+      : undefined;
+  const componentFolders =
+    typeof sources?.components === "object"
+      ? sources.components.folders
+      : undefined;
 
+  /**
+   * If it's not specified to fetch projects or the component library, then there
+   * is no source data to pull.
+   */
   const hasSourceData = !!validProjects.length || shouldFetchComponentLibrary;
 
   return {
@@ -235,8 +246,8 @@ function parseSourceInformation(file?: string): SourceInformation {
     hasTopLevelProjectsField: !!projectsRoot,
     hasTopLevelComponentsField: !!componentsRoot,
     hasComponentLibraryInProjects,
-    componentRoot: sources?.components?.root || false,
-    componentFolders: sources?.components?.folders || null,
+    componentRoot,
+    componentFolders,
   };
 }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -5,7 +5,7 @@ import yaml from "js-yaml";
 
 import output from "./output";
 import consts from "./consts";
-import { Project, ConfigYAML } from "./types";
+import { Project, ConfigYAML, SourceInformation } from "./types";
 
 export const DEFAULT_CONFIG_JSON: ConfigYAML = {
   sources: {
@@ -186,7 +186,7 @@ function dedupeProjectName(projectNames: Set<string>, projectName: string) {
  * - an array of valid, deduped projects
  * - the `variants` and `format` config options
  */
-function parseSourceInformation(file?: string) {
+function parseSourceInformation(file?: string): SourceInformation {
   const {
     sources,
     variants,
@@ -235,6 +235,7 @@ function parseSourceInformation(file?: string) {
     hasTopLevelProjectsField: !!projectsRoot,
     hasTopLevelComponentsField: !!componentsRoot,
     hasComponentLibraryInProjects,
+    componentRoot: sources?.components?.root || false,
     componentFolders: sources?.components?.folders || null,
   };
 }

--- a/lib/init/project.ts
+++ b/lib/init/project.ts
@@ -17,7 +17,7 @@ import { quit } from "../utils/quit";
 function saveProject(file: string, name: string, id: string) {
   if (id === "components") {
     config.writeProjectConfigData(file, {
-      sources: { components: { enabled: true } },
+      sources: { components: true },
     });
     return;
   }

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -116,13 +116,21 @@ async function downloadAndSaveVariant(
   const api = createApiClient();
   const params: Record<string, string | null> = { variant: variantApiId };
   if (format) params.format = format;
-  if (status) params.status = status;
   if (richText) params.includeRichText = richText.toString();
 
+  // Root-level status gets set as the default if specified
+  if (status) params.status = status;
+
   const savedMessages = await Promise.all(
-    projects.map(async ({ id, fileName }: Project) => {
-      const { data } = await api.get(`/projects/${id}`, {
-        params,
+    projects.map(async (project) => {
+      const projectParams = { ...params };
+      // If project-level status is specified, overrides root-level status
+      if (project.status) projectParams.status = project.status;
+      if (project.exclude_components)
+        projectParams.exclude_components = String(project.exclude_components);
+
+      const { data } = await api.get(`/projects/${project.id}`, {
+        params: projectParams,
         headers: { Authorization: `token ${token}` },
       });
 
@@ -133,7 +141,7 @@ async function downloadAndSaveVariant(
       const extension = getFormatExtension(format);
 
       const filename = cleanFileName(
-        fileName + ("__" + (variantApiId || "base")) + extension
+        project.fileName + ("__" + (variantApiId || "base")) + extension
       );
       const filepath = path.join(consts.TEXT_DIR, filename);
 
@@ -184,18 +192,26 @@ async function downloadAndSaveBase(
   const api = createApiClient();
   const params = { ...options?.meta };
   if (format) params.format = format;
-  if (status) params.status = status;
   if (richText) params.includeRichText = richText.toString();
 
+  // Root-level status gets set as the default if specified
+  if (status) params.status = status;
+
   const savedMessages = await Promise.all(
-    projects.map(async ({ id, fileName }: Project) => {
-      const { data } = await api.get(`/projects/${id}`, {
-        params,
+    projects.map(async (project) => {
+      const projectParams = { ...params };
+      // If project-level status is specified, overrides root-level status
+      if (project.status) projectParams.status = project.status;
+      if (project.exclude_components)
+        projectParams.exclude_components = String(project.exclude_components);
+
+      const { data } = await api.get(`/projects/${project.id}`, {
+        params: projectParams,
         headers: { Authorization: `token ${token}` },
       });
 
       const extension = getFormatExtension(format);
-      const filename = cleanFileName(`${fileName}__base${extension}`);
+      const filename = cleanFileName(`${project.fileName}__base${extension}`);
       const filepath = path.join(consts.TEXT_DIR, filename);
 
       let dataString = data;
@@ -276,23 +292,34 @@ async function downloadAndSave(
       if (options?.meta)
         Object.entries(options.meta).forEach(([k, v]) => params.append(k, v));
       if (format) params.append("format", format);
-      if (status) params.append("status", status);
       if (richText) params.append("includeRichText", richText.toString());
+
+      // Root-level status gets set as the default if specified
+      if (status) params.append("status", status);
 
       const messages = await Promise.all(
         componentVariants.flatMap(async ({ apiID: variantApiId }) => {
           return Promise.all(
             (componentFolders || [{ id: "__root__", name: "Root" }]).map(
               async (componentFolder) => {
-                const p = new URLSearchParams(params);
-                if (variantApiId) p.append("variant", variantApiId);
+                const componentFolderParams = new URLSearchParams(params);
+                if (variantApiId)
+                  componentFolderParams.append("variant", variantApiId);
+                // If folder-level status is specified, overrides root-level status
+                if (componentFolder.status)
+                  componentFolderParams.append(
+                    "status",
+                    componentFolder.status
+                  );
 
                 const url =
                   componentFolder.id === "__root__"
                     ? "/components"
                     : `/component-folders/${componentFolder.id}/components`;
 
-                const { data } = await api.get(url, { params: p });
+                const { data } = await api.get(url, {
+                  params: componentFolderParams,
+                });
 
                 const nameExt = getFormatExtension(format);
                 const nameBase = "components";

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -278,37 +278,47 @@ async function downloadAndSave(
       if (format) params.append("format", format);
       if (status) params.append("status", status);
       if (richText) params.append("includeRichText", richText.toString());
-      if (componentFolders) {
-        componentFolders.forEach(({ id }) => params.append("folder_id[]", id));
-      }
 
       const messages = await Promise.all(
-        componentVariants.map(async ({ apiID: variantApiId }) => {
-          const p = new URLSearchParams(params);
-          if (variantApiId) p.append("variant", variantApiId);
+        componentVariants.flatMap(async ({ apiID: variantApiId }) => {
+          return Promise.all(
+            (componentFolders || [{ id: "__root__", name: "Root" }]).map(
+              async (componentFolder) => {
+                const p = new URLSearchParams(params);
+                if (variantApiId) p.append("variant", variantApiId);
 
-          const { data } = await api.get(`/components`, { params: p });
+                const url =
+                  componentFolder.id === "__root__"
+                    ? "/components"
+                    : `/component-folders/${componentFolder.id}/components`;
 
-          const nameExt = getFormatExtension(format);
-          const nameBase = "ditto-component-library";
-          const namePostfix = `__${variantApiId || "base"}`;
+                const { data } = await api.get(url, { params: p });
 
-          const fileName = cleanFileName(`${nameBase}${namePostfix}${nameExt}`);
-          const filePath = path.join(consts.TEXT_DIR, fileName);
+                const nameExt = getFormatExtension(format);
+                const nameBase = "components";
+                const nameFolder = `__${componentFolder.name}`;
+                const namePostfix = `__${variantApiId || "base"}`;
 
-          let dataString = data;
-          if (nameExt === ".json") {
-            dataString = JSON.stringify(data, null, 2);
-          }
+                const fileName = cleanFileName(
+                  `${nameBase}${nameFolder}${namePostfix}${nameExt}`
+                );
+                const filePath = path.join(consts.TEXT_DIR, fileName);
 
-          const dataIsValid = getFormatDataIsValid[format];
-          if (!dataIsValid(dataString)) {
-            return "";
-          }
+                let dataString = data;
+                if (nameExt === ".json") {
+                  dataString = JSON.stringify(data, null, 2);
+                }
 
-          await writeFile(filePath, dataString);
+                const dataIsValid = getFormatDataIsValid[format];
+                if (!dataIsValid(dataString)) {
+                  return "";
+                }
 
-          return getSavedMessage(fileName);
+                await writeFile(filePath, dataString);
+                return getSavedMessage(fileName);
+              }
+            )
+          );
         })
       );
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,7 +9,7 @@ export interface Project {
 
 export type Source = Project;
 
-interface ComponentFolder {
+export interface ComponentFolder {
   id: string;
   name: string;
   status?: string;
@@ -27,6 +27,7 @@ export interface ConfigYAML {
   sources?: {
     components?: {
       enabled?: boolean;
+      root?: boolean | { status: string };
       folders?: ComponentFolder[];
     };
     projects?: Project[];
@@ -45,12 +46,16 @@ export interface ConfigYAML {
 
 export interface SourceInformation {
   hasSourceData: boolean;
+  hasTopLevelProjectsField: boolean;
+  hasTopLevelComponentsField: boolean;
+  hasComponentLibraryInProjects: boolean;
   validProjects: Project[];
   shouldFetchComponentLibrary: boolean;
   variants: boolean;
   format: string | string[] | undefined;
   status: string | undefined;
   richText: boolean | undefined;
+  componentRoot: boolean | { status: string } | undefined;
   componentFolders: ComponentFolder[] | null;
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,13 +23,16 @@ export type SupportedFormat =
   | "ios-stringsdict"
   | "icu";
 
+type ComponentsSourceBool = boolean;
+type ComponentsSourceConfig = {
+  root?: boolean | { status: string };
+  folders?: ComponentFolder[];
+};
+type ComponentsSource = ComponentsSourceBool | ComponentsSourceConfig;
+
 export interface ConfigYAML {
   sources?: {
-    components?: {
-      enabled?: boolean;
-      root?: boolean | { status: string };
-      folders?: ComponentFolder[];
-    };
+    components?: ComponentsSource;
     projects?: Project[];
   };
   format?: SupportedFormat;
@@ -56,7 +59,7 @@ export interface SourceInformation {
   status: string | undefined;
   richText: boolean | undefined;
   componentRoot: boolean | { status: string } | undefined;
-  componentFolders: ComponentFolder[] | null;
+  componentFolders: ComponentFolder[] | undefined;
 }
 
 export type Token = string | undefined;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,6 +3,8 @@ export interface Project {
   id: string;
   url?: string;
   fileName?: string;
+  status?: string;
+  exclude_components?: boolean;
 }
 
 export type Source = Project;
@@ -10,6 +12,7 @@ export type Source = Project;
 interface ComponentFolder {
   id: string;
   name: string;
+  status?: string;
 }
 
 export type SupportedFormat =

--- a/lib/utils/generateJsDriver.ts
+++ b/lib/utils/generateJsDriver.ts
@@ -23,6 +23,8 @@ const stringifySourceId = (projectId: string) =>
  */
 
 // TODO: support ESM
+// TODO: to avoid breaking changes with Ditto React, we need to update components part of the file
+// to ...require('folder_file) for each folder into one larger object
 export function generateJsDriver(sources: Source[]) {
   const fileNames = fs
     .readdirSync(consts.TEXT_DIR)


### PR DESCRIPTION
## Overview
- Write files for component data on a per folder, per variant basis (previously was only on a per variant basis)
```
# Before
ditto_component_library__base.json
ditto_component_library__spanish.json

# After
components__root__base.json
components__root__spanish.json
components__some-folder__base.json
components__some-folder__spanish.json
```
- Gets rid of `sources.components.enabled`, instead supporting `sources.components: true` (for explicitly enabled with no configuration) or implicitly understanding that components should be fetched when `sources.components` is a configuration object
```yml
# Before 1
sources:
  components:
    enabled: true

# Before 2
sources:
  components:
    enabled: true
    folders:
      ...

# After 1
sources:
  components: true

# After 2 (same as Before 2, w/o `enabled`)
sources:
  components:
    folders:
      ...
```
- Adds support for a `sources.components.root` property -- similar to `sources.components`, can be a boolean or a configuration object; this allows the user to explicitly control whether or not components at the root of the component library (i.e. outside of folders) are fetched
```yml
sources:
  components:
    root: true
    folders:
      ...
```

## Context
https://linear.app/dittowords/issue/DIT-4720/cli-allow-users-to-pull-component-folders-into-different-string-files

Should be merged into v4 integration branch.

## Test Plan
### Setup
1. Create component folders in your workspace, and populate them with components
2. Populate the root of your component library with components
3. Test against a local API server running on this branch: https://github.com/dittowords/ditto-app/pull/3267
4. `export DITTO_API_HOST=http://localhost:3001` before running `yarn start:api`
### Basic Testing
- [x] Running the CLI with `components.enabled: true` and `components.folders` unspecified writes a component file per variant, with each file following the naming convention `components__root__{variant}.{extension}`
```yml
components:
  enabled: true
```
- [x] Running the CLI with `components.enabled: true`, `components.folders` specified as `{ id: string; name: string }[]`, and `variants: true` writes a component file per variant per component folder, and with each file following the naming convention `components__{folder-name}__{variant}.{extension}`
```yml
components:
  enabled: true
  folders:
    - id: folder-api-id-1
       name: folder-1
    - id: folder-api-id-2
       name: folder-2
variants: true
```
- [x] Running the CLI with `components.enabled: true`, `components.folders` specified as `{ id: string; name: string }[]`, and `variants: false` writes a component file per variant per component folder, and with each file following the naming convention `components__root__{variant}.{extension}`
```yml
components:
  enabled: true
  folders:
    - id: folder-api-id-1
       name: folder-1
    - id: folder-api-id-2
       name: folder-2
variants: false
```
### Root specification
- [x] With neither `sources.components.root` nor `sources.components.folders` specified, confirm that `yarn start` pulls ALL components from your component library
```yml
sources:
  components: true
```
- [x] With `sources.components.root: true` specified and `sources.components.folders` unspecified, confirm that `yarn start` pulls only components from the root of your component library
```yml
sources:
  components:
    root: true
```
- [x] With `sources.components.root` unspecified and `sources.components.folders` specified, confirm that `yarn start` pulls only components from the specified component folders (none from root)
```yml
sources:
  components:
    folders:
      - id: folder-api-id-1
         name: Folder 1
```
- [x] With `sources.components.root: true` and `sources.components.folders` specified, confirm that `yarn start` pulls components from the root of the component library AND components from the specified component folders
```yml
sources:
  components:
    root: true
    folders:
      - id: folder-api-id-1
         name: Folder 1
```
- [x] Set `sources.components.root` to a config object specifying status, and confirm that you only get components from the root that have the status indicated
```yml
sources:
  components:
    root:
      status: WIP
```