### PR TITLE
Update url for creating a new API key

### DIFF
--- a/lib/init/token.ts
+++ b/lib/init/token.ts
@@ -98,13 +98,11 @@ async function checkToken(token: string): Promise<any> {
 
 async function collectToken(message: string | null) {
   const blue = output.info;
-  const apiUrl = output.url("https://app.dittowords.com/account/user");
-  const breadcrumbs = `${blue("User")}`;
+  const apiUrl = output.url("https://app.dittowords.com/account/devtools");
+  const breadcrumbs = `${chalk.bold(blue("API Keys"))}`;
   const tokenDescription =
     message ||
-    `To get started, you'll need your Ditto API key. You can find this at: ${apiUrl} > ${breadcrumbs} under "${chalk.bold(
-      "API Keys"
-    )}".`;
+    `To get started, you'll need your Ditto API key. You can find this at: ${apiUrl} under "${breadcrumbs}".`;
   console.log(tokenDescription);
 
   const response = await prompt<{ token: string }>({


### PR DESCRIPTION
## Overview

Updates the printed out url the url to where a user can create a ditto api key.

## Context

Current URL points and outdated /user endpoint.

## Screenshots
![Screenshot 2024-03-11 at 10 16 11 AM](https://github.com/dittowords/cli/assets/19922122/58a9154b-cd60-4f56-bf4e-f2b37a6d49fd)
