### PR TITLE
Fix: Support for Nested JSON Format

### DIFF
--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -17,6 +17,7 @@ import {
   Token,
   Project,
   SupportedFormat,
+  SupportedExtension,
   ComponentFolder,
   ComponentSource,
   Source,
@@ -49,6 +50,7 @@ export const writeFile = (path: string, data: string) =>
 
 const SUPPORTED_FORMATS: SupportedFormat[] = [
   "flat",
+  "nested",
   "structured",
   "android",
   "ios-strings",
@@ -59,7 +61,7 @@ const SUPPORTED_FORMATS: SupportedFormat[] = [
 export type JSONFormat = "flat" | "nested" | "structured" | "icu";
 
 const IOS_FORMATS: SupportedFormat[] = ["ios-strings", "ios-stringsdict"];
-const JSON_FORMATS: JSONFormat[] = ["flat", "structured", "icu"];
+const JSON_FORMATS: JSONFormat[] = ["flat", "nested", "structured", "icu"];
 
 const getJsonFormat = (formats: string[]): JSONFormat => {
   // edge case: multiple json formats specified
@@ -71,8 +73,9 @@ const getJsonFormat = (formats: string[]): JSONFormat => {
   return jsonFormats[jsonFormats.length - 1] || "flat";
 };
 
-const FORMAT_EXTENSIONS = {
+const FORMAT_EXTENSIONS: Record<SupportedFormat, SupportedExtension> = {
   flat: ".json",
+  nested: ".json",
   structured: ".json",
   android: ".xml",
   "ios-strings": ".strings",
@@ -93,6 +96,7 @@ const getJsonFormatIsValid = (data: string) => {
 // exported for test usage only
 export const getFormatDataIsValid = {
   flat: getJsonFormatIsValid,
+  nested: getJsonFormatIsValid,
   structured: getJsonFormatIsValid,
   icu: getJsonFormatIsValid,
   android: (data: string) => data.includes("<string"),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,11 +23,14 @@ export interface ComponentFolder {
 
 export type SupportedFormat =
   | "flat"
+  | "nested"
   | "structured"
   | "android"
   | "ios-strings"
   | "ios-stringsdict"
   | "icu";
+
+export type SupportedExtension = ".json" | ".xml" | ".strings" | ".stringsdict";
 
 type ComponentsSourceBool = boolean;
 type ComponentsSourceConfig = {


### PR DESCRIPTION
## Overview

When the `nested` format is specified in the configuration file, instead of processing the files in the expected nested format, the CLI tool silently defaults to the `flat` format. This behavior contradicts the documented capabilities of the tool and can lead to confusion for users relying on the nested format.

In this pull request, I have implemented changes to ensure that the @dittowords/cli tool correctly processes and outputs files in the "nested" JSON format when it is specified. 

This pull request contains a fix to align the tool's behavior with the documented features and expected functionality by adding `nested` value to all necessary constants.

Additionally, this pull request introduces two minor enhancements:
- adding of a new type named `SupportedExtension`, mirroring the existing `SupportedFormat`
- refactoring of the `downloadAndSaveBase` test to minimize code duplication

## Context

The official developers documentation for the [DittoWords API](https://developer.dittowords.com/api-reference/components/fetch-component-text) and [CLI tool](https://developer.dittowords.com/cli-reference/configuration#format) clearly states support for various file formats, including `nested` JSON. However, the current behavior of the CLI tool does not align with these documented capabilities.

## Test Plan

Testing successfully completed in via:

- [x] create a group of components using the Ditto web interface:
    <img width="944" alt="image" src="https://github.com/dittowords/cli/assets/11535067/56f24d3d-b3f5-4a54-aa9c-278e0aec8a27">

- [x] set up a `ditto` folder and a `config.yml` file with the following configuration:
    ```yml
    sources:
      components: true
    variants: true
    format: nested # selected format
    ```
- [x] run `yarn start -- pull` to fetch the data
- [x] verify that the nested structure is correctly preserved in the output JSON file
    <img width="708" alt="image" src="https://github.com/dittowords/cli/assets/11535067/5aee64e3-1b67-4e32-b306-b4b23d638414">
