### PR TITLE
Add  module type support in i18next framework output file

### DIFF
--- a/lib/src/formatters/frameworks/json/base.ts
+++ b/lib/src/formatters/frameworks/json/base.ts
@@ -8,7 +8,7 @@ export default class BaseFramework {
 
   constructor(output: Output) {
     this.output = output;
-    this.outDir = output.outDir ?? appContext.projectConfigDir;
+    this.outDir = output.outDir ?? appContext.outDir;
   }
 
   get framework() {

--- a/lib/src/formatters/frameworks/json/i18next.ts
+++ b/lib/src/formatters/frameworks/json/i18next.ts
@@ -12,6 +12,11 @@ export default class I18NextFramework extends applyMixins(
   process(
     outputJsonFiles: Record<string, JSONOutputFile<{ variantId: string }>>
   ) {
+    let moduleType: "commonjs" | "module" = "commonjs";
+    if ("type" in this.output && this.output.type) {
+      moduleType = this.output.type;
+    }
+
     const driverFile = new JavascriptOutputFile({
       filename: "index",
       path: this.outDir,
@@ -27,13 +32,23 @@ export default class I18NextFramework extends applyMixins(
       {} as Record<string, OutputFile[]>
     );
 
-    driverFile.content += this.generateImportStatements(outputJsonFiles);
+    if (moduleType === "module") {
+      driverFile.content += this.generateImportStatements(outputJsonFiles);
 
-    driverFile.content += `\n`;
+      driverFile.content += `\n`;
 
-    driverFile.content += this.generateDefaultExportString(
-      filesGroupedByVariantId
-    );
+      driverFile.content += this.codegenDefaultExport(
+        this.generateExportedObjectString(filesGroupedByVariantId)
+      );
+    } else {
+      driverFile.content += this.generateRequireStatements(outputJsonFiles);
+
+      driverFile.content += `\n`;
+
+      driverFile.content += this.codegenModuleExports(
+        this.generateExportedObjectString(filesGroupedByVariantId)
+      );
+    }
 
     return [driverFile];
   }
@@ -57,11 +72,29 @@ export default class I18NextFramework extends applyMixins(
   }
 
   /**
+   * Generates the require statements for the driver file. One require per generated json file.
+   * @param outputJsonFiles - The output json files.
+   * @returns The require statements, stringified.
+   */
+  private generateRequireStatements(
+    outputJsonFiles: Record<string, JSONOutputFile<{ variantId: string }>>
+  ) {
+    let requireStatements = "";
+    for (const file of Object.values(outputJsonFiles)) {
+      requireStatements += this.codegenDefaultRequire(
+        this.sanitizeStringForJSVariableName(file.filename),
+        `./${file.filenameWithExtension}`
+      );
+    }
+    return requireStatements;
+  }
+
+  /**
    * Generates the default export for the driver file. By default this is an object with the json imports grouped by variant id.
    * @param filesGroupedByVariantId - The files grouped by variant id.
    * @returns The default export, stringified.
    */
-  private generateDefaultExportString(
+  private generateExportedObjectString(
     filesGroupedByVariantId: Record<string, OutputFile[]>
   ) {
     const variantIds = Object.keys(filesGroupedByVariantId);
@@ -85,6 +118,6 @@ export default class I18NextFramework extends applyMixins(
 
     defaultExportObjectString += `}`;
 
-    return this.codegenDefaultExport(defaultExportObjectString);
+    return defaultExportObjectString;
   }
 }

--- a/lib/src/formatters/frameworks/json/i18next.ts
+++ b/lib/src/formatters/frameworks/json/i18next.ts
@@ -45,7 +45,7 @@ export default class I18NextFramework extends applyMixins(
 
       driverFile.content += `\n`;
 
-      driverFile.content += this.codegenModuleExports(
+      driverFile.content += this.codegenCommonJSModuleExports(
         this.generateExportedObjectString(filesGroupedByVariantId)
       );
     }
@@ -54,7 +54,7 @@ export default class I18NextFramework extends applyMixins(
   }
 
   /**
-   * Generates the import statements for the driver file. One import per generated json file.
+   * Generates the import statements for the driver file with type "module". One import per generated json file.
    * @param outputJsonFiles - The output json files.
    * @returns The import statements, stringified.
    */
@@ -72,7 +72,7 @@ export default class I18NextFramework extends applyMixins(
   }
 
   /**
-   * Generates the require statements for the driver file. One require per generated json file.
+   * Generates the require statements for the driver file with type "commonjs". One require per generated json file.
    * @param outputJsonFiles - The output json files.
    * @returns The require statements, stringified.
    */

--- a/lib/src/formatters/json.ts
+++ b/lib/src/formatters/json.ts
@@ -37,7 +37,7 @@ export default class JSONFormatter extends applyMixins(
 
     const variablesOutputFile = new JSONOutputFile({
       filename: "variables",
-      path: this.outputDir,
+      path: this.outDir,
     });
 
     for (let i = 0; i < data.textItems.length; i++) {
@@ -47,7 +47,7 @@ export default class JSONFormatter extends applyMixins(
 
       outputJsonFiles[fileName] ??= new JSONOutputFile({
         filename: fileName,
-        path: this.outputDir,
+        path: this.outDir,
         metadata: { variantId: textItem.variantId || "base" },
       });
       

--- a/lib/src/formatters/mixins/javascriptCodegenMixin.ts
+++ b/lib/src/formatters/mixins/javascriptCodegenMixin.ts
@@ -15,8 +15,13 @@ export default function javascriptCodegenMixin<TBase extends Constructor>(
       return str.replace(/[^a-zA-Z0-9]/g, "_");
     }
 
-    protected codegenNamedImport(modules: NamedImport[], moduleName: string) {
-      const formattedModules = modules
+    /**
+     * Converts an array of modules into a string that can be used for a named import or require statement.
+     * @param modules array of { name: string, alias?: string }, each named import
+     * @returns a string of comma-separated module names/aliases, sorted
+     */
+    protected formatNamedModules(modules: NamedImport[]) {
+      return modules
         .map((m) => {
           if (m.alias) {
             return `${m.name} as ${m.alias}`;
@@ -25,23 +30,69 @@ export default function javascriptCodegenMixin<TBase extends Constructor>(
         })
         .sort()
         .join(", ");
+    }
+
+    /**
+     * Creates a named import statement for one or more items from a module.
+     * Used for i18next type "module".
+     * @param modules array of { name: string, alias?: string }, each named import
+     * @param moduleName the name of the file or package to import from
+     * @returns i.e `import { foo, bar as name } from "./file";`
+     */
+    protected codegenNamedImport(modules: NamedImport[], moduleName: string) {
+      const formattedModules = this.formatNamedModules(modules);
 
       return `import { ${formattedModules} } from "${moduleName}";\n`;
     }
 
+    /**
+     * Creates a named require statement for one or more items from a module.
+     * Used for i18next type "commonjs".
+     * @param modules array of { name: string, alias?: string }, each named import
+     * @param moduleName the name of the file or package to import from
+     * @returns i.e `const { foo, bar as name } = require("./file");`
+     */
+    protected codegenNamedRequire(modules: NamedImport[], moduleName: string) {
+      const formattedModules = this.formatNamedModules(modules);
+
+      return `const { ${formattedModules} } = require("${moduleName}");\n`;
+    }
+
+    /**
+     * Creates a default import statement for i18next type "module".
+     * @param module the name of the module to import
+     * @param moduleName the name of the file or package to import from
+     * @returns i.e codegenDefaultImport("item", "./file") => `import item from "./file";`
+     */
     protected codegenDefaultImport(module: string, moduleName: string) {
       return `import ${module} from "${moduleName}";\n`;
     }
 
+    /**
+     * Creates a default require statement for i18next type "commonjs".
+     * @param module the name of the module to import
+     * @param moduleName the name of the file or package to import from
+     * @returns i.e codegenDefaultRequire("item", "./file") => `const item = require("./file)";`
+     */
     protected codegenDefaultRequire(module: string, moduleName: string) {
       return `const ${module} = require("${moduleName}");\n`;
     }
 
+    /**
+     * Creates a default export statement for i18next type "module".
+     * @param module the name of the module to export
+     * @returns i.e codegenDefaultExport("item") => "export default item;"
+     */
     protected codegenDefaultExport(module: string) {
       return `export default ${module};`;
     }
 
-    protected codegenModuleExports(module: string) {
+    /**
+     * Creates a module exports statement for i18next type "commonjs".
+     * @param module the name of the module to export
+     * @returns i.e codegenModuleExports("item") => "module.exports = item;"
+     */
+    protected codegenCommonJSModuleExports(module: string) {
       return `module.exports = ${module};`;
     }
 

--- a/lib/src/formatters/mixins/javascriptCodegenMixin.ts
+++ b/lib/src/formatters/mixins/javascriptCodegenMixin.ts
@@ -33,8 +33,16 @@ export default function javascriptCodegenMixin<TBase extends Constructor>(
       return `import ${module} from "${moduleName}";\n`;
     }
 
+    protected codegenDefaultRequire(module: string, moduleName: string) {
+      return `const ${module} = require("${moduleName}");\n`;
+    }
+
     protected codegenDefaultExport(module: string) {
       return `export default ${module};`;
+    }
+
+    protected codegenModuleExports(module: string) {
+      return `module.exports = ${module};`;
     }
 
     protected codegenPad(depth: number) {

--- a/lib/src/formatters/shared/base.ts
+++ b/lib/src/formatters/shared/base.ts
@@ -8,12 +8,12 @@ import appContext from "../../utils/appContext";
 export default class BaseFormatter<APIDataType = unknown> {
   protected output: Output;
   protected projectConfig: ProjectConfigYAML;
-  protected outputDir: string;
+  protected outDir: string;
 
   constructor(output: Output, projectConfig: ProjectConfigYAML) {
     this.output = output;
     this.projectConfig = projectConfig;
-    this.outputDir = output.outDir ?? appContext.outDir;
+    this.outDir = output.outDir ?? appContext.outDir;
   }
 
   protected async fetchAPIData(): Promise<APIDataType> {

--- a/lib/src/outputs/json.ts
+++ b/lib/src/outputs/json.ts
@@ -8,6 +8,7 @@ const ZBaseJSONOutput = ZBaseOutputFilters.extend({
 
 const Zi18NextJSONOutput = ZBaseJSONOutput.extend({
   framework: z.literal("i18next"),
+  type: z.literal("module").or(z.literal("commonjs")).optional(),
 });
 
 export const ZJSONOutput = z.discriminatedUnion("framework", [


### PR DESCRIPTION
## Overview

Adds support for a `type` field used by the i18next framework to generate commonjs or ES6 module syntax in the generated javascript driver file. Defaults to commonjs

## Context

- Updated `JSONFormatter` and `BaseFramework` to use `outDir` instead of `outputDir` for improved consistency.
- Introduced module type handling in `I18NextFramework` to support both CommonJS and ES module formats.
- Added methods for generating require statements and module exports to streamline output generation.
- Enhanced Zod schema for JSON output to include optional module type specification.
## Screenshots

<!--- Include some screenshots of any visual changes you made to make it easier for the reviewer to understand what changes were made --->

## Test Plan

Testing successfully completed in <env> via:

- [ ] by default, specifying a json output with a framework of `i18next` should generate a javascript file with commonjs syntax.
- [ ] Specifying a `type` property with a value of `commonjs` in the json output with the framework set to `i18next` should generate a javascript file with commonjs syntax. (equivalent of the first bullet point.
- [ ] Specifying a `type` property with a value of `module` in the json output with the framework set to `i18next` should generate a javascript file with module syntax.
