### PR TITLE
[DIT-5321] Support generating ESM JavaScript driver

### DIFF
--- a/lib/utils/determineModuleType.ts
+++ b/lib/utils/determineModuleType.ts
@@ -51,5 +51,5 @@ function getTypeOrDefault(value: string | null): "commonjs" | "module" {
     return valueLower;
   }
 
-  return "module";
+  return "commonjs";
 }

--- a/lib/utils/determineModuleType.ts
+++ b/lib/utils/determineModuleType.ts
@@ -1,0 +1,55 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Looks for a `package.json` file starting in the current working directory and traversing upwards
+ * until it finds one or reaches root.
+ * @returns "commonjs" or "module", defaulting to "module" if no `package.json` is found or if the found
+ * file does not include a `type` property.
+ */
+export function determineModuleType() {
+  const value = getRawTypeFromPackageJson();
+  return getTypeOrDefault(value);
+}
+
+function getRawTypeFromPackageJson() {
+  if (process.env.DITTO_MODULE_TYPE) {
+    return process.env.DITTO_MODULE_TYPE;
+  }
+
+  let currentDir: string | null = process.cwd(); // Get the current working directory
+
+  while (currentDir) {
+    const packageJsonPath = path.join(currentDir, "package.json");
+    if (fs.existsSync(packageJsonPath)) {
+      const packageJsonContents = fs.readFileSync(packageJsonPath, "utf8");
+      try {
+        const packageData: { type?: string } = JSON.parse(packageJsonContents);
+        if (packageData?.type) {
+          return packageData.type;
+        }
+      } catch {}
+
+      return null;
+    }
+
+    if (currentDir === "/") {
+      return null;
+    }
+
+    // Move up a directory and continue the search
+    currentDir = path.dirname(currentDir);
+  }
+
+  // No package.json
+  return null;
+}
+
+function getTypeOrDefault(value: string | null): "commonjs" | "module" {
+  const valueLower = value?.toLowerCase() || "";
+  if (valueLower === "commonjs" || valueLower === "module") {
+    return valueLower;
+  }
+
+  return "module";
+}

--- a/lib/utils/generateJsDriver.ts
+++ b/lib/utils/generateJsDriver.ts
@@ -32,8 +32,8 @@ export function generateJsDriver(sources: Source[]) {
   const variableNameGenerator = createVariableNameGenerator();
   const importStatements: string[] = [];
 
+  const data: DriverFile = {};
   const dataComponents: Record<string, string[]> = {};
-  const dataProjects: DriverFile = {};
 
   fullyQualifiedSources.forEach((source) => {
     let variableName: string;
@@ -55,8 +55,8 @@ export function generateJsDriver(sources: Source[]) {
     if (source.type === "project") {
       const { variantApiId } = source;
       const projectId = stringifySourceId(source.projectId);
-      dataProjects[projectId] ??= {};
-      dataProjects[projectId][variantApiId] = `{...${variableName}}`;
+      data[projectId] ??= {};
+      data[projectId][variantApiId] = `{...${variableName}}`;
     } else {
       dataComponents[source.variantApiId] ??= [];
       dataComponents[source.variantApiId].push(`...${variableName}`);
@@ -67,7 +67,7 @@ export function generateJsDriver(sources: Source[]) {
   // into a unified string, and set it on the final data object
   // that will be written to the driver file
   Object.keys(dataComponents).forEach((key) => {
-    dataProjects.ditto_component_library ??= {};
+    data.ditto_component_library ??= {};
 
     let str = "{";
     dataComponents[key].forEach((k: any, i: any) => {
@@ -75,13 +75,13 @@ export function generateJsDriver(sources: Source[]) {
       if (i < dataComponents[key].length - 1) str += ", ";
     });
     str += "}";
-    dataProjects.ditto_component_library[key] = str;
+    data.ditto_component_library[key] = str;
   });
 
   let dataString = "";
   dataString += importStatements.join("\n") + "\n\n";
   dataString += `${getExportPrefix(moduleType)}`;
-  dataString += `${JSON.stringify(dataProjects, null, 2)}`
+  dataString += `${JSON.stringify(data, null, 2)}`
     // remove quotes around opening & closing curlies
     .replace(/"\{/g, "{")
     .replace(/\}"/g, "}");

--- a/lib/utils/generateJsDriver.ts
+++ b/lib/utils/generateJsDriver.ts
@@ -4,6 +4,7 @@ import consts from "../consts";
 import output from "../output";
 import { Source } from "../types";
 import { cleanFileName } from "./cleanFileName";
+import { determineModuleType } from "./determineModuleType";
 
 // compatability with legacy method of specifying project ids
 // that is still used by the default format
@@ -22,18 +23,59 @@ const stringifySourceId = (projectId: string) =>
  * data from Ditto.
  */
 
-// TODO: support ESM
 export function generateJsDriver(sources: Source[]) {
-  const sourceIdsByName: Record<string, string> = sources.reduce(
-    (agg, source) => {
-      if (source.fileName) {
-        return { ...agg, [cleanFileName(source.fileName)]: source.id };
-      }
+  const moduleType = determineModuleType();
 
-      return agg;
-    },
-    {}
-  );
+  let filePath: string;
+  if (moduleType === "commonjs") {
+    filePath = generateJsDriverCommonJS(sources, moduleType);
+  } else if (moduleType === "module") {
+    filePath = generateJsDriverESM(sources);
+  } else {
+    throw new Error(`Unknown module type: ${moduleType}`);
+  }
+
+  return `Generated .js SDK driver at ${output.info(filePath)}`;
+}
+
+function generateJsDriverCommonJS(
+  sources: Source[],
+  moduleType: "commonjs" | "esm"
+) {
+  const variableNameGenerator = createVariableNameGenerator();
+  const importStatements: string[] = [];
+
+  const sourceInfoByName: Record<
+    string,
+    {
+      projectId: string;
+      variableName: string;
+      importStatement: string;
+      requireStatement: string;
+    }
+  > = {};
+
+  const data2: DriverFile = {};
+
+  sources.forEach((source) => {
+    if (!source.fileName) {
+      return;
+    }
+
+    const fileName = cleanFileName(source.fileName);
+    console.log("source.fileName", source.fileName);
+    const variableName = variableNameGenerator.generate(fileName.split(".")[0]);
+
+    const importStatement = `import ${variableName} from './${source.fileName}';`;
+    const requireStatement = `const ${variableName} = require('./${source.fileName}');`;
+
+    sourceInfoByName[fileName] = {
+      projectId: source.id,
+      variableName,
+      importStatement,
+      requireStatement,
+    };
+  });
 
   const projectFileNames = fs
     .readdirSync(consts.TEXT_DIR)
@@ -47,8 +89,8 @@ export function generateJsDriver(sources: Source[]) {
       const [sourceId, rest] = fileName.split("__");
       const [variantApiId] = rest.split(".");
 
-      const projectId = sourceIdsByName[sourceId];
-      const projectIdStr = stringifySourceId(projectId);
+      const sourceInfo = sourceInfoByName[sourceId];
+      const projectIdStr = stringifySourceId(sourceInfo.projectId);
 
       if (!obj[projectIdStr]) {
         obj[projectIdStr] = {};
@@ -59,6 +101,8 @@ export function generateJsDriver(sources: Source[]) {
     },
     {}
   );
+
+  console.log("data", data);
 
   // Create arrays of stringified "...require()" statements,
   // each of which corresponds to one of the component files
@@ -88,7 +132,24 @@ export function generateJsDriver(sources: Source[]) {
     data.ditto_component_library[key] = str;
   });
 
-  let dataString = `module.exports = ${JSON.stringify(data, null, 2)}`
+  let dataString = "";
+
+  Object.values(sourceInfoByName).forEach((sourceInfo) => {
+    if (moduleType === "commonjs") {
+      dataString += `${sourceInfo.requireStatement}\n`;
+      return;
+    }
+    if (moduleType === "esm") {
+      dataString += `${sourceInfo.importStatement}\n`;
+      return;
+    }
+    throw new Error("Unknown module type: " + moduleType);
+  });
+
+  dataString += "\n";
+  dataString += `${getExportPrefix(moduleType)}
+
+  dataString += ${JSON.stringify(data, null, 2)}`
     // remove quotes around require statements
     .replace(/"require\((.*)\)"/g, "require($1)")
     // remove quotes around opening & closing curlies
@@ -98,5 +159,37 @@ export function generateJsDriver(sources: Source[]) {
   const filePath = path.resolve(consts.TEXT_DIR, "index.js");
   fs.writeFileSync(filePath, dataString, { encoding: "utf8" });
 
-  return `Generated .js SDK driver at ${output.info(filePath)}`;
+  return filePath;
+}
+
+function createVariableNameGenerator() {
+  const variableNames = new Set<string>();
+
+  return {
+    generate: (str: string) => {
+      const baseName = str.replace(/\W/g, "_");
+      let name = baseName;
+      let i = 1;
+      while (variableNames.has(name)) {
+        name = `${baseName}${i}`;
+        i++;
+      }
+      variableNames.add(name);
+      return name;
+    },
+  };
+}
+
+function generateJsDriverESM(sources: Source[]) {
+  return "";
+}
+
+function getExportPrefix(moduleType: "commonjs" | "esm") {
+  if (moduleType === "commonjs") {
+    return "module.exports = ";
+  }
+  if (moduleType === "esm") {
+    return "export default ";
+  }
+  throw new Error("Unknown module type: " + moduleType);
 }

--- a/lib/utils/generateJsDriver.ts
+++ b/lib/utils/generateJsDriver.ts
@@ -107,6 +107,10 @@ type IFullyQualifiedJSONSource =
       fileName: string;
     };
 
+/**
+ * Upstream source data is a mess - this function is an attempt at cleaning it up
+ * so that it can be used in a more straightforward way to generate the driver file.
+ */
 function getFullyQualifiedJSONSources(
   sources: Source[]
 ): IFullyQualifiedJSONSource[] {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "4.0.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
-  "type": "commonjs",
   "main": "bin/index.js",
   "scripts": {
     "prepublishOnly": "ENV=production etsc && sentry-cli sourcemaps inject ./bin && npx sentry-cli sourcemaps upload ./bin --release=\"$(cat package.json | jq -r '.version')\"",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
+  "type": "commonjs",
   "main": "bin/index.js",
   "scripts": {
     "prepublishOnly": "ENV=production etsc && sentry-cli sourcemaps inject ./bin && npx sentry-cli sourcemaps upload ./bin --release=\"$(cat package.json | jq -r '.version')\"",


### PR DESCRIPTION
## Overview
Refactors `generateJsDriver` to depend on the `type` property of the nearest `package.json` file.
- if `type` is `module`, an ESM module is generated
- otherwise, a CommonJS module is generated 

## Context
https://linear.app/dittowords/issue/DIT-5321/make-ditto-react-work-with-default-vite-react-setup
<!--- Any context about why you are creating this PR? Notion doc, screenshot, conversation, etc. --->

## Test Plan
- [ ] Test with https://github.com/dittowords/ditto-react-demo/pull/10 and confirm that the sample project operates normally
