### PR TITLE
[DIT-6177] Add pull --sample-data flag for variants

### DIFF
--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -63,6 +63,11 @@ const COMMANDS: CommandConfig<Command>[] = [
   {
     name: "pull",
     description: "Sync copy from Ditto into the current working directory",
+    flags: {
+      "--sample-data": {
+        description: "Include sample data. Currently only supports variants.",
+      },
+    },
   },
   {
     name: "project",
@@ -210,7 +215,10 @@ const executeCommand = async (
   switch (command) {
     case "none":
     case "pull": {
-      return pull({ meta: processMetaOption(meta) });
+      return pull({
+        meta: processMetaOption(meta),
+        includeSampleData: options.sampleData || false,
+      });
     }
     case "project":
     case "project add": {

--- a/lib/http/fetchVariants.ts
+++ b/lib/http/fetchVariants.ts
@@ -15,7 +15,7 @@ export async function fetchVariants(
   const { shouldFetchComponentLibrary, validProjects } = source;
 
   const config: AxiosRequestConfig = {
-    params: { ...options?.meta },
+    params: { ...options?.meta, showSampleData: options.includeSampleData },
   };
 
   // if we're not syncing from the component library, then we pass the project ids

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -583,7 +583,7 @@ export interface PullOptions {
 
 export const pull = async (options?: PullOptions) => {
   const meta = options ? options.meta : {};
-  const includeSampleData = options ? options.includeSampleData : false;
+  const includeSampleData = options?.includeSampleData || false
   const token = config.getToken(consts.CONFIG_FILE, consts.API_HOST);
   const sourceInformation = config.parseSourceInformation();
 

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -327,7 +327,7 @@ async function downloadAndSave(
   spinner.start();
 
   const [variants, allComponentFoldersResponse] = await Promise.all([
-    fetchVariants(source),
+    fetchVariants(source, options),
     fetchComponentFolders({}),
   ]);
 
@@ -578,15 +578,20 @@ async function downloadAndSave(
 
 export interface PullOptions {
   meta?: Record<string, string>;
+  includeSampleData?: boolean;
 }
 
 export const pull = async (options?: PullOptions) => {
   const meta = options ? options.meta : {};
+  const includeSampleData = options ? options.includeSampleData : false;
   const token = config.getToken(consts.CONFIG_FILE, consts.API_HOST);
   const sourceInformation = config.parseSourceInformation();
 
   try {
-    return await downloadAndSave(sourceInformation, token, { meta });
+    return await downloadAndSave(sourceInformation, token, {
+      meta,
+      includeSampleData,
+    });
   } catch (e) {
     const eventId = Sentry.captureException(e);
     const eventStr = `\n\nError ID: ${output.info(eventId)}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
   "main": "bin/index.js",


### PR DESCRIPTION
## Overview
This PR adds the `--sample-data` flag to the `pull` command and is intended to allow support for sample data to be included in the `pull` execution. With this PR, only variants will be supported.

## Test Plan

Testing successfully completed in <env> via:

- [ ] Run `yarn pull --sample-data` and verify sample variant data is included
