### PR TITLE
[DIT-4784] (v4) Generate backwards-compatible index.js driver file for `ditto-react` compat

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,7 +7,13 @@ export interface Project {
   exclude_components?: boolean;
 }
 
-export type Source = Project;
+export type ComponentSource = ComponentFolder & {
+  type: "components";
+  fileName: string;
+  variant: string;
+};
+
+export type Source = (Project & { type?: undefined }) | ComponentSource;
 
 export interface ComponentFolder {
   id: string;

--- a/lib/utils/generateJsDriver.ts
+++ b/lib/utils/generateJsDriver.ts
@@ -23,13 +23,7 @@ const stringifySourceId = (projectId: string) =>
  */
 
 // TODO: support ESM
-// TODO: to avoid breaking changes with Ditto React, we need to update components part of the file
-// to ...require('folder_file) for each folder into one larger object
 export function generateJsDriver(sources: Source[]) {
-  const fileNames = fs
-    .readdirSync(consts.TEXT_DIR)
-    .filter((fileName) => /\.json$/.test(fileName));
-
   const sourceIdsByName: Record<string, string> = sources.reduce(
     (agg, source) => {
       if (source.fileName) {
@@ -41,7 +35,14 @@ export function generateJsDriver(sources: Source[]) {
     {}
   );
 
-  const data = fileNames.reduce(
+  const projectFileNames = fs
+    .readdirSync(consts.TEXT_DIR)
+    .filter(
+      (fileName) => /\.json$/.test(fileName) && !/^components__/.test(fileName)
+    );
+
+  type DriverFile = Record<string, Record<string, string | object>>;
+  const data: DriverFile = projectFileNames.reduce(
     (obj: Record<string, Record<string, string>>, fileName) => {
       const [sourceId, rest] = fileName.split("__");
       const [variantApiId] = rest.split(".");
@@ -59,9 +60,40 @@ export function generateJsDriver(sources: Source[]) {
     {}
   );
 
+  // Create arrays of stringified "...require()" statements,
+  // each of which corresponds to one of the component files
+  // (which are created on a per-component-folder basis)
+  const componentData: Record<string, string[]> = {};
+  sources
+    .filter((s) => s.type === "components")
+    .forEach((componentSource) => {
+      if (componentSource.type !== "components") return;
+      componentData[componentSource.variant] ??= [];
+      componentData[componentSource.variant].push(
+        `...require('./${componentSource.fileName}')`
+      );
+    });
+  // Convert each array of stringified "...require()" statements
+  // into a unified string, and set it on the final data object
+  // that will be written to the driver file
+  Object.keys(componentData).forEach((key) => {
+    data.ditto_component_library ??= {};
+
+    let str = "{";
+    componentData[key].forEach((k, i) => {
+      str += k;
+      if (i < componentData[key].length - 1) str += ", ";
+    });
+    str += "}";
+    data.ditto_component_library[key] = str;
+  });
+
   let dataString = `module.exports = ${JSON.stringify(data, null, 2)}`
     // remove quotes around require statements
-    .replace(/"require\((.*)\)"/g, "require($1)");
+    .replace(/"require\((.*)\)"/g, "require($1)")
+    // remove quotes around opening & closing curlies
+    .replace(/"\{/g, "{")
+    .replace(/\}"/g, "}");
 
   const filePath = path.resolve(consts.TEXT_DIR, "index.js");
   fs.writeFileSync(filePath, dataString, { encoding: "utf8" });


### PR DESCRIPTION
## Overview
Generate backwards-compatible index.js driver format that includes all component keys for a given variant (independent of the folders they're in) under a single key.

This is done by generating a file that looks like this:
```js
module.exports = {
  ditto_component_library: {
    base: {
      ...require('./components__root__base.json'),
      ...require('./components__folder-1__base.json'),
    },
    some_variant: {
      ...require('./components__root__some_variant.json'),
      ...require('./components__folder-1__some_variant.json'),
    },
  }
}
```

This makes it so that the CLI v4 is backwards compatible with previous `ditto-react` versions.

## Context
https://linear.app/dittowords/issue/DIT-4784/update-indexjs-driver-file-to-be-backwards-compatible-for-ditto-react

Now that components are written on a per-folder basis, we need to update the driver file so that all of the components are still flattened into variant-level properties. This ensures that we maintain backwards compatibility with `ditto-react`.

## Test Plan
1. `export DITTO_API_HOST=http://localhost:3001`
2. Create components in multiple folders with multiple variants in your component library
3. Set up your configuration to pull components
```yml
sources:
  components: true
```
4. Run `yarn start` to pull
5. Confirm that in the generated `index.js` driver file is valid JavaScript, and that you can access all of the components for a given variant via `ditto_component_library[variant-api-id]`