### PR TITLE
[DIT-4524] (v4) Ensure generated output files have trailing newlines

### DIFF
--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -13,7 +13,12 @@ import { generateJsDriver } from "./utils/generateJsDriver";
 import { cleanFileName } from "./utils/cleanFileName";
 import { SourceInformation, Token, Project, SupportedFormat } from "./types";
 import { fetchVariants } from "./http/fetchVariants";
-import { kMaxLength } from "buffer";
+
+const ensureEndsWithNewLine = (str: string) =>
+  str + (/[\r\n]$/.test(str) ? "" : "\n");
+
+const writeFile = (path: string, data: string) =>
+  new Promise((r) => fs.writeFile(path, ensureEndsWithNewLine(data), r));
 
 const SUPPORTED_FORMATS: SupportedFormat[] = [
   "flat",
@@ -142,7 +147,7 @@ async function downloadAndSaveVariant(
         return "";
       }
 
-      fs.writeFileSync(filepath, dataString);
+      await writeFile(filepath, dataString);
       return getSavedMessage(filename);
     })
   );
@@ -203,7 +208,7 @@ async function downloadAndSaveBase(
         return "";
       }
 
-      fs.writeFileSync(filepath, dataString);
+      await writeFile(filepath, dataString);
       return getSavedMessage(filename);
     })
   );
@@ -301,7 +306,8 @@ async function downloadAndSave(
             return "";
           }
 
-          await new Promise((r) => fs.writeFile(filePath, dataString, r));
+          await writeFile(filePath, dataString);
+
           return getSavedMessage(fileName);
         })
       );


### PR DESCRIPTION
## Overview
Ensure generated files end with new lines to comply with POSIX standard and not break tools.

## Context
https://linear.app/dittowords/issue/DIT-4524/ensure-generated-output-files-have-trailing-newlines

## Test Plan
1. On `master`, run `yarn start` and `cat` the contents of an output file -- observe that a `%` displays at the end of the output, indicating that the file ends in a "partial" line (i.e. no new line at the end)
2. Check out this branch
3. Run `yarn start` and `cat` the contents of the same file -- observe the absence of `%`, indicating that the file correctly terminates with a new line