### PR TITLE
DIT-5759: component folder dev IDs properly exclude emojis

### DIFF
--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -436,7 +436,10 @@ async function downloadAndSave(
 
             const nameExt = getFormatExtension(format);
             const nameBase = "components";
-            const nameFolder = `__${componentFolder.name}`;
+
+            // we need to clean the folder name by itself first, otherwise we can
+            // end up with "empty" words and weird hyphenation.
+            const nameFolder = `__${cleanFileName(componentFolder.name)}`;
             const namePostfix = `__${variantApiId || "base"}`;
 
             const fileName = cleanFileName(

--- a/lib/utils/cleanFileName.test.ts
+++ b/lib/utils/cleanFileName.test.ts
@@ -1,0 +1,11 @@
+import { cleanFileName } from "./cleanFileName";
+
+describe("cleanFileName tests", () => {
+  it("correctly cleans emojis", () => {
+    const folderName = "👍Good Folder";
+    expect(cleanFileName(folderName)).toEqual("good-folder");
+
+    const fileName = "👍 Good Folder";
+    expect(cleanFileName(fileName)).toEqual("good-folder");
+  });
+});

--- a/lib/utils/cleanFileName.ts
+++ b/lib/utils/cleanFileName.ts
@@ -1,6 +1,8 @@
 export function cleanFileName(fileName: string): string {
-  return fileName
-    .replace(/\s{1,}/g, "-")
-    .replace(/[^a-zA-Z0-9-_.]/g, "")
-    .toLowerCase();
+  let parts = fileName.split(/\s{1,}/g);
+  parts = parts.map((part) =>
+    part.replace(/[^a-zA-Z0-9-_.]/g, "").toLowerCase()
+  );
+  parts = parts.filter((part) => part !== "");
+  return parts.join("-");
 }


### PR DESCRIPTION
## Overview

<!--- What does this PR do? --->
This PR refines the logic to create .js filenames; we make sure emojis don't turn into weird hyphens.

## Context

<!--- Any context about why you are creating this PR? Notion doc, screenshot, conversation, etc. --->
[DIT-5759 : Component Folder Dev IDs do not handle emojis well](https://linear.app/dittowords/issue/DIT-5759/component-folder-dev-ids-do-not-handle-emojis-well)

## Screenshots

<!--- Include some screenshots of any visual changes you made to make it easier for the reviewer to understand what changes were made --->
![image](https://github.com/dittowords/cli/assets/25183392/8ad5e7d5-34ae-480d-a017-0396fad0d2c7)

![image](https://github.com/dittowords/cli/assets/25183392/11259889-667a-4226-bb60-f3340cafeca7)

## Test Plan

Testing successfully completed in <env> via:

- [ ] yarn test
