### PR TITLE
[DIT-6730] Add `disableJsDriver` option

### DIFF
--- a/.sentryclirc
+++ b/.sentryclirc
@@ -1,0 +1,3 @@
+
+[auth]
+token=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

--- a/.sentryclirc
+++ b/.sentryclirc
@@ -1,3 +1,0 @@
-
-[auth]
-token=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

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -6,7 +6,7 @@ import * as Sentry from "@sentry/node";
 
 import consts from "./consts";
 import { createSentryContext } from "./utils/createSentryContext";
-import { Project, ConfigYAML, SourceInformation } from "./types";
+import { Project, ConfigYAML, SourceInformation, Source } from "./types";
 
 export const DEFAULT_CONFIG_JSON: ConfigYAML = {
   sources: {
@@ -198,6 +198,7 @@ function parseSourceInformation(file?: string): SourceInformation {
     iosLocales,
     projects: projectsRoot,
     components: componentsRoot,
+    disableJsDriver,
   } = readProjectConfigData(file);
 
   const projects = sources?.projects || [];
@@ -239,7 +240,7 @@ function parseSourceInformation(file?: string): SourceInformation {
    */
   const hasSourceData = !!validProjects.length || shouldFetchComponentLibrary;
 
-  const result = {
+  const result: SourceInformation = {
     hasSourceData,
     validProjects,
     shouldFetchComponentLibrary,
@@ -255,6 +256,7 @@ function parseSourceInformation(file?: string): SourceInformation {
     localeByVariantApiId: iosLocales
       ? iosLocales.reduce((acc, e) => ({ ...acc, ...e }), {} as any)
       : undefined,
+    disableJsDriver,
   };
 
   Sentry.setContext("config", createSentryContext(result));

--- a/lib/pull.ts
+++ b/lib/pull.ts
@@ -286,7 +286,7 @@ function cleanOutputFiles() {
 
     if (
       item.isFile() &&
-      /\.js(on)?|\.xml|\.strings(dict)?$|\.swift$/.test(item.name)
+      /\.js(on)?|\.ts|\.xml|\.strings(dict)?$|\.swift$/.test(item.name)
     ) {
       return fs.unlinkSync(path.resolve(consts.TEXT_DIR, item.name));
     }
@@ -310,6 +310,7 @@ async function downloadAndSave(
     componentFolders: specifiedComponentFolders,
     componentRoot,
     localeByVariantApiId,
+    disableJsDriver,
   } = source;
 
   const formats = getFormat(formatFromSource);
@@ -525,7 +526,8 @@ async function downloadAndSave(
 
     const sources: Source[] = [...validProjects, ...componentSources];
 
-    if (hasJSONFormat) msg += generateJsDriver(sources, getJsonFormat(formats));
+    if (hasJSONFormat && !disableJsDriver)
+      msg += generateJsDriver(sources, getJsonFormat(formats));
 
     if (shouldGenerateIOSBundles) {
       msg += "iOS locale information detected, generating bundles..\n\n";

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,6 +52,10 @@ export interface ConfigYAML {
   // TODO: might want to rename this at some point
   iosLocales?: Record<string, string>[];
 
+  // prevents the generation of index.js and index.d.ts files
+  // when working with JSON formats
+  disableJsDriver?: boolean;
+
   // these are legacy fields - if they exist, we should output
   // a deprecation error, and suggest that they nest them under
   // a top-level `sources` property
@@ -73,6 +77,7 @@ export interface SourceInformation {
   componentRoot: boolean | { status: string } | undefined;
   componentFolders: ComponentFolder[] | undefined;
   localeByVariantApiId: Record<string, string> | undefined;
+  disableJsDriver?: boolean;
 }
 
 export type Token = string | undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
   "main": "bin/index.js",


### PR DESCRIPTION
## Overview
- feat: add config option for disabling js driver file generation

## Context
https://linear.app/dittowords/issue/DIT-6730/feature-request-for-a-cli-option-to-not-create-js-driver-files

## Test Plan
- [ ] With `format: flat` in `config.yml`, run `yarn start pull` and confirm `index.js` and `index.d.ts` are generated
- [ ] Add `disableJsDriver: true` to `confirm.yml`, run `yarn start pull` again, and confirm the driver files are NOT generated

### Reviewer checklist
- [ ] Have you thought about additional items that should be tested? Add them below if necessary.