### PR TITLE
[DIT-4704] (v4) Add support for source-specific CLI config flags

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,6 +3,8 @@ export interface Project {
   id: string;
   url?: string;
   fileName?: string;
+  status?: string;
+  exclude_components?: boolean;
 }
 
 export type Source = Project;
@@ -10,6 +12,7 @@ export type Source = Project;
 interface ComponentFolder {
   id: string;
   name: string;
+  status?: string;
 }
 
 export type SupportedFormat =


### PR DESCRIPTION
## Overview
Adds support for source-level configuration flags: 
- "status" 
- "exclude_components" (projects only)

"status" can still be specified at the top-level as a default, but the specification of source-specific "status" will override it.

## Context
https://linear.app/dittowords/issue/DIT-4704/source-specific-cli-config-flags

Components & projects
* [x] status

Projects only
* [x] exclude_components (corresponding to the API param)

## Test Plan
### Setup
1. Create multiple component folders in your component library
2. Create components in each component folder
3. Give all components diverse statuses
4. In two different projects:
  1. Attach some text items to components
  2. Assign diverse statuses to text items
5. Setup another project with diverse statuses and some attached components
6. In the terminal where you'll use the CLI, point at your local API: `export DITTO_API_HOST=http://localhost:3001`
7. Run your local API: `yarn start:api`
8. Set up your `config.yml` such that all component folders and projects are specified
```yml
sources:
  components:
    enabled: true
    folders:
      - id: folder-api-id-1
        name: Folder 1
      - id: folder-api-id-2
        name: Folder 2
  projects:
    - id: project-_id-1 
      name: Project 1
    - id: project-_id-2
      name: Project 2
```
### Testing
- [x] Run `yarn start` and confirm that all text data from all folders/projects is pulled
#### status
- [x] Add a root-level `status` (e.g. `WIP`) and confirm that only text data with the given status from folders/projects is pulled
```yml
...rest of config
status: WIP
```
- [x] Add an individual `status` property to one of the projects listed in your `config.yml`; confirm only text data with the given status is pulled from that project, and that only text data with the root status is pulled from the other project
```yml
...rest of config
  projects:
    - id: project-_id-1 
      name: Project 1
      status: WIP
    - id: project-_id-2
      name: Project 2
```
- [ ] Add an `exclude_components` property to one of the projects listed in your `config.yml`; confirm only text data without components attached is pulled for that project, and that text data with + without components is pulled for the other projects
```yml
...rest of config
  projects:
    - id: project-_id-1 
      name: Project 1
      exclude_components: WIP
    - id: project-_id-2
      name: Project 2
```
- [x] Add an individual `status` property to one of the component folders listed in your `config.yml`; confirm only text data with the given status is pulled from that component folder, and that only text data with the root status is pulled from the other component folder
```yml
...rest of config
    folders:
      - id: folder-api-id-1
        name: Folder 1
        status: WIP
      - id: folder-api-id-2
        name: Folder 2
```