### PR TITLE
Only run init() on commands that need it

### DIFF
--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -152,7 +152,7 @@ const setupCommands = () => {
           } else {
             cmd.option(flags, description);
           }
-        }
+        },
       );
     }
 
@@ -177,16 +177,25 @@ const setupCommands = () => {
 const setupOptions = () => {
   program.option(
     "-m, --meta <data...>",
-    "Include arbitrary data in requests to the Ditto API. Ex: -m githubActionRequest:true trigger:manual"
+    "Include arbitrary data in requests to the Ditto API. Ex: -m githubActionRequest:true trigger:manual",
   );
   program.version(VERSION, "-v, --version", "Output the current version");
 };
 
 const executeCommand = async (
   command: Command | "none",
-  options: any
+  options: any,
 ): Promise<void> => {
-  const needsInitialization = needsTokenOrSource();
+  const configFileReliantCommands = [
+    "pull",
+    "none",
+    "project",
+    "project add",
+    "project remove",
+  ];
+  const needsInitialization =
+    needsTokenOrSource() && configFileReliantCommands.includes(command);
+
   if (needsInitialization) {
     try {
       await init();

--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -32,6 +32,14 @@ function getVersion(): string {
 
 const VERSION = getVersion();
 
+const CONFIG_FILE_RELIANT_COMMANDS = [
+  "pull",
+  "none",
+  "project",
+  "project add",
+  "project remove",
+];
+
 type Command =
   | "pull"
   | "project"
@@ -186,15 +194,8 @@ const executeCommand = async (
   command: Command | "none",
   options: any,
 ): Promise<void> => {
-  const configFileReliantCommands = [
-    "pull",
-    "none",
-    "project",
-    "project add",
-    "project remove",
-  ];
   const needsInitialization =
-    configFileReliantCommands.includes(command) && needsTokenOrSource();
+    CONFIG_FILE_RELIANT_COMMANDS.includes(command) && needsTokenOrSource();
 
   if (needsInitialization) {
     try {

--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -194,7 +194,7 @@ const executeCommand = async (
     "project remove",
   ];
   const needsInitialization =
-    needsTokenOrSource() && configFileReliantCommands.includes(command);
+    configFileReliantCommands.includes(command) && needsTokenOrSource();
 
   if (needsInitialization) {
     try {

--- a/lib/generate-suggestions.ts
+++ b/lib/generate-suggestions.ts
@@ -27,7 +27,9 @@ async function generateSuggestions(flags: {
   componentFolder?: string;
 }) {
   const components = await fetchComponents({
-     ...(flags.componentFolder ? { componentFolder: flags.componentFolder} : {})
+    ...(flags.componentFolder
+      ? { componentFolder: flags.componentFolder }
+      : {}),
   });
   const directory = flags.directory || ".";
 
@@ -66,7 +68,7 @@ async function findComponentsInJSXFiles(params: {
         traverse(ast, {
           JSXText(path) {
             for (const [compApiId, component] of Object.entries(
-              params.components
+              params.components,
             )) {
               // If we haven't seen this component before, add it to the result
               if (!result[compApiId]) {
@@ -77,11 +79,16 @@ async function findComponentsInJSXFiles(params: {
                 };
               }
 
-              if (path.node.value.includes(component.text)) {
+              if (
+                // Skip white space lines
+                !/^\s*$/.test(path.node.value) &&
+                !/^\s*$/.test(component.text) &&
+                path.node.value.includes(component.text)
+              ) {
                 // Escape all special characters from the text so we can use it in a regex
                 const escapedText = component.text.replace(
                   /[.*+?^${}()|[\]\\]/g,
-                  "\\$&"
+                  "\\$&",
                 );
                 const regex = new RegExp(escapedText, "g");
                 let match;
@@ -103,7 +110,7 @@ async function findComponentsInJSXFiles(params: {
                     line,
                     match.index,
                     component.text,
-                    `${component.text}`
+                    `${component.text}`,
                   );
 
                   // Initialize the occurrences array if it doesn't exist
@@ -125,7 +132,7 @@ async function findComponentsInJSXFiles(params: {
             }
           },
         });
-      })
+      }),
     );
   }
 
@@ -138,7 +145,7 @@ function replaceAt(
   str: string,
   index: number,
   searchString: string,
-  replacement: string
+  replacement: string,
 ) {
   return (
     str.substring(0, index) +

--- a/lib/http/fetchComponents.ts
+++ b/lib/http/fetchComponents.ts
@@ -32,7 +32,7 @@ export async function fetchComponents(options: {
     }
   } else {
     const { data } = await api.get<FetchComponentResponse>(
-      "/v1/components",
+      "/v1/components?format=structured",
       {}
     );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
   "main": "bin/index.js",


### PR DESCRIPTION
## Overview
This PR makes a change to take into account what command is being run before deciding to run init() or not.

Also includes two minor improvements:
- Explicitly use `structured` format when querying for components
- Ignore white space only lines of code and components when generating suggestions

## Context
The Ditto VSCode extension runs commands such as `generate-suggestions`, `component-folders`, and `replace`. These commands don't rely on local data (it calls the Ditto API) and thus doesn't require a `config.yml` to be present. Because of this, it is unnecessary to run init() when these commands are called.

## Test Plan

Testing successfully completed in <env> via:

- [x] Delete `ditto` directory
- [x] Run `yarn start generate-suggestions`, verify that the `ditto` directory isn't created
- [x] Run `yarn start pull`, verify that the `ditto` directory is created
- [x] Update `testfiles/test1.jsx` to include text for a component in your workspace. Verify `yarn start generate-suggestions` results in a suggestion for that text
