### PR TITLE
[DIT-6187] Test coverage improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ testing/tmp
 ditto
 bin/
 .env
+coverage

--- a/lib/__mocks__/api.ts
+++ b/lib/__mocks__/api.ts
@@ -1,0 +1,12 @@
+import axios from "axios";
+import { jest } from "@jest/globals";
+
+jest.mock("axios");
+
+// by returning the mocked module directly, we can mock responses in tests
+// like `axios.get.mockResolvedValue()`; otherwise, we'd be unable to mock
+// responses because `createApiClient` would be returning an axios instance
+// unaffected by mocks applied to the `axios` module itself.
+export function createApiClient(_token?: string) {
+  return axios;
+}

--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -1,20 +1,22 @@
 import { homedir } from "os";
 import path from "path";
 
-export const API_HOST =
-  process.env.DITTO_API_HOST || "https://api.dittowords.com";
-export const CONFIG_FILE =
-  process.env.DITTO_CONFIG_FILE || path.join(homedir(), ".config", "ditto");
-export const PROJECT_CONFIG_FILE = path.normalize(
-  path.join("ditto", "config.yml")
-);
-export const TEXT_DIR = process.env.DITTO_TEXT_DIR || "ditto";
-export const TEXT_FILE = path.normalize(path.join(TEXT_DIR, "text.json"));
-
-export default {
-  API_HOST,
-  CONFIG_FILE,
-  PROJECT_CONFIG_FILE,
-  TEXT_DIR,
-  TEXT_FILE,
-};
+export default new (class {
+  get API_HOST() {
+    return process.env.DITTO_API_HOST || "https://api.dittowords.com";
+  }
+  get CONFIG_FILE() {
+    return (
+      process.env.DITTO_CONFIG_FILE || path.join(homedir(), ".config", "ditto")
+    );
+  }
+  get PROJECT_CONFIG_FILE() {
+    return path.normalize(path.join("ditto", "config.yml"));
+  }
+  get TEXT_DIR() {
+    return process.env.DITTO_TEXT_DIR || "ditto";
+  }
+  get TEXT_FILE() {
+    return path.normalize(path.join(this.TEXT_DIR, "text.json"));
+  }
+})();

--- a/lib/http/__mocks__/fetchComponentFolders.ts
+++ b/lib/http/__mocks__/fetchComponentFolders.ts
@@ -1,18 +1,23 @@
 import type { FetchComponentFoldersResponse } from "../fetchComponentFolders";
 
+export const MOCK_COMPONENT_FOLDERS: FetchComponentFoldersResponse = {
+  example_folder: "Example Folder",
+};
+
+export const MOCK_COMPONENT_FOLDERS_WITH_SAMPLE_DATA: FetchComponentFoldersResponse =
+  {
+    example_folder: "Example Folder",
+    example_folder_sample: "Sample Example Folder",
+  };
+
 export async function fetchComponentFolders(
   _options: {
     showSampleData?: boolean;
   } = {}
 ): Promise<FetchComponentFoldersResponse> {
   if (_options.showSampleData) {
-    return {
-      example_folder: "Example Folder",
-      example_folder_sample: "Sample Example Folder",
-    };
+    return MOCK_COMPONENT_FOLDERS_WITH_SAMPLE_DATA;
   }
 
-  return {
-    example_folder: "Example Folder",
-  };
+  return MOCK_COMPONENT_FOLDERS;
 }

--- a/lib/http/__mocks__/fetchComponentFolders.ts
+++ b/lib/http/__mocks__/fetchComponentFolders.ts
@@ -1,0 +1,18 @@
+import type { FetchComponentFoldersResponse } from "../fetchComponentFolders";
+
+export async function fetchComponentFolders(
+  _options: {
+    showSampleData?: boolean;
+  } = {}
+): Promise<FetchComponentFoldersResponse> {
+  if (_options.showSampleData) {
+    return {
+      example_folder: "Example Folder",
+      example_folder_sample: "Sample Example Folder",
+    };
+  }
+
+  return {
+    example_folder: "Example Folder",
+  };
+}

--- a/lib/http/__mocks__/fetchComponents.ts
+++ b/lib/http/__mocks__/fetchComponents.ts
@@ -1,0 +1,22 @@
+import { FetchComponentResponse } from "../fetchComponents";
+
+export async function fetchComponents(
+  _options: {
+    componentFolder?: string;
+  } = {}
+): Promise<FetchComponentResponse> {
+  return {
+    "component-1": {
+      name: "Example Component 1",
+      text: "This is example component text.",
+      status: "NONE",
+      folder: null,
+    },
+    "component-2": {
+      name: "Example Component 2",
+      text: "This is example component text.",
+      status: "NONE",
+      folder: null,
+    },
+  };
+}

--- a/lib/http/__mocks__/fetchComponents.ts
+++ b/lib/http/__mocks__/fetchComponents.ts
@@ -1,22 +1,24 @@
 import { FetchComponentResponse } from "../fetchComponents";
 
+export const MOCK_COMPONENTS_RESPONSE: FetchComponentResponse = {
+  "component-1": {
+    name: "Example Component 1",
+    text: "This is example component text.",
+    status: "NONE",
+    folder: null,
+  },
+  "component-2": {
+    name: "Example Component 2",
+    text: "This is example component text.",
+    status: "NONE",
+    folder: null,
+  },
+};
+
 export async function fetchComponents(
   _options: {
     componentFolder?: string;
   } = {}
 ): Promise<FetchComponentResponse> {
-  return {
-    "component-1": {
-      name: "Example Component 1",
-      text: "This is example component text.",
-      status: "NONE",
-      folder: null,
-    },
-    "component-2": {
-      name: "Example Component 2",
-      text: "This is example component text.",
-      status: "NONE",
-      folder: null,
-    },
-  };
+  return MOCK_COMPONENTS_RESPONSE;
 }

--- a/lib/http/__mocks__/fetchVariants.ts
+++ b/lib/http/__mocks__/fetchVariants.ts
@@ -1,0 +1,19 @@
+import { IVariant } from "../fetchVariants";
+
+export async function fetchVariants(
+  source: any,
+  options: any = {}
+): Promise<IVariant[] | null> {
+  return [
+    {
+      name: "Example Variant 1",
+      description: "This is example variant 1.",
+      apiID: "example-variant-1",
+    },
+    {
+      name: "Example Variant 2",
+      description: "This is example variant 2.",
+      apiID: "example-variant-2",
+    },
+  ];
+}

--- a/lib/http/__mocks__/fetchVariants.ts
+++ b/lib/http/__mocks__/fetchVariants.ts
@@ -1,19 +1,21 @@
 import { IVariant } from "../fetchVariants";
 
+export const MOCK_VARIANTS_RESPONSE: IVariant[] = [
+  {
+    name: "Example Variant 1",
+    description: "This is example variant 1.",
+    apiID: "example-variant-1",
+  },
+  {
+    name: "Example Variant 2",
+    description: "This is example variant 2.",
+    apiID: "example-variant-2",
+  },
+];
+
 export async function fetchVariants(
-  source: any,
-  options: any = {}
+  _source: any,
+  _options: any = {}
 ): Promise<IVariant[] | null> {
-  return [
-    {
-      name: "Example Variant 1",
-      description: "This is example variant 1.",
-      apiID: "example-variant-1",
-    },
-    {
-      name: "Example Variant 2",
-      description: "This is example variant 2.",
-      apiID: "example-variant-2",
-    },
-  ];
+  return MOCK_VARIANTS_RESPONSE;
 }

--- a/lib/http/fetchComponentFolders.ts
+++ b/lib/http/fetchComponentFolders.ts
@@ -1,6 +1,6 @@
 import { createApiClient } from "../api";
 
-interface FetchComponentFoldersResponse {
+export interface FetchComponentFoldersResponse {
   [id: string]: string;
 }
 

--- a/lib/http/fetchComponentFolders.ts
+++ b/lib/http/fetchComponentFolders.ts
@@ -4,9 +4,11 @@ interface FetchComponentFoldersResponse {
   [id: string]: string;
 }
 
-export async function fetchComponentFolders(options: {
-  showSampleData?: boolean;
-}): Promise<FetchComponentFoldersResponse> {
+export async function fetchComponentFolders(
+  options: {
+    showSampleData?: boolean;
+  } = {}
+): Promise<FetchComponentFoldersResponse> {
   const api = createApiClient();
 
   let url = "/v1/component-folders";

--- a/lib/http/fetchComponents.ts
+++ b/lib/http/fetchComponents.ts
@@ -11,9 +11,11 @@ export interface FetchComponentResponse {
   [compApiId: string]: FetchComponentResponseComponent;
 }
 
-export async function fetchComponents(options: {
-  componentFolder?: string;
-}): Promise<FetchComponentResponse> {
+export async function fetchComponents(
+  options: {
+    componentFolder?: string;
+  } = {}
+): Promise<FetchComponentResponse> {
   const api = createApiClient();
 
   if (options.componentFolder) {

--- a/lib/http/fetchVariants.ts
+++ b/lib/http/fetchVariants.ts
@@ -3,10 +3,21 @@ import { createApiClient } from "../api";
 import { PullOptions } from "../pull";
 import { SourceInformation } from "../types";
 
+interface IVariant {
+  name: string;
+  description: string;
+  apiID: string;
+}
+
+type SourceArg = Pick<
+  SourceInformation,
+  "shouldFetchComponentLibrary" | "validProjects" | "variants"
+>;
+
 export async function fetchVariants(
-  source: SourceInformation,
+  source: SourceArg,
   options: PullOptions = {}
-) {
+): Promise<IVariant[] | null> {
   const api = createApiClient();
   if (!source.variants) {
     return null;
@@ -25,7 +36,7 @@ export async function fetchVariants(
     config.params.projectIds = validProjects.map(({ id }) => id);
   }
 
-  const { data } = await api.get<{ apiID: string }[]>("/v1/variants", config);
+  const { data } = await api.get<IVariant[]>("/v1/variants", config);
 
   return data;
 }

--- a/lib/http/fetchVariants.ts
+++ b/lib/http/fetchVariants.ts
@@ -3,7 +3,7 @@ import { createApiClient } from "../api";
 import { PullOptions } from "../pull";
 import { SourceInformation } from "../types";
 
-interface IVariant {
+export interface IVariant {
   name: string;
   description: string;
   apiID: string;

--- a/lib/http/http.test.ts
+++ b/lib/http/http.test.ts
@@ -1,0 +1,122 @@
+import { fetchComponentFolders } from "./fetchComponentFolders";
+import { fetchComponents } from "./fetchComponents";
+import { fetchVariants } from "./fetchVariants";
+import { importComponents } from "./importComponents";
+import { jest } from "@jest/globals";
+import axios from "axios";
+import { vol } from "memfs";
+
+jest.mock("../api");
+jest.mock("fs");
+
+const axiosMocked = jest.mocked(axios);
+
+describe("fetchComponentFolders", () => {
+  it("fetches component folders without error", async () => {
+    axiosMocked.get.mockResolvedValueOnce({
+      data: { "folder-id": "folder-name" },
+    });
+    const result = await fetchComponentFolders();
+    expect(result["folder-id"]).toBe("folder-name");
+  });
+  it("supports showSampleData option", async () => {
+    axiosMocked.get.mockResolvedValueOnce({
+      data: { "folder-id": "folder-name" },
+    });
+    const result = await fetchComponentFolders({ showSampleData: true });
+    expect(result["folder-id"]).toBe("folder-name");
+  });
+});
+
+describe("fetchComponents", () => {
+  it("fetches components without error", async () => {
+    axiosMocked.get.mockResolvedValueOnce({
+      data: {
+        "component-id": {
+          name: "component-name",
+          text: "component-text",
+          status: "NONE",
+          folder: null,
+        },
+      },
+    });
+    const result = await fetchComponents();
+    expect(result["component-id"]).toBeDefined();
+    expect(result["component-id"].name).toBe("component-name");
+    expect(result["component-id"].text).toBe("component-text");
+  });
+});
+
+describe("fetchVariants", () => {
+  it("fetches variants without error", async () => {
+    axiosMocked.get.mockResolvedValueOnce({
+      data: [
+        {
+          name: "variant-name",
+          description: "variant-description",
+          apiID: "variant-api-id",
+        },
+      ],
+    });
+    const result = await fetchVariants({
+      shouldFetchComponentLibrary: true,
+      validProjects: [],
+      variants: true,
+    });
+    expect(result).toBeTruthy();
+    expect(result![0]).toBeDefined();
+    expect(result![0].name).toBe("variant-name");
+    expect(result![0].description).toBe("variant-description");
+    expect(result![0].apiID).toBe("variant-api-id");
+  });
+  it("returns null if `variants` isn't in config", async () => {
+    const result = await fetchVariants({
+      shouldFetchComponentLibrary: true,
+      validProjects: [],
+      variants: false,
+    });
+    expect(result).toBe(null);
+  });
+});
+
+describe("importComponents", () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+  it("imports components from existing file without error", async () => {
+    vol.fromJSON({
+      "/file.csv": "id,name,text\n1,one1,not empty\n2,two1,empty",
+    });
+
+    axiosMocked.mockResolvedValueOnce({
+      data: {
+        componentsInserted: 2,
+        firstImportedId: "1",
+      },
+    });
+
+    const result = await importComponents("/file.csv", {
+      csvColumnMapping: {
+        name: "name",
+        text: 2,
+        componentId: 0,
+      },
+    });
+
+    expect(result.componentsInserted).toBe(2);
+    expect(result.firstImportedId).toBe("1");
+  });
+
+  it("returns null firstImportedId if file doesn't exist", async () => {
+    const result = await importComponents("/file.csv", {
+      csvColumnMapping: {
+        name: "name",
+        text: 2,
+        componentId: 0,
+      },
+    });
+
+    expect(result.componentsInserted).toBe(0);
+    expect(result.firstImportedId).toBe("null");
+  });
+});

--- a/lib/http/importComponents.ts
+++ b/lib/http/importComponents.ts
@@ -24,6 +24,14 @@ export async function importComponents(
 ): Promise<ImportComponentResponse> {
   const api = createApiClient();
 
+  if (!fs.existsSync(path)) {
+    console.error("Failed to import file: couldn't find file at path " + path);
+    return {
+      componentsInserted: 0,
+      firstImportedId: "null",
+    };
+  }
+
   const form = new FormData();
   form.append("import", fs.createReadStream(path));
 

--- a/lib/init/token.ts
+++ b/lib/init/token.ts
@@ -9,6 +9,7 @@ import consts from "../consts";
 import output from "../output";
 import config from "../config";
 import { quit } from "../utils/quit";
+import { AxiosError, AxiosResponse } from "axios";
 
 export const needsToken = (configFile?: string, host = consts.API_HOST) => {
   if (config.getTokenFromEnv()) {
@@ -26,40 +27,74 @@ export const needsToken = (configFile?: string, host = consts.API_HOST) => {
   return false;
 };
 
-// Returns true if valid, otherwise an error message.
-async function checkToken(token: string): Promise<any> {
+async function verifyTokenUsingTokenCheck(
+  token: string
+): Promise<{ success: true } | { success: false; output: string[] }> {
   const axios = createApiClient(token);
   const endpoint = "/token-check";
 
-  let resOrError;
+  let resOrError: AxiosResponse<any> | undefined;
   try {
-    resOrError = await axios.get(endpoint).catch((error: any) => {
-      if (error.code === "ENOTFOUND") {
-        return output.errorText(
-          `Can't connect to API: ${output.url(error.hostname)}`
-        );
-      }
-      if (error.response.status === 401 || error.response.status === 404) {
-        return output.errorText(
-          "This API key isn't valid. Please try another."
-        );
-      }
-      return output.warnText("We're having trouble reaching the Ditto API.");
-    });
+    resOrError = await axios.get(endpoint);
   } catch (e: unknown) {
-    output.errorText(e as any);
-    output.errorText("Sorry! We're having trouble reaching the Ditto API.");
+    console.log(e);
+    if (!(e instanceof AxiosError)) {
+      return {
+        success: false,
+        output: [
+          output.warnText(
+            "Sorry! We're having trouble reaching the Ditto API."
+          ),
+        ],
+      };
+    }
+
+    if (e.code === "ENOTFOUND") {
+      return {
+        success: false,
+        output: [
+          output.errorText(
+            `Can't connect to API: ${output.url(consts.API_HOST)}`
+          ),
+        ],
+      };
+    }
+
+    if (e.response?.status === 401 || e.response?.status === 404) {
+      return {
+        success: false,
+        output: [
+          output.errorText("This API key isn't valid. Please try another."),
+        ],
+      };
+    }
   }
 
   if (typeof resOrError === "string") {
-    return resOrError;
+    return {
+      success: false,
+      output: [resOrError],
+    };
   }
 
   if (resOrError?.status === 200) {
-    return true;
+    return { success: true };
   }
 
-  return output.errorText("This API key isn't valid. Please try another.");
+  return {
+    success: false,
+    output: [output.errorText("This API key isn't valid. Please try another.")],
+  };
+}
+
+// Returns true if valid, otherwise an error message.
+async function checkToken(token: string): Promise<any> {
+  const result = await verifyTokenUsingTokenCheck(token);
+  if (!result.success) {
+    return result.output.join("\n");
+  }
+
+  return true;
 }
 
 async function collectToken(message: string | null) {
@@ -105,3 +140,5 @@ export const collectAndSaveToken = async (message: string | null = null) => {
 };
 
 export default { needsToken, collectAndSaveToken };
+
+export const _test = { verifyTokenUsingTokenCheck };

--- a/lib/pull-lib.test.ts
+++ b/lib/pull-lib.test.ts
@@ -1,0 +1,367 @@
+import fs from "fs";
+import path from "path";
+import { _test } from "./pull";
+import { jest } from "@jest/globals";
+import axios from "axios";
+const axiosMock = jest.mocked(axios);
+
+jest.mock("fs");
+jest.mock("./api");
+
+const testProjects: Project[] = [
+  {
+    id: "1",
+    name: "Project 1",
+    fileName: "Project 1",
+  },
+  { id: "2", name: "Project 2", fileName: "Project 2" },
+];
+
+jest.mock("./consts", () => ({
+  TEXT_DIR: "/.testing",
+  API_HOST: "https://api.dittowords.com",
+  CONFIG_FILE: "/.testing/ditto",
+  PROJECT_CONFIG_FILE: "/.testing/config.yml",
+  TEXT_FILE: "/.testing/text.json",
+}));
+
+import consts from "./consts";
+import allPull, { getFormatDataIsValid } from "./pull";
+import { Project, SupportedExtension, SupportedFormat } from "./types";
+
+const {
+  _testing: { cleanOutputFiles, downloadAndSaveBase },
+} = allPull;
+
+const cleanOutputDir = () => {
+  if (fs.existsSync(consts.TEXT_DIR))
+    fs.rmSync(consts.TEXT_DIR, { recursive: true, force: true });
+
+  fs.mkdirSync(consts.TEXT_DIR);
+};
+
+afterAll(() => {
+  fs.rmSync(consts.TEXT_DIR, { force: true, recursive: true });
+});
+
+describe("cleanOutputFiles", () => {
+  it("removes .js, .json, .xml, .strings, .stringsdict files", () => {
+    cleanOutputDir();
+
+    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.json"), "test");
+    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.js"), "test");
+    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.xml"), "test");
+    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.strings"), "test");
+    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.stringsdict"), "test");
+    // this file shouldn't be deleted
+    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.txt"), "test");
+
+    expect(fs.readdirSync(consts.TEXT_DIR).length).toEqual(6);
+
+    cleanOutputFiles();
+
+    expect(fs.readdirSync(consts.TEXT_DIR).length).toEqual(1);
+  });
+});
+
+describe("downloadAndSaveBase", () => {
+  beforeAll(() => {
+    if (!fs.existsSync(consts.TEXT_DIR)) {
+      fs.mkdirSync(consts.TEXT_DIR);
+    }
+  });
+
+  beforeEach(() => {
+    cleanOutputDir();
+  });
+
+  const mockDataFlat = { hello: "world" };
+  const mockDataNested = { hello: { text: "world" } };
+  const mockDataStructured = { hello: { text: "world" } };
+  const mockDataIcu = { hello: "world" };
+  const mockDataAndroid = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+          <string name="hello-world" ditto_api_id="hello-world">Hello World</string>
+      </resources>
+    `;
+  const mockDataIosStrings = `
+      "hello" = "world"; 
+    `;
+  const mockDataIosStringsDict = `
+      <?xml version="1.0" encoding="utf-8"?>
+      <plist version="1.0">
+          <dict>
+              <key>hello-world</key>
+              <dict>
+                  <key>NSStringLocalizedFormatKey</key>
+                  <string>%1$#@count@</string>
+                  <key>count</key>
+                  <dict>
+                      <key>NSStringFormatSpecTypeKey</key>
+                      <string>NSStringPluralRuleType</string>
+                      <key>NSStringFormatValueTypeKey</key>
+                      <string>d</string>
+                      <key>other</key>
+                      <string>espanol</string>
+                  </dict>
+              </dict>
+          </dict>
+      </plist>
+    `;
+
+  const formats: Array<{
+    format: SupportedFormat;
+    data: Object;
+    ext: SupportedExtension;
+  }> = [
+    { format: "flat", data: mockDataFlat, ext: ".json" },
+    { format: "nested", data: mockDataNested, ext: ".json" },
+    { format: "structured", data: mockDataStructured, ext: ".json" },
+    { format: "icu", data: mockDataIcu, ext: ".json" },
+    { format: "android", data: mockDataAndroid, ext: ".xml" },
+    { format: "ios-strings", data: mockDataIosStrings, ext: ".strings" },
+    {
+      format: "ios-stringsdict",
+      data: mockDataIosStringsDict,
+      ext: ".stringsdict",
+    },
+  ];
+
+  const mockApiCall = (data: unknown) => {
+    axiosMock.get.mockResolvedValue({ data });
+  };
+
+  const verifySavedData = async (
+    format: SupportedFormat,
+    data: unknown,
+    ext: SupportedExtension
+  ) => {
+    const output = await downloadAndSaveBase({
+      projects: testProjects,
+      format: format,
+    } as any);
+    expect(/successfully saved/i.test(output)).toEqual(true);
+    const directoryContents = fs.readdirSync(consts.TEXT_DIR);
+    expect(directoryContents.length).toEqual(testProjects.length);
+    expect(directoryContents.every((f) => f.endsWith(ext))).toBe(true);
+    const fileDataString = fs.readFileSync(
+      path.resolve(consts.TEXT_DIR, directoryContents[0]),
+      "utf8"
+    );
+
+    switch (format) {
+      case "android":
+      case "ios-strings":
+      case "ios-stringsdict":
+        expect(typeof data).toBe("string");
+        expect(fileDataString.replace(/\s/g, "")).toEqual(
+          (data as string).replace(/\s/g, "")
+        );
+        break;
+
+      case "flat":
+      case "nested":
+      case "structured":
+      case "icu":
+      default:
+        expect(JSON.parse(fileDataString)).toEqual(data);
+        break;
+    }
+  };
+
+  formats.forEach(({ format, data, ext }) => {
+    it(`writes the ${format} format to disk`, async () => {
+      mockApiCall(data);
+      await verifySavedData(format, data, ext);
+    });
+  });
+});
+
+describe("getFormatDataIsValid", () => {
+  it("handles flat format appropriately", () => {
+    expect(getFormatDataIsValid.flat("{}")).toBe(false);
+    expect(getFormatDataIsValid.flat(`{ "hello": "world" }`)).toBe(true);
+    expect(
+      getFormatDataIsValid.flat(`{
+      "__variant-name": "English",
+      "__variant-description": ""
+    }`)
+    ).toBe(false);
+    expect(
+      getFormatDataIsValid.flat(`{
+      "__variant-name": "English",
+      "__variant-description": "",
+      "hello": "world"
+    }`)
+    ).toBe(true);
+  });
+  it("handles structured format appropriately", () => {
+    expect(getFormatDataIsValid.structured("{}")).toBe(false);
+    expect(
+      getFormatDataIsValid.structured(`{ "hello": { "text": "world" } }`)
+    ).toBe(true);
+    expect(
+      getFormatDataIsValid.structured(`{
+      "__variant-name": "English",
+      "__variant-description": ""
+    }`)
+    ).toBe(false);
+    expect(
+      getFormatDataIsValid.structured(`{
+      "__variant-name": "English",
+      "__variant-description": "",
+      "hello": { "text": "world" }
+    }`)
+    ).toBe(true);
+  });
+  it("handles icu format appropriately", () => {
+    expect(getFormatDataIsValid.icu("{}")).toBe(false);
+    expect(getFormatDataIsValid.icu(`{ "hello": "world" }`)).toBe(true);
+    expect(
+      getFormatDataIsValid.icu(`{
+      "__variant-name": "English",
+      "__variant-description": ""
+    }`)
+    ).toBe(false);
+    expect(
+      getFormatDataIsValid.icu(`{
+      "__variant-name": "English",
+      "__variant-description": "",
+      "hello": "world"
+    }`)
+    ).toBe(true);
+  });
+  it("handles android format appropriately", () => {
+    expect(
+      getFormatDataIsValid.android(`
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"/>
+    `)
+    ).toBe(false);
+    expect(
+      getFormatDataIsValid.android(`
+      <?xml version="1.0" encoding="utf-8"?>
+      <!--Variant Name: English-->
+      <!--Variant Description: -->
+      <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"/>
+    `)
+    ).toBe(false);
+    expect(
+      getFormatDataIsValid.android(`
+      <?xml version="1.0" encoding="utf-8"?>
+      <!--Variant Name: English-->
+      <!--Variant Description: -->
+      <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+          <string name="hello-world" ditto_api_id="hello-world">Hello World</string>
+      </resources>
+    `)
+    ).toBe(true);
+  });
+  it("handles ios-strings format appropriately", () => {
+    expect(getFormatDataIsValid["ios-strings"]("")).toBe(false);
+    expect(
+      getFormatDataIsValid["ios-strings"](`
+        /* Variant Name: English */
+        /* Variant Description: */
+      `)
+    ).toBe(false);
+    expect(
+      getFormatDataIsValid["ios-strings"](`
+        /* Variant Name: English */
+        /* Variant Description: */
+        "Hello" = "World";
+      `)
+    ).toBe(true);
+  });
+  it("handles ios-stringsdict format appropriately", () => {
+    expect(
+      getFormatDataIsValid["ios-stringsdict"](`
+        <?xml version="1.0" encoding="utf-8"?>
+        <plist version="1.0">
+            <dict/>
+        </plist>
+      `)
+    ).toBe(false);
+    expect(
+      getFormatDataIsValid["ios-stringsdict"](`
+        <?xml version="1.0" encoding="utf-8"?>
+        <!--Variant Name: English-->
+        <!--Variant Description: -->
+        <plist version="1.0">
+            <dict/>
+        </plist>
+      `)
+    ).toBe(false);
+    expect(
+      getFormatDataIsValid["ios-stringsdict"](`
+        <?xml version="1.0" encoding="utf-8"?>
+        <!--Variant Name: English-->
+        <!--Variant Description: -->
+        <plist version="1.0">
+            <dict>
+              <key>Hello World</key>
+              <dict>
+                  <key>NSStringLocalizedFormatKey</key>
+                  <string>%1$#@count@</string>
+                  <key>count</key>
+                  <dict>
+                      <key>NSStringFormatSpecTypeKey</key>
+                      <string>NSStringPluralRuleType</string>
+                      <key>NSStringFormatValueTypeKey</key>
+                      <string>d</string>
+                      <key>other</key>
+                      <string>espanol</string>
+                  </dict>
+              </dict>
+            </dict>
+        </plist>
+      `)
+    ).toBe(true);
+  });
+});
+
+const { getJsonFormat } = _test;
+describe("getJsonFormat", () => {
+  it("returns 'flat' if no format specified", () => {
+    expect(getJsonFormat([])).toBe("flat");
+  });
+  it("returns 'flat' if invalid format specified", () => {
+    expect(getJsonFormat(["invalid-format"])).toBe("flat");
+  });
+  it("returns valid specified formats", () => {
+    expect(getJsonFormat(["structured"])).toBe("structured");
+    expect(getJsonFormat(["nested"])).toBe("nested");
+    expect(getJsonFormat(["icu"])).toBe("icu");
+    expect(getJsonFormat(["flat"])).toBe("flat");
+  });
+  it("returns last of formats if multiple specified", () => {
+    expect(getJsonFormat(["flat", "structured", "icu"])).toBe("icu");
+    expect(getJsonFormat(["flat", "icu", "structured"])).toBe("structured");
+  });
+});
+
+const { getJsonFormatIsValid } = _test;
+describe("getJsonFormatIsValid", () => {
+  it("returns true for valid json", () => {
+    expect(getJsonFormatIsValid(`{ "key": "value" }`)).toBe(true);
+    expect(getJsonFormatIsValid(`{ "key": { "text": "value" }}`)).toBe(true);
+    expect(getJsonFormatIsValid(`{ "nested": { "key": "value" }}`)).toBe(true);
+  });
+  it("returns false for empty json", () => {
+    expect(getJsonFormatIsValid(`{}`)).toBe(false);
+  });
+  it("returns false for invalid json", () => {
+    expect(getJsonFormatIsValid(`abcdefg`)).toBe(false);
+  });
+});
+
+const { ensureEndsWithNewLine } = _test;
+describe("ensureEndsWithNewLine", () => {
+  it("adds a newline to the end of a string if it doesn't already have one", () => {
+    expect(ensureEndsWithNewLine("hello")).toBe("hello\n");
+  });
+  it("doesn't add a newline to the end of a string if it already has one", () => {
+    expect(ensureEndsWithNewLine("hello\n")).toBe("hello\n");
+  });
+});

--- a/lib/pull.test.ts
+++ b/lib/pull.test.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { _test } from "./pull";
 
 jest.mock("./api", () => ({
   createApiClient: jest.fn(), // this needs to be mocked in each test that requires it
@@ -328,5 +329,50 @@ describe("getFormatDataIsValid", () => {
         </plist>
       `)
     ).toBe(true);
+  });
+});
+
+const { getJsonFormat } = _test;
+describe("getJsonFormat", () => {
+  it("returns 'flat' if no format specified", () => {
+    expect(getJsonFormat([])).toBe("flat");
+  });
+  it("returns 'flat' if invalid format specified", () => {
+    expect(getJsonFormat(["invalid-format"])).toBe("flat");
+  });
+  it("returns valid specified formats", () => {
+    expect(getJsonFormat(["structured"])).toBe("structured");
+    expect(getJsonFormat(["nested"])).toBe("nested");
+    expect(getJsonFormat(["icu"])).toBe("icu");
+    expect(getJsonFormat(["flat"])).toBe("flat");
+  });
+  it("returns last of formats if multiple specified", () => {
+    expect(getJsonFormat(["flat", "structured", "icu"])).toBe("icu");
+    expect(getJsonFormat(["flat", "icu", "structured"])).toBe("structured");
+  });
+});
+
+const { getJsonFormatIsValid } = _test;
+describe("getJsonFormatIsValid", () => {
+  it("returns true for valid json", () => {
+    expect(getJsonFormatIsValid(`{ "key": "value" }`)).toBe(true);
+    expect(getJsonFormatIsValid(`{ "key": { "text": "value" }}`)).toBe(true);
+    expect(getJsonFormatIsValid(`{ "nested": { "key": "value" }}`)).toBe(true);
+  });
+  it("returns false for empty json", () => {
+    expect(getJsonFormatIsValid(`{}`)).toBe(false);
+  });
+  it("returns false for invalid json", () => {
+    expect(getJsonFormatIsValid(`abcdefg`)).toBe(false);
+  });
+});
+
+const { ensureEndsWithNewLine } = _test;
+describe("ensureEndsWithNewLine", () => {
+  it("adds a newline to the end of a string if it doesn't already have one", () => {
+    expect(ensureEndsWithNewLine("hello")).toBe("hello\n");
+  });
+  it("doesn't add a newline to the end of a string if it already has one", () => {
+    expect(ensureEndsWithNewLine("hello\n")).toBe("hello\n");
   });
 });

--- a/lib/pull.test.ts
+++ b/lib/pull.test.ts
@@ -1,14 +1,12 @@
 import fs from "fs";
 import path from "path";
-import { _test } from "./pull";
-
-jest.mock("./api", () => ({
-  createApiClient: jest.fn(), // this needs to be mocked in each test that requires it
-}));
+import { pull, _test } from "./pull";
+import { jest } from "@jest/globals";
+import axios from "axios";
+const axiosMock = jest.mocked(axios);
 
 jest.mock("fs");
-
-import { createApiClient } from "./api";
+jest.mock("./api");
 
 const testProjects: Project[] = [
   {
@@ -18,13 +16,6 @@ const testProjects: Project[] = [
   },
   { id: "2", name: "Project 2", fileName: "Project 2" },
 ];
-
-// TODO: all tests in this file currently failing because we're re-instantiating the api client
-// everywhere and are unable to mock the return type separately for each instance of usage.
-// We need to refactor to share one api client everywhere instead of always re-creating it.
-const mockApi = createApiClient() as any as jest.Mocked<
-  ReturnType<typeof createApiClient>
->;
 
 jest.mock("./consts", () => ({
   TEXT_DIR: "/.testing",
@@ -138,9 +129,7 @@ describe("downloadAndSaveBase", () => {
   ];
 
   const mockApiCall = (data: unknown) => {
-    (createApiClient as any).mockImplementation(() => ({
-      get: () => ({ data }),
-    }));
+    axiosMock.get.mockResolvedValue({ data });
   };
 
   const verifySavedData = async (
@@ -376,3 +365,7 @@ describe("ensureEndsWithNewLine", () => {
     expect(ensureEndsWithNewLine("hello\n")).toBe("hello\n");
   });
 });
+
+// describe("pull", () => {
+//   //
+// });

--- a/lib/pull.test.ts
+++ b/lib/pull.test.ts
@@ -1,371 +1,77 @@
-import fs from "fs";
-import path from "path";
-import { pull, _test } from "./pull";
+import { pull } from "./pull";
+import { vol } from "memfs";
+import consts from "./consts";
 import { jest } from "@jest/globals";
 import axios from "axios";
 const axiosMock = jest.mocked(axios);
+import fs from "fs";
 
 jest.mock("fs");
 jest.mock("./api");
 
-const testProjects: Project[] = [
-  {
-    id: "1",
-    name: "Project 1",
-    fileName: "Project 1",
-  },
-  { id: "2", name: "Project 2", fileName: "Project 2" },
-];
+jest.mock("./http/fetchComponentFolders");
+jest.mock("./http/fetchComponents");
+jest.mock("./http/fetchVariants");
 
-jest.mock("./consts", () => ({
-  TEXT_DIR: "/.testing",
-  API_HOST: "https://api.dittowords.com",
-  CONFIG_FILE: "/.testing/ditto",
-  PROJECT_CONFIG_FILE: "/.testing/config.yml",
-  TEXT_FILE: "/.testing/text.json",
-}));
+const defaultEnv = { ...process.env };
 
-import consts from "./consts";
-import allPull, { getFormatDataIsValid } from "./pull";
-import { Project, SupportedExtension, SupportedFormat } from "./types";
-
-const {
-  _testing: { cleanOutputFiles, downloadAndSaveBase },
-} = allPull;
-
-const cleanOutputDir = () => {
-  if (fs.existsSync(consts.TEXT_DIR))
-    fs.rmSync(consts.TEXT_DIR, { recursive: true, force: true });
-
-  fs.mkdirSync(consts.TEXT_DIR);
-};
-
-afterAll(() => {
-  fs.rmSync(consts.TEXT_DIR, { force: true, recursive: true });
+beforeEach(() => {
+  vol.reset();
+  process.env = { ...defaultEnv };
 });
 
-describe("cleanOutputFiles", () => {
-  it("removes .js, .json, .xml, .strings, .stringsdict files", () => {
-    cleanOutputDir();
+const mockGlobalConfigFile = `
+api.dittowords.com:
+  - token: xxx-xxx-xxx
+`;
+const mockProjectConfigFile = `
+sources:
+  components: true
+  projects:
+    - id: project-id-1
+      name: Test Project
+variants: true
+`;
 
-    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.json"), "test");
-    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.js"), "test");
-    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.xml"), "test");
-    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.strings"), "test");
-    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.stringsdict"), "test");
-    // this file shouldn't be deleted
-    fs.writeFileSync(path.resolve(consts.TEXT_DIR, "test.txt"), "test");
+describe("pull", () => {
+  it("correctly writes files to disk per source for basic config", async () => {
+    process.env.DITTO_TEXT_DIR = "/ditto";
+    process.env.DITTO_PROJECT_CONFIG_FILE = "/ditto/config.yml";
 
-    expect(fs.readdirSync(consts.TEXT_DIR).length).toEqual(6);
-
-    cleanOutputFiles();
-
-    expect(fs.readdirSync(consts.TEXT_DIR).length).toEqual(1);
-  });
-});
-
-describe("downloadAndSaveBase", () => {
-  beforeAll(() => {
-    if (!fs.existsSync(consts.TEXT_DIR)) {
-      fs.mkdirSync(consts.TEXT_DIR);
-    }
-  });
-
-  beforeEach(() => {
-    cleanOutputDir();
-  });
-
-  const mockDataFlat = { hello: "world" };
-  const mockDataNested = { hello: { text: "world" } };
-  const mockDataStructured = { hello: { text: "world" } };
-  const mockDataIcu = { hello: "world" };
-  const mockDataAndroid = `
-      <?xml version="1.0" encoding="utf-8"?>
-      <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-          <string name="hello-world" ditto_api_id="hello-world">Hello World</string>
-      </resources>
-    `;
-  const mockDataIosStrings = `
-      "hello" = "world"; 
-    `;
-  const mockDataIosStringsDict = `
-      <?xml version="1.0" encoding="utf-8"?>
-      <plist version="1.0">
-          <dict>
-              <key>hello-world</key>
-              <dict>
-                  <key>NSStringLocalizedFormatKey</key>
-                  <string>%1$#@count@</string>
-                  <key>count</key>
-                  <dict>
-                      <key>NSStringFormatSpecTypeKey</key>
-                      <string>NSStringPluralRuleType</string>
-                      <key>NSStringFormatValueTypeKey</key>
-                      <string>d</string>
-                      <key>other</key>
-                      <string>espanol</string>
-                  </dict>
-              </dict>
-          </dict>
-      </plist>
-    `;
-
-  const formats: Array<{
-    format: SupportedFormat;
-    data: Object;
-    ext: SupportedExtension;
-  }> = [
-    { format: "flat", data: mockDataFlat, ext: ".json" },
-    { format: "nested", data: mockDataNested, ext: ".json" },
-    { format: "structured", data: mockDataStructured, ext: ".json" },
-    { format: "icu", data: mockDataIcu, ext: ".json" },
-    { format: "android", data: mockDataAndroid, ext: ".xml" },
-    { format: "ios-strings", data: mockDataIosStrings, ext: ".strings" },
-    {
-      format: "ios-stringsdict",
-      data: mockDataIosStringsDict,
-      ext: ".stringsdict",
-    },
-  ];
-
-  const mockApiCall = (data: unknown) => {
-    axiosMock.get.mockResolvedValue({ data });
-  };
-
-  const verifySavedData = async (
-    format: SupportedFormat,
-    data: unknown,
-    ext: SupportedExtension
-  ) => {
-    const output = await downloadAndSaveBase({
-      projects: testProjects,
-      format: format,
-    } as any);
-    expect(/successfully saved/i.test(output)).toEqual(true);
-    const directoryContents = fs.readdirSync(consts.TEXT_DIR);
-    expect(directoryContents.length).toEqual(testProjects.length);
-    expect(directoryContents.every((f) => f.endsWith(ext))).toBe(true);
-    const fileDataString = fs.readFileSync(
-      path.resolve(consts.TEXT_DIR, directoryContents[0]),
-      "utf8"
+    // we need to manually mock responses for the http calls that happen
+    // directly within the pull function; we don't need to mock the http
+    // calls that happen by way of http/* function calls since those have
+    // their own mocks already.
+    axiosMock.get.mockImplementation(
+      (): Promise<any> => Promise.resolve({ data: "data" })
     );
 
-    switch (format) {
-      case "android":
-      case "ios-strings":
-      case "ios-stringsdict":
-        expect(typeof data).toBe("string");
-        expect(fileDataString.replace(/\s/g, "")).toEqual(
-          (data as string).replace(/\s/g, "")
-        );
-        break;
-
-      case "flat":
-      case "nested":
-      case "structured":
-      case "icu":
-      default:
-        expect(JSON.parse(fileDataString)).toEqual(data);
-        break;
-    }
-  };
-
-  formats.forEach(({ format, data, ext }) => {
-    it(`writes the ${format} format to disk`, async () => {
-      mockApiCall(data);
-      await verifySavedData(format, data, ext);
+    vol.fromJSON({
+      [consts.CONFIG_FILE]: mockGlobalConfigFile,
+      [consts.PROJECT_CONFIG_FILE]: mockProjectConfigFile,
     });
+
+    await pull();
+
+    const filesOnDiskExpected = new Set([
+      "components__example-folder__base.json",
+      "components__example-folder__example-variant-1.json",
+      "components__example-folder__example-variant-2.json",
+      "components__root__base.json",
+      "components__root__example-variant-1.json",
+      "components__root__example-variant-2.json",
+      "test-project__base.json",
+      "test-project__example-variant-1.json",
+      "test-project__example-variant-2.json",
+      "index.d.ts",
+      "index.js",
+    ]);
+
+    const filesOnDisk = fs.readdirSync("/ditto");
+    filesOnDisk.forEach((file) => {
+      filesOnDiskExpected.delete(file);
+    });
+
+    expect(filesOnDiskExpected.size).toBe(0);
   });
 });
-
-describe("getFormatDataIsValid", () => {
-  it("handles flat format appropriately", () => {
-    expect(getFormatDataIsValid.flat("{}")).toBe(false);
-    expect(getFormatDataIsValid.flat(`{ "hello": "world" }`)).toBe(true);
-    expect(
-      getFormatDataIsValid.flat(`{
-      "__variant-name": "English",
-      "__variant-description": ""
-    }`)
-    ).toBe(false);
-    expect(
-      getFormatDataIsValid.flat(`{
-      "__variant-name": "English",
-      "__variant-description": "",
-      "hello": "world"
-    }`)
-    ).toBe(true);
-  });
-  it("handles structured format appropriately", () => {
-    expect(getFormatDataIsValid.structured("{}")).toBe(false);
-    expect(
-      getFormatDataIsValid.structured(`{ "hello": { "text": "world" } }`)
-    ).toBe(true);
-    expect(
-      getFormatDataIsValid.structured(`{
-      "__variant-name": "English",
-      "__variant-description": ""
-    }`)
-    ).toBe(false);
-    expect(
-      getFormatDataIsValid.structured(`{
-      "__variant-name": "English",
-      "__variant-description": "",
-      "hello": { "text": "world" }
-    }`)
-    ).toBe(true);
-  });
-  it("handles icu format appropriately", () => {
-    expect(getFormatDataIsValid.icu("{}")).toBe(false);
-    expect(getFormatDataIsValid.icu(`{ "hello": "world" }`)).toBe(true);
-    expect(
-      getFormatDataIsValid.icu(`{
-      "__variant-name": "English",
-      "__variant-description": ""
-    }`)
-    ).toBe(false);
-    expect(
-      getFormatDataIsValid.icu(`{
-      "__variant-name": "English",
-      "__variant-description": "",
-      "hello": "world"
-    }`)
-    ).toBe(true);
-  });
-  it("handles android format appropriately", () => {
-    expect(
-      getFormatDataIsValid.android(`
-      <?xml version="1.0" encoding="utf-8"?>
-      <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"/>
-    `)
-    ).toBe(false);
-    expect(
-      getFormatDataIsValid.android(`
-      <?xml version="1.0" encoding="utf-8"?>
-      <!--Variant Name: English-->
-      <!--Variant Description: -->
-      <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2"/>
-    `)
-    ).toBe(false);
-    expect(
-      getFormatDataIsValid.android(`
-      <?xml version="1.0" encoding="utf-8"?>
-      <!--Variant Name: English-->
-      <!--Variant Description: -->
-      <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-          <string name="hello-world" ditto_api_id="hello-world">Hello World</string>
-      </resources>
-    `)
-    ).toBe(true);
-  });
-  it("handles ios-strings format appropriately", () => {
-    expect(getFormatDataIsValid["ios-strings"]("")).toBe(false);
-    expect(
-      getFormatDataIsValid["ios-strings"](`
-        /* Variant Name: English */
-        /* Variant Description: */
-      `)
-    ).toBe(false);
-    expect(
-      getFormatDataIsValid["ios-strings"](`
-        /* Variant Name: English */
-        /* Variant Description: */
-        "Hello" = "World";
-      `)
-    ).toBe(true);
-  });
-  it("handles ios-stringsdict format appropriately", () => {
-    expect(
-      getFormatDataIsValid["ios-stringsdict"](`
-        <?xml version="1.0" encoding="utf-8"?>
-        <plist version="1.0">
-            <dict/>
-        </plist>
-      `)
-    ).toBe(false);
-    expect(
-      getFormatDataIsValid["ios-stringsdict"](`
-        <?xml version="1.0" encoding="utf-8"?>
-        <!--Variant Name: English-->
-        <!--Variant Description: -->
-        <plist version="1.0">
-            <dict/>
-        </plist>
-      `)
-    ).toBe(false);
-    expect(
-      getFormatDataIsValid["ios-stringsdict"](`
-        <?xml version="1.0" encoding="utf-8"?>
-        <!--Variant Name: English-->
-        <!--Variant Description: -->
-        <plist version="1.0">
-            <dict>
-              <key>Hello World</key>
-              <dict>
-                  <key>NSStringLocalizedFormatKey</key>
-                  <string>%1$#@count@</string>
-                  <key>count</key>
-                  <dict>
-                      <key>NSStringFormatSpecTypeKey</key>
-                      <string>NSStringPluralRuleType</string>
-                      <key>NSStringFormatValueTypeKey</key>
-                      <string>d</string>
-                      <key>other</key>
-                      <string>espanol</string>
-                  </dict>
-              </dict>
-            </dict>
-        </plist>
-      `)
-    ).toBe(true);
-  });
-});
-
-const { getJsonFormat } = _test;
-describe("getJsonFormat", () => {
-  it("returns 'flat' if no format specified", () => {
-    expect(getJsonFormat([])).toBe("flat");
-  });
-  it("returns 'flat' if invalid format specified", () => {
-    expect(getJsonFormat(["invalid-format"])).toBe("flat");
-  });
-  it("returns valid specified formats", () => {
-    expect(getJsonFormat(["structured"])).toBe("structured");
-    expect(getJsonFormat(["nested"])).toBe("nested");
-    expect(getJsonFormat(["icu"])).toBe("icu");
-    expect(getJsonFormat(["flat"])).toBe("flat");
-  });
-  it("returns last of formats if multiple specified", () => {
-    expect(getJsonFormat(["flat", "structured", "icu"])).toBe("icu");
-    expect(getJsonFormat(["flat", "icu", "structured"])).toBe("structured");
-  });
-});
-
-const { getJsonFormatIsValid } = _test;
-describe("getJsonFormatIsValid", () => {
-  it("returns true for valid json", () => {
-    expect(getJsonFormatIsValid(`{ "key": "value" }`)).toBe(true);
-    expect(getJsonFormatIsValid(`{ "key": { "text": "value" }}`)).toBe(true);
-    expect(getJsonFormatIsValid(`{ "nested": { "key": "value" }}`)).toBe(true);
-  });
-  it("returns false for empty json", () => {
-    expect(getJsonFormatIsValid(`{}`)).toBe(false);
-  });
-  it("returns false for invalid json", () => {
-    expect(getJsonFormatIsValid(`abcdefg`)).toBe(false);
-  });
-});
-
-const { ensureEndsWithNewLine } = _test;
-describe("ensureEndsWithNewLine", () => {
-  it("adds a newline to the end of a string if it doesn't already have one", () => {
-    expect(ensureEndsWithNewLine("hello")).toBe("hello\n");
-  });
-  it("doesn't add a newline to the end of a string if it already has one", () => {
-    expect(ensureEndsWithNewLine("hello\n")).toBe("hello\n");
-  });
-});
-
-// describe("pull", () => {
-//   //
-// });

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -583,7 +583,7 @@ export interface PullOptions {
 
 export const pull = async (options?: PullOptions) => {
   const meta = options ? options.meta : {};
-  const includeSampleData = options?.includeSampleData || false
+  const includeSampleData = options?.includeSampleData || false;
   const token = config.getToken(consts.CONFIG_FILE, consts.API_HOST);
   const sourceInformation = config.parseSourceInformation();
 
@@ -619,4 +619,10 @@ export default {
     downloadAndSaveVariants,
     downloadAndSaveBase,
   },
+};
+
+export const _test = {
+  getJsonFormat,
+  getJsonFormatIsValid,
+  ensureEndsWithNewLine,
 };

--- a/lib/utils/determineModuleType.test.ts
+++ b/lib/utils/determineModuleType.test.ts
@@ -1,0 +1,48 @@
+import { determineModuleType } from "./determineModuleType";
+import { vol } from "memfs";
+
+const defaultEnv = process.env;
+
+jest.mock("fs");
+
+beforeEach(() => {
+  vol.reset();
+  process.env = { ...defaultEnv };
+});
+
+test("'commonjs' if no package.json found", () => {
+  expect(determineModuleType()).toBe("commonjs");
+});
+
+test("'commonjs' if package.json found but no `type` property", () => {
+  vol.fromJSON({ "package.json": JSON.stringify({}) }, process.cwd());
+  expect(determineModuleType()).toBe("commonjs");
+});
+
+test("'commonjs' if package.json found and `type` property is 'commonjs'", () => {
+  vol.fromJSON({ "package.json": JSON.stringify({ type: "commonjs" }) });
+  expect(determineModuleType()).toBe("commonjs");
+});
+
+test("'commonjs' if package.json found and `type` property is invalid", () => {
+  vol.fromJSON({ "package.json": JSON.stringify({ type: "invalid-type" }) });
+  expect(determineModuleType()).toBe("commonjs");
+});
+
+test("'module' if package.json found and `type` property is 'module'", () => {
+  vol.fromJSON({ "package.json": JSON.stringify({ type: "module" }) });
+  expect(determineModuleType()).toBe("module");
+});
+
+test("finds package.json in parent directories", () => {
+  vol.fromJSON({
+    "/some/nested/dir/test.txt": "",
+    "/package.json": JSON.stringify({ type: "module" }),
+  });
+  expect(determineModuleType("/some/nested/dir")).toBe("module");
+});
+
+test("supports explicit specification of module type via environment variable", () => {
+  process.env.DITTO_MODULE_TYPE = "module";
+  expect(determineModuleType()).toBe("module");
+});

--- a/lib/utils/determineModuleType.ts
+++ b/lib/utils/determineModuleType.ts
@@ -9,17 +9,15 @@ export type ModuleType = "commonjs" | "module";
  * @returns "commonjs" or "module", defaulting to "module" if no `package.json` is found or if the found
  * file does not include a `type` property.
  */
-export function determineModuleType() {
-  const value = getRawTypeFromPackageJson();
+export function determineModuleType(currentDir: string | null = process.cwd()) {
+  const value = getRawTypeFromPackageJson(currentDir);
   return getTypeOrDefault(value);
 }
 
-function getRawTypeFromPackageJson() {
+function getRawTypeFromPackageJson(currentDir: string | null) {
   if (process.env.DITTO_MODULE_TYPE) {
     return process.env.DITTO_MODULE_TYPE;
   }
-
-  let currentDir: string | null = process.cwd(); // Get the current working directory
 
   while (currentDir) {
     const packageJsonPath = path.join(currentDir, "package.json");
@@ -36,7 +34,7 @@ function getRawTypeFromPackageJson() {
     }
 
     if (currentDir === "/") {
-      return null;
+      break;
     }
 
     // Move up a directory and continue the search

--- a/lib/utils/getSelectedProjects.ts
+++ b/lib/utils/getSelectedProjects.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import yaml, { YAMLException } from "js-yaml";
 
-import { PROJECT_CONFIG_FILE } from "../consts";
+import consts from "../consts";
 import { ConfigYAML, Project } from "../types";
 import Config, { DEFAULT_CONFIG_JSON } from "../config";
 
@@ -29,8 +29,8 @@ function yamlToJson(_yaml: string): ConfigYAML | null {
  * Returns an array containing all valid projects ({ id, name })
  * currently contained in the project config file.
  */
-export const getSelectedProjects = (configFile = PROJECT_CONFIG_FILE) =>
+export const getSelectedProjects = (configFile = consts.PROJECT_CONFIG_FILE) =>
   Config.parseSourceInformation(configFile).validProjects;
 
-export const getIsUsingComponents = (configFile = PROJECT_CONFIG_FILE) =>
+export const getIsUsingComponents = (configFile = consts.PROJECT_CONFIG_FILE) =>
   Config.parseSourceInformation(configFile).shouldFetchComponentLibrary;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.18.6",
+    "@jest/globals": "^29.7.0",
     "@sentry/cli": "^2.20.5",
     "@tsconfig/node16": "^1.0.3",
     "@types/jest": "^26.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1291,12 +1291,29 @@
     "@types/node" "*"
     jest-mock "^29.3.1"
 
+"@jest/environment@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.7.0.tgz#24d61f54ff1f786f3cd4073b4b94416383baf2a7"
+  integrity sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==
+  dependencies:
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    jest-mock "^29.7.0"
+
 "@jest/expect-utils@^29.3.1":
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.3.1.tgz#531f737039e9b9e27c42449798acb5bba01935b6"
   integrity sha512-wlrznINZI5sMjwvUoLVk617ll/UYfGIZNxmbU+Pa7wmkL4vYzhV9R2pwVqUh4NWWuLQWkI8+8mOkxs//prKQ3g==
   dependencies:
     jest-get-type "^29.2.0"
+
+"@jest/expect-utils@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz#023efe5d26a8a70f21677d0a1afc0f0a44e3a1c6"
+  integrity sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==
+  dependencies:
+    jest-get-type "^29.6.3"
 
 "@jest/expect@^29.3.1":
   version "29.3.1"
@@ -1305,6 +1322,14 @@
   dependencies:
     expect "^29.3.1"
     jest-snapshot "^29.3.1"
+
+"@jest/expect@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.7.0.tgz#76a3edb0cb753b70dfbfe23283510d3d45432bf2"
+  integrity sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==
+  dependencies:
+    expect "^29.7.0"
+    jest-snapshot "^29.7.0"
 
 "@jest/fake-timers@^29.3.1":
   version "29.3.1"
@@ -1318,6 +1343,18 @@
     jest-mock "^29.3.1"
     jest-util "^29.3.1"
 
+"@jest/fake-timers@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.7.0.tgz#fd91bf1fffb16d7d0d24a426ab1a47a49881a565"
+  integrity sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@sinonjs/fake-timers" "^10.0.2"
+    "@types/node" "*"
+    jest-message-util "^29.7.0"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
+
 "@jest/globals@^29.3.1":
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.3.1.tgz#92be078228e82d629df40c3656d45328f134a0c6"
@@ -1327,6 +1364,16 @@
     "@jest/expect" "^29.3.1"
     "@jest/types" "^29.3.1"
     jest-mock "^29.3.1"
+
+"@jest/globals@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.7.0.tgz#8d9290f9ec47ff772607fa864ca1d5a2efae1d4d"
+  integrity sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==
+  dependencies:
+    "@jest/environment" "^29.7.0"
+    "@jest/expect" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    jest-mock "^29.7.0"
 
 "@jest/reporters@^29.3.1":
   version "29.3.1"
@@ -1364,6 +1411,13 @@
   integrity sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==
   dependencies:
     "@sinclair/typebox" "^0.24.1"
+
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
 
 "@jest/source-map@^29.2.0":
   version "29.2.0"
@@ -1415,6 +1469,27 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.1"
 
+"@jest/transform@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.7.0.tgz#df2dd9c346c7d7768b8a06639994640c642e284c"
+  integrity sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@jest/types" "^29.6.3"
+    "@jridgewell/trace-mapping" "^0.3.18"
+    babel-plugin-istanbul "^6.1.1"
+    chalk "^4.0.0"
+    convert-source-map "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-util "^29.7.0"
+    micromatch "^4.0.4"
+    pirates "^4.0.4"
+    slash "^3.0.0"
+    write-file-atomic "^4.0.2"
+
 "@jest/types@^25.5.0":
   version "25.5.0"
   resolved "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz"
@@ -1431,6 +1506,18 @@
   integrity sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==
   dependencies:
     "@jest/schemas" "^29.0.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
+"@jest/types@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
+  integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
@@ -1459,7 +1546,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
-"@jridgewell/resolve-uri@^3.0.3":
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
@@ -1473,6 +1560,11 @@
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/sourcemap-codec@^1.4.14":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
@@ -1489,6 +1581,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.18":
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
+  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@sentry-internal/tracing@7.64.0":
   version "7.64.0"
@@ -1552,12 +1652,31 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.51.tgz#645f33fe4e02defe26f2f5c0410e1c094eac7f5f"
   integrity sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==
 
+"@sinclair/typebox@^0.27.8":
+  version "0.27.8"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
+  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.5.tgz#e280c94c95f206dcfd5aca00a43f2156b758c764"
   integrity sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==
   dependencies:
     type-detect "4.0.8"
+
+"@sinonjs/commons@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
+  integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^10.0.2":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz#55fdff1ecab9f354019129daf4df0dd4d923ea66"
+  integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
 
 "@sinonjs/fake-timers@^9.1.2":
   version "9.1.2"
@@ -2296,6 +2415,11 @@ diff-sequences@^29.3.1:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.3.1.tgz#104b5b95fe725932421a9c6e5b4bef84c3f2249e"
   integrity sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==
 
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -2546,6 +2670,17 @@ expect@^29.3.1:
     jest-matcher-utils "^29.3.1"
     jest-message-util "^29.3.1"
     jest-util "^29.3.1"
+
+expect@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
+  integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
+  dependencies:
+    "@jest/expect-utils" "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
 
 faker@^5.1.0:
   version "5.1.0"
@@ -3011,6 +3146,16 @@ jest-diff@^29.3.1:
     jest-get-type "^29.2.0"
     pretty-format "^29.3.1"
 
+jest-diff@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
 jest-docblock@^29.2.0:
   version "29.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.2.0.tgz#307203e20b637d97cee04809efc1d43afc641e82"
@@ -3051,6 +3196,11 @@ jest-get-type@^29.2.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.2.0.tgz#726646f927ef61d583a3b3adb1ab13f3a5036408"
   integrity sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==
 
+jest-get-type@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
+  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
+
 jest-haste-map@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.3.1.tgz#af83b4347f1dae5ee8c2fb57368dc0bb3e5af843"
@@ -3065,6 +3215,25 @@ jest-haste-map@^29.3.1:
     jest-regex-util "^29.2.0"
     jest-util "^29.3.1"
     jest-worker "^29.3.1"
+    micromatch "^4.0.4"
+    walker "^1.0.8"
+  optionalDependencies:
+    fsevents "^2.3.2"
+
+jest-haste-map@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.7.0.tgz#3c2396524482f5a0506376e6c858c3bbcc17b104"
+  integrity sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/graceful-fs" "^4.1.3"
+    "@types/node" "*"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.9"
+    jest-regex-util "^29.6.3"
+    jest-util "^29.7.0"
+    jest-worker "^29.7.0"
     micromatch "^4.0.4"
     walker "^1.0.8"
   optionalDependencies:
@@ -3088,6 +3257,16 @@ jest-matcher-utils@^29.3.1:
     jest-get-type "^29.2.0"
     pretty-format "^29.3.1"
 
+jest-matcher-utils@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz#ae8fec79ff249fd592ce80e3ee474e83a6c44f12"
+  integrity sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
 jest-message-util@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.3.1.tgz#37bc5c468dfe5120712053dd03faf0f053bd6adb"
@@ -3103,6 +3282,21 @@ jest-message-util@^29.3.1:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-message-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
+  integrity sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^29.6.3"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-mock@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.3.1.tgz#60287d92e5010979d01f218c6b215b688e0f313e"
@@ -3111,6 +3305,15 @@ jest-mock@^29.3.1:
     "@jest/types" "^29.3.1"
     "@types/node" "*"
     jest-util "^29.3.1"
+
+jest-mock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
+  integrity sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    jest-util "^29.7.0"
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
@@ -3121,6 +3324,11 @@ jest-regex-util@^29.2.0:
   version "29.2.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.2.0.tgz#82ef3b587e8c303357728d0322d48bbfd2971f7b"
   integrity sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==
+
+jest-regex-util@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.6.3.tgz#4a556d9c776af68e1c5f48194f4d0327d24e8a52"
+  integrity sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==
 
 jest-resolve-dependencies@^29.3.1:
   version "29.3.1"
@@ -3230,12 +3438,50 @@ jest-snapshot@^29.3.1:
     pretty-format "^29.3.1"
     semver "^7.3.5"
 
+jest-snapshot@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.7.0.tgz#c2c574c3f51865da1bb329036778a69bf88a6be5"
+  integrity sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@babel/generator" "^7.7.2"
+    "@babel/plugin-syntax-jsx" "^7.7.2"
+    "@babel/plugin-syntax-typescript" "^7.7.2"
+    "@babel/types" "^7.3.3"
+    "@jest/expect-utils" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    babel-preset-current-node-syntax "^1.0.0"
+    chalk "^4.0.0"
+    expect "^29.7.0"
+    graceful-fs "^4.2.9"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+    natural-compare "^1.4.0"
+    pretty-format "^29.7.0"
+    semver "^7.5.3"
+
 jest-util@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.3.1.tgz#1dda51e378bbcb7e3bc9d8ab651445591ed373e1"
   integrity sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==
   dependencies:
     "@jest/types" "^29.3.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
+jest-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
+  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
+  dependencies:
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
@@ -3275,6 +3521,16 @@ jest-worker@^29.3.1:
   dependencies:
     "@types/node" "*"
     jest-util "^29.3.1"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
+jest-worker@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.7.0.tgz#acad073acbbaeb7262bd5389e1bcf43e10058d4a"
+  integrity sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==
+  dependencies:
+    "@types/node" "*"
+    jest-util "^29.7.0"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
@@ -3763,6 +4019,15 @@ pretty-format@^29.3.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
@@ -3933,6 +4198,13 @@ semver@^7.2.1, semver@^7.3.5:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.5.3:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -4361,7 +4633,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-write-file-atomic@^4.0.1:
+write-file-atomic@^4.0.1, write-file-atomic@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.2.tgz#a9df01ae5b77858a027fd2e80768ee433555fcfd"
   integrity sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==


### PR DESCRIPTION
## Overview
Improves mocking capabilities generally and adds a bunch of tests to improve coverage.

- test: full coverage for determineModuleType
- chore: add jest globals dep for typesafe mocking
- test: substantial coverage improvements for token.ts + some pull.ts utils
- test: add basic http tests
- test: add mocks for http files, clean up http mocking in pull.test.ts
- test: basic e2e for pull command

## Context
https://linear.app/dittowords/issue/DIT-6187/cli-audit-existing-tests

## Test Plan
- [ ] Tests pass