### PR TITLE
[DIT-4793] (v4) Include Sentry event ID in error messages, fix publish environment

### DIFF
--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -524,19 +524,20 @@ export const pull = async (options?: PullOptions) => {
   try {
     return await downloadAndSave(sourceInformation, token, { meta });
   } catch (e) {
-    Sentry.captureException(e);
+    const eventId = Sentry.captureException(e);
+    const eventStr = `\n\nError ID: ${output.info(eventId)}`;
     if (e instanceof AxiosError) {
       return quit(
         output.errorText(
           "Something went wrong connecting to Ditto servers. Please contact support or try again later."
-        )
+        ) + eventStr
       );
     }
 
     return quit(
       output.errorText(
         "Something went wrong. Please contact support or try again later."
-      )
+      ) + eventStr
     );
   }
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "bin/index.js",
   "scripts": {
-    "prepublishOnly": "etsc && sentry-cli sourcemaps inject ./bin && npx sentry-cli sourcemaps upload ./bin --release=\"$(cat package.json | jq -r '.version')\"",
+    "prepublishOnly": "ENV=production etsc && sentry-cli sourcemaps inject ./bin && npx sentry-cli sourcemaps upload ./bin --release=\"$(cat package.json | jq -r '.version')\"",
     "prepare": "husky install",
     "start": "etsc && node bin/ditto.js",
     "sync": "etsc && node bin/ditto.js pull",


### PR DESCRIPTION
## Overview
- Ensure that the Sentry environment is correctly set to `production` when errors are captured
- Log the Sentry event ID to the console for customer reference

## Context
https://linear.app/dittowords/issue/DIT-4793/include-sentry-event-id-in-error-messages

## Test Plan
- [ ] `yarn start pull` pulls data w/o error
- [ ] hardcoding an error in the `pull` function in `pull.ts` results in a Sentry error being recorded and a Slack message being sent with an env of development

