### PR TITLE
Rename ios_locales property for naming convention consistency

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -195,7 +195,7 @@ function parseSourceInformation(file?: string): SourceInformation {
     format,
     status,
     richText,
-    ios_locales,
+    iosLocales,
     projects: projectsRoot,
     components: componentsRoot,
   } = readProjectConfigData(file);
@@ -252,8 +252,8 @@ function parseSourceInformation(file?: string): SourceInformation {
     hasComponentLibraryInProjects,
     componentRoot,
     componentFolders,
-    localeByVariantApiId: ios_locales
-      ? ios_locales.reduce((acc, e) => ({ ...acc, ...e }), {} as any)
+    localeByVariantApiId: iosLocales
+      ? iosLocales.reduce((acc, e) => ({ ...acc, ...e }), {} as any)
       : undefined,
   };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -47,7 +47,7 @@ export interface ConfigYAML {
   richText?: boolean;
 
   // TODO: might want to rename this at some point
-  ios_locales?: Record<string, string>[];
+  iosLocales?: Record<string, string>[];
 
   // these are legacy fields - if they exist, we should output
   // a deprecation error, and suggest that they nest them under


### PR DESCRIPTION
## Overview
Rename `ios_locales` -> `iosLocales` for consistency with other camelCase properties.