### PR TITLE
Add sample-data field to the components-folder command

### DIFF
--- a/lib/component-folders.ts
+++ b/lib/component-folders.ts
@@ -1,7 +1,7 @@
 import { fetchComponentFolders } from "./http/fetchComponentFolders";
 
-async function showComponentFolders() {
-  const folders = await fetchComponentFolders();
+async function showComponentFolders(options: { showSampleData?: boolean }) {
+  const folders = await fetchComponentFolders(options);
 
   console.log(JSON.stringify(folders));
 }

--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -55,7 +55,7 @@ describe("Tokens in config files", () => {
   describe("saveToken", () => {
     it("creates a config file with config data", () => {
       const fileContents = fs.readFileSync(configFile, "utf8");
-      const configData = yaml.load(fileContents);
+      const configData = yaml.load(fileContents) as Record<string, any>;
       if (configData && typeof configData === "object") {
         expect(configData["testing.dittowords.com"]).toBeDefined();
         expect(configData["testing.dittowords.com"][0].token).toEqual(

--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -215,7 +215,6 @@ const executeCommand = async (
       return removeProject();
     }
     case "component-folders": {
-      console.log(options.showSampleData);
       return showComponentFolders({
         showSampleData: options.showSampleData,
       });

--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -74,6 +74,11 @@ const COMMANDS: CommandConfig<Command>[] = [
     name: "component-folders",
     description:
       "List component folders in your workspace. More information about component folders can be found here: https://www.dittowords.com/docs/component-folders.",
+    flags: {
+      "-s, --sample-data": {
+        description: "Includes the sample components folder in the output",
+      },
+    },
   },
   {
     name: "generate-suggestions",
@@ -210,7 +215,10 @@ const executeCommand = async (
       return removeProject();
     }
     case "component-folders": {
-      return showComponentFolders();
+      console.log(options.showSampleData);
+      return showComponentFolders({
+        showSampleData: options.showSampleData,
+      });
     }
     case "generate-suggestions": {
       return generateSuggestions({

--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -216,7 +216,7 @@ const executeCommand = async (
     }
     case "component-folders": {
       return showComponentFolders({
-        showSampleData: options.showSampleData,
+        showSampleData: options.sampleData,
       });
     }
     case "generate-suggestions": {

--- a/lib/generate-suggestions.test.ts
+++ b/lib/generate-suggestions.test.ts
@@ -3,13 +3,13 @@ import path from "path";
 import { findComponentsInJSXFiles } from "./generate-suggestions";
 
 describe("findTextInJSXFiles", () => {
-  async function createTempFile(filename, content) {
+  async function createTempFile(filename: string, content: string) {
     const filePath = path.join(".", filename);
     await fs.writeFile(filePath, content);
     return filePath;
   }
 
-  async function deleteTempFile(filename) {
+  async function deleteTempFile(filename: string) {
     const filePath = path.join(".", filename);
     await fs.unlink(filePath);
   }

--- a/lib/http/fetchComponentFolders.ts
+++ b/lib/http/fetchComponentFolders.ts
@@ -4,13 +4,18 @@ interface FetchComponentFoldersResponse {
   [id: string]: string;
 }
 
-export async function fetchComponentFolders(): Promise<FetchComponentFoldersResponse> {
+export async function fetchComponentFolders(options: {
+  showSampleData?: boolean;
+}): Promise<FetchComponentFoldersResponse> {
   const api = createApiClient();
 
-  const { data } = await api.get<FetchComponentFoldersResponse>(
-    "/v1/component-folders",
-    {}
-  );
+  let url = "/v1/component-folders";
+
+  if (options.showSampleData === true) {
+    url += "?showSampleData=true";
+  }
+
+  const { data } = await api.get<FetchComponentFoldersResponse>(url, {});
 
   return data;
 }

--- a/lib/init/token.test.ts
+++ b/lib/init/token.test.ts
@@ -9,7 +9,7 @@ describe("needsToken()", () => {
   });
 
   describe("with a config file", () => {
-    let configFile;
+    let configFile = "";
 
     beforeEach(() => {
       configFile = tempy.writeSync("");

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -324,7 +324,7 @@ async function downloadAndSave(
 
   const [variants, allComponentFoldersResponse] = await Promise.all([
     fetchVariants(source),
-    fetchComponentFolders(),
+    fetchComponentFolders({}),
   ]);
 
   const allComponentFolders = Object.entries(

--- a/lib/replace.ts
+++ b/lib/replace.ts
@@ -66,6 +66,7 @@ async function replaceJSXTextInFile(
   /* @ts-ignore */
   const { code: transformedCode } = transformFromAst(ast, code, {
     // Don't let this codebase's Babel config affect the code we're transforming.
+    /* @ts-ignore */
     configFile: false,
   });
   fs.writeFile(filePath, transformedCode);

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "prepublishOnly": "ENV=production etsc && sentry-cli sourcemaps inject ./bin && npx sentry-cli sourcemaps upload ./bin --release=\"$(cat package.json | jq -r '.version')\"",
     "prepare": "husky install",
-    "start": "etsc && node bin/ditto.js",
-    "sync": "etsc && node bin/ditto.js pull",
-    "dev": "etsc --watch"
+    "start": "tsc --noEmit --excludeFiles './**/*.test.ts' && etsc && node bin/ditto.js",
+    "sync": "tsc --noEmit --excludeFiles './**/*.test.ts' && etsc && node bin/ditto.js pull",
+    "dev": "tsc --noEmit --excludeFiles './**/*.test.ts' && etsc --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
   "main": "bin/index.js",


### PR DESCRIPTION
## Overview
Adds a flag to return sample data for the components-folder command.

## Test Plan

Testing successfully completed in <env> via:

- [ ] `yarn start components-folder` returns components folder without sample-components
- [ ] `yarn start components-folder --sample-data` returns components folder with sample-components
