### PR TITLE
[DIT-6379] Fix terminal hanging when Ctrl + C pressed during `pull` and token prompt

### DIFF
--- a/lib/utils/quit.ts
+++ b/lib/utils/quit.ts
@@ -1,4 +1,4 @@
 export function quit(message: string | null, exitCode = 2) {
   if (message) console.log(`\n${message}\n`);
-  process.exitCode = exitCode;
+  process.exit(exitCode);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
   "main": "bin/index.js",


### PR DESCRIPTION
## Overview
Fixes an issue where the CLI would become unresponsive but fail to fully exit when the user attempted to use Ctrl + C to bail out of the process.
<!--- What does this PR do? --->

## Context
https://linear.app/dittowords/issue/DIT-6379/fix-cli-hanging-when-ctrlc-out-of-token-collection-prompt
<!--- Any context about why you are creating this PR? Notion doc, screenshot, conversation, etc. --->

## Test Plan
1. Remove the file `~/.config/ditto`
2. Run `yarn start pull`
3. At the prompt, hit Ctrl + C
4. Confirm that the CLI exits and control is immediately returned to the user
