### PR TITLE
[DIT-5333] Emit type declaration for `index.js` driver file

### DIFF
--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -27,6 +27,7 @@ import { AxiosError } from "axios";
 import { fetchComponentFolders } from "./http/fetchComponentFolders";
 import { generateSwiftDriver } from "./utils/generateSwiftDriver";
 import { generateIOSBundles } from "./utils/generateIOSBundles";
+import { JSONFormat } from "./utils/generateJsDriverTypeFile";
 
 interface IRequestOptions {
   projects: Project[];
@@ -56,8 +57,20 @@ const SUPPORTED_FORMATS: SupportedFormat[] = [
   "icu",
 ];
 
+export type JSONFormat = "flat" | "nested" | "structured" | "icu";
+
 const IOS_FORMATS: SupportedFormat[] = ["ios-strings", "ios-stringsdict"];
-const JSON_FORMATS: SupportedFormat[] = ["flat", "structured", "icu"];
+const JSON_FORMATS: JSONFormat[] = ["flat", "structured", "icu"];
+
+const getJsonFormat = (formats: string[]): JSONFormat => {
+  // edge case: multiple json formats specified
+  // we should grab the last one
+  const jsonFormats = formats.filter((f) =>
+    JSON_FORMATS.includes(f as JSONFormat)
+  );
+
+  return jsonFormats[jsonFormats.length - 1] || "flat";
+};
 
 const FORMAT_EXTENSIONS = {
   flat: ".json",
@@ -504,7 +517,7 @@ async function downloadAndSave(
 
     const sources: Source[] = [...validProjects, ...componentSources];
 
-    if (hasJSONFormat) msg += generateJsDriver(sources);
+    if (hasJSONFormat) msg += generateJsDriver(sources, getJsonFormat(formats));
 
     if (shouldGenerateIOSBundles) {
       msg += "iOS locale information detected, generating bundles..\n\n";

--- a/lib/utils/determineModuleType.ts
+++ b/lib/utils/determineModuleType.ts
@@ -1,6 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
 
+export type ModuleType = "commonjs" | "module";
+
 /**
  * Looks for a `package.json` file starting in the current working directory and traversing upwards
  * until it finds one or reaches root.
@@ -45,7 +47,7 @@ function getRawTypeFromPackageJson() {
   return null;
 }
 
-function getTypeOrDefault(value: string | null): "commonjs" | "module" {
+function getTypeOrDefault(value: string | null): ModuleType {
   const valueLower = value?.toLowerCase() || "";
   if (valueLower === "commonjs" || valueLower === "module") {
     return valueLower;

--- a/lib/utils/generateJsDriverTypeFile.ts
+++ b/lib/utils/generateJsDriverTypeFile.ts
@@ -1,0 +1,75 @@
+import fs from "fs";
+import path from "path";
+import { ModuleType } from "./determineModuleType";
+import { JSONFormat } from "../pull";
+import consts from "../consts";
+
+function getFormatString(format: JSONFormat) {
+  switch (format) {
+    case "flat":
+      return "IJSONFlat";
+    case "nested":
+      return "IJSONNested";
+    case "structured":
+      return "IJSONStructured";
+    case "icu":
+      return "IJSONICU";
+    default:
+      return "_JSON";
+  }
+}
+
+function getExportString(exportedValue: string, moduleType: ModuleType) {
+  if (moduleType === "commonjs") {
+    return `export = ${exportedValue};`;
+  }
+
+  return `export default ${exportedValue};`;
+}
+
+function getTypesString(options: IOptions) {
+  return `
+interface IJSONFlat {
+  [key: string]: string;
+}
+
+interface IJSONStructured {
+  [key: string]: {
+    text: string;
+    status?: string;
+    notes?: string;
+    [property: string]: any;
+  };
+}
+
+interface IJSONNested {
+  [key: string]: string | IJSONNested;
+}
+
+type _JSON = IJSONFlat | IJSONStructured | IJSONNested;
+
+interface IDriverFile {
+  [sourceKey: string]: {
+    [variantKey: string]: ${getFormatString(options.format)};
+  };
+}
+
+declare const driver: IDriverFile;
+
+${getExportString("driver", options.moduleType)}
+`.trim();
+}
+
+interface IOptions {
+  format: JSONFormat;
+  moduleType: ModuleType;
+}
+
+export function generateJsDriverTypeFile(options: IOptions) {
+  const typeFileString = getTypesString(options);
+  fs.writeFileSync(
+    path.resolve(consts.TEXT_DIR, "index.d.ts"),
+    typeFileString + "\n",
+    "utf8"
+  );
+}


### PR DESCRIPTION
## Overview
When a JavaScript driver file is generated, generate a basic `index.d.ts` file for TypeScript projects.

## Context
https://linear.app/dittowords/issue/DIT-5333/type-declaration-for-source-when-importing-ditto-json-from-cli

## Test Plan
- [ ] Confirm works with both CommonJS and ESM module formats 
- [ ] Confirm that https://github.com/dittowords/ditto-react-demo/pull/10 now works without compensation for lack of type definitions 
- [ ] Switch between JSON formats and confirm that the type definitions change