### PR TITLE
[DIT-5338] Migrate CLI to use v1 API Endpoints

### DIFF
--- a/lib/http/fetchComponentFolders.ts
+++ b/lib/http/fetchComponentFolders.ts
@@ -8,7 +8,7 @@ export async function fetchComponentFolders(): Promise<FetchComponentFoldersResp
   const api = createApiClient();
 
   const { data } = await api.get<FetchComponentFoldersResponse>(
-    "/component-folders",
+    "/v1/component-folders",
     {}
   );
 

--- a/lib/http/fetchComponents.ts
+++ b/lib/http/fetchComponents.ts
@@ -18,18 +18,23 @@ export async function fetchComponents(options: {
 
   if (options.componentFolder) {
     try {
-      const { data } = await api.get<FetchComponentResponse>(`/component-folders/${options.componentFolder}/components`, {});
+      const { data } = await api.get<FetchComponentResponse>(
+        `/v1/component-folders/${options.componentFolder}/components`,
+        {}
+      );
 
       return data;
+    } catch (e) {
+      console.log(
+        `Failed to get components for ${options.componentFolder}. Please verify the folder's API ID.`
+      );
+      return {};
     }
-    catch (e) {
-      console.log(`Failed to get components for ${options.componentFolder}. Please verify the folder's API ID.`)
-      return {}
-    }
-
-  }
-  else {
-    const { data } = await api.get<FetchComponentResponse>("/components", {});
+  } else {
+    const { data } = await api.get<FetchComponentResponse>(
+      "/v1/components",
+      {}
+    );
 
     return data;
   }

--- a/lib/http/fetchVariants.ts
+++ b/lib/http/fetchVariants.ts
@@ -25,7 +25,7 @@ export async function fetchVariants(
     config.params.projectIds = validProjects.map(({ id }) => id);
   }
 
-  const { data } = await api.get<{ apiID: string }[]>("/variants", config);
+  const { data } = await api.get<{ apiID: string }[]>("/v1/variants", config);
 
   return data;
 }

--- a/lib/init/project.ts
+++ b/lib/init/project.ts
@@ -44,7 +44,7 @@ async function listProjects(token: Token, projectsAlreadySelected: Project[]) {
 
   let response: AxiosResponse<{ id: string; name: string }[]>;
   try {
-    response = await api.get("/project-names");
+    response = await api.get("/v1/projects");
   } catch (e) {
     spinner.stop();
     throw e;

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -154,7 +154,7 @@ async function downloadAndSaveVariant(
       if (project.exclude_components)
         projectParams.exclude_components = String(project.exclude_components);
 
-      const { data } = await api.get(`/projects/${project.id}`, {
+      const { data } = await api.get(`/v1/projects/${project.id}`, {
         params: projectParams,
         headers: { Authorization: `token ${token}` },
       });
@@ -220,7 +220,7 @@ async function downloadAndSaveBase(requestOptions: IRequestOptions) {
       if (project.exclude_components)
         projectParams.exclude_components = String(project.exclude_components);
 
-      const { data } = await api.get(`/projects/${project.id}`, {
+      const { data } = await api.get(`/v1/projects/${project.id}`, {
         params: projectParams,
         headers: { Authorization: `token ${token}` },
       });
@@ -413,8 +413,8 @@ async function downloadAndSave(
 
             const url =
               componentFolder.id === "__root__"
-                ? "/components?root_only=true"
-                : `/component-folders/${componentFolder.id}/components`;
+                ? "/v1/components?root_only=true"
+                : `/v1/component-folders/${componentFolder.id}/components`;
 
             const { data } = await api.get(url, {
               params: componentFolderParams,


### PR DESCRIPTION
## Overview
Migrate all endpoints to `/v1`

## Context
https://linear.app/dittowords/issue/DIT-5338/migrate-cli-to-use-v1-api-endpoints

## Test Plan
1. Create a full config with components and projects
```yaml
sources:
  components:
    folders:
      - id: some-folder
        name: Some Folder
    root: true
  projects:
    - id: xxx-xxx-xxx
      name: Some Project
format: flat
variants: true
```



Test with a bunch of different formats:
- [x] `flat`, `structured`
- [x] `ios-strings`, `ios-stringsdict`
- [x] `android`



Test the project add command (undocumented as of new release since we're going to revamp the way that managing the config file works):
- [x] `yarn project add` and confirm you get a list of projects with dev mode enabled



- [x] Test with just components at the root:
```yaml
sources:
  components:
    root: true
format: flat
variants: true
```