### PR TITLE
[DIT-10128] Better error messaging for config errors

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -106,36 +106,7 @@ const executeCommand = async (
       if (isDittoErrorType(error, ErrorType.ConfigYamlLoadError)) {
         errorText = error.message;
       } else if (isDittoErrorType(error, ErrorType.ConfigParseError)) {
-        const invalidKeys = Array.from(
-          new Set(
-            error.data.issues
-              .map((issue) => ("keys" in issue ? issue.keys : null))
-              .flat()
-              .filter(Boolean)
-          )
-        );
-        const invalidValues = Array.from(
-          new Set(
-            error.data.issues
-              .map((issue) => issue.path)
-              .flat()
-              .filter(Boolean)
-          )
-        );
-
-        if (invalidKeys.length) {
-          errorText = `${
-            error.data.messagePrefix
-          } Please remove or rename the following fields: ${invalidKeys.join(
-            ", "
-          )}.`;
-        } else if (invalidValues.length) {
-          errorText = `${
-            error.data.messagePrefix
-          } Please check the following fields: ${invalidValues.join(", ")}.`;
-        } else {
-          errorText = `${error.data.messagePrefix} Please check the file format.`;
-        }
+        errorText = `${error.data.messagePrefix}\n\n${error.data.formattedError}`;
       }
     }
 

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -98,9 +98,6 @@ const executeCommand = async (
       "Something went wrong. Please contact support or try again later.";
 
     if (isDittoError(error)) {
-      sentryOptions = {
-        extra: { message: error.message, ...(error.data || {}) },
-      };
       exitCode = error.exitCode;
 
       if (isDittoErrorType(error, ErrorType.ConfigYamlLoadError)) {
@@ -108,6 +105,10 @@ const executeCommand = async (
       } else if (isDittoErrorType(error, ErrorType.ConfigParseError)) {
         errorText = `${error.data.messagePrefix}\n\n${error.data.formattedError}`;
       }
+
+      sentryOptions = {
+        extra: { message: errorText, ...(error.data || {}) },
+      };
     }
 
     const eventId = Sentry.captureException(error, sentryOptions);

--- a/lib/src/outputs/json.ts
+++ b/lib/src/outputs/json.ts
@@ -4,12 +4,12 @@ import { ZBaseOutputFilters } from "./shared";
 const ZBaseJSONOutput = ZBaseOutputFilters.extend({
   format: z.literal("json"),
   framework: z.undefined(),
-});
+}).strict();
 
 const Zi18NextJSONOutput = ZBaseJSONOutput.extend({
   framework: z.literal("i18next"),
   type: z.literal("module").or(z.literal("commonjs")).optional(),
-});
+}).strict();
 
 export const ZJSONOutput = z.discriminatedUnion("framework", [
   ZBaseJSONOutput,

--- a/lib/src/services/projectConfig.ts
+++ b/lib/src/services/projectConfig.ts
@@ -5,6 +5,7 @@ import appContext from "../utils/appContext";
 import yaml from "js-yaml";
 import { ZBaseOutputFilters } from "../outputs/shared";
 import { ZOutput } from "../outputs";
+import { YAML_PARSE_ERROR, YAML_LOAD_ERROR } from "../utils/errors";
 
 const ZProjectConfigYAML = ZBaseOutputFilters.extend({
   outputs: z.array(ZOutput),
@@ -38,12 +39,19 @@ function readProjectConfigData(
   file = appContext.projectConfigFile,
   defaultData: ProjectConfigYAML = DEFAULT_PROJECT_CONFIG_JSON
 ): ProjectConfigYAML {
-  createFileIfMissingSync(file, yaml.dump(defaultData));
-  const fileContents = fs.readFileSync(file, "utf8");
-  const yamlData = yaml.load(fileContents);
+  let yamlData: unknown = defaultData;
+
+  try {
+    createFileIfMissingSync(file, yaml.dump(defaultData));
+    const fileContents = fs.readFileSync(file, "utf8");
+    yamlData = yaml.load(fileContents);
+  } catch (err) {
+    throw new Error(YAML_LOAD_ERROR);
+  }
+
   const parsedYAML = ZProjectConfigYAML.safeParse(yamlData);
   if (!parsedYAML.success) {
-    throw new Error("Failed to parse project config file");
+    throw new Error(YAML_PARSE_ERROR, { cause: parsedYAML.error.issues });
   }
   return parsedYAML.data;
 }

--- a/lib/src/services/projectConfig.ts
+++ b/lib/src/services/projectConfig.ts
@@ -59,7 +59,7 @@ function readProjectConfigData(
     throw new DittoError({
       type: ErrorType.ConfigParseError,
       data: {
-        issues: parsedYAML.error.issues,
+        formattedError: JSON.stringify(parsedYAML.error.flatten(), null, 2),
         messagePrefix: "There is an error in your project config file.",
       },
     });

--- a/lib/src/utils/DittoError.ts
+++ b/lib/src/utils/DittoError.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+/**
+ * An Error extension designed to be thrown from anywhere in the CLI.
+ * The custom properties provide a reliable way to include additional data
+ * (what the error was and context around it) that can be leveraged
+ * to pass along data to the user, to Sentry, or to other services.
+ */
+export default class DittoError<T extends ErrorType> extends Error {
+  exitCode: number | undefined;
+  type: ErrorType;
+  // Note: if you see the type error "Type 'T' cannot be used to index type 'ErrorDataMap'",
+  // a value is missing from the ErrorDataMap defined below
+  data: ErrorDataMap[T];
+
+  /**
+   * Creates a new custom error with the following properties:
+   * @param type The type of error, from the ErrorType enum
+   * @param message Optional: error message to display to the user
+   * @param exitCode Optional: exit code to return to the shell.
+   * @param data Optional: additional data to pass along with the error
+   */
+  constructor({
+    type,
+    message,
+    exitCode,
+    data,
+  }: {
+    type: T;
+    message?: string;
+    exitCode?: number;
+    data: ErrorDataMap[T];
+  }) {
+    const errorMessage =
+      message ||
+      "Something went wrong. Please contact support or try again later.";
+
+    super(errorMessage);
+
+    this.exitCode = exitCode;
+    this.type = type;
+    this.data = data;
+  }
+}
+
+/**
+ * Exhaustive list of DittoError types
+ * When adding to this list, you must also add a Data type to ErrorDataMap
+ */
+export enum ErrorType {
+  ConfigYamlLoadError = "ConfigYamlLoadError",
+  ConfigParseError = "ConfigParseError",
+}
+
+/**
+ * Map of DittoError types to the data that is required for that type
+ * The keys of this must exhaustively match the keys of the ErrorType enum
+ */
+type ErrorDataMap = {
+  [ErrorType.ConfigYamlLoadError]: ConfigYamlLoadErrorData;
+  [ErrorType.ConfigParseError]: ConfigParseErrorData;
+};
+
+type ConfigYamlLoadErrorData = {
+  rawErrorMessage: string;
+};
+
+type ConfigParseErrorData = {
+  issues: z.ZodIssue[];
+  messagePrefix: string;
+};
+
+export function isDittoError(error: unknown): error is DittoError<ErrorType> {
+  return error instanceof DittoError;
+}
+export function isDittoErrorType<T extends ErrorType>(
+  error: DittoError<ErrorType>,
+  type: T
+): error is DittoError<T> {
+  return error.type === type;
+}

--- a/lib/src/utils/DittoError.ts
+++ b/lib/src/utils/DittoError.ts
@@ -66,7 +66,7 @@ type ConfigYamlLoadErrorData = {
 };
 
 type ConfigParseErrorData = {
-  issues: z.ZodIssue[];
+  formattedError: string;
   messagePrefix: string;
 };
 

--- a/lib/src/utils/errors.ts
+++ b/lib/src/utils/errors.ts
@@ -1,2 +1,0 @@
-export const YAML_LOAD_ERROR = "YAML_LOAD_ERROR";
-export const YAML_PARSE_ERROR = "YAML_PARSE_ERROR";

--- a/lib/src/utils/errors.ts
+++ b/lib/src/utils/errors.ts
@@ -1,0 +1,2 @@
+export const YAML_LOAD_ERROR = "YAML_LOAD_ERROR";
+export const YAML_PARSE_ERROR = "YAML_PARSE_ERROR";


### PR DESCRIPTION
## Overview

Creates a new custom error class `DittoError` that allows use to pass specific error data from the call site to the error handler. This is similar to `ApiError` in the main app, but with stronger typing since we're starting from scratch.

Updates the error messages we surface to the user when we encounter a failure in the config file.

1. If we fail to read the yaml file (not valid format at all), the error message will tell them to make sure it's valid yaml
2. If it's valid yaml but doesn't match our schema, the error message will attempt to tell them which fields are extra or have invalid typing
3. Sends the zod issues in to sentry as `extra` -- this seemed to be the best place to put unconstrained metadata, but I'm not sure how to test this.

## Context

https://linear.app/dittowords/issue/DIT-10128/improve-the-error-messaging-for-when-a-project-config-is-invalid

## Test Plan

Testing successfully completed in <env> via:

- [ ] Set your .env `DEBUG` to false so you only see what the user will see
- [ ] Edit your `config.yml` so it has a formatting/yaml error - you should see the right error message
- [ ] Add 1+ extra fields that shouldn't exist - the error should tell you which fields to remove
- [ ] Edit 1+ fields to give them invalid values for the expected type - the error should tell you which fields to look at
- [ ] Remove the outputs field, which is required - the error should tell you to check the outputs field
- [ ] All the errors above should use our default exit code of 2.
- [ ] Edit one of the `new DittoError` calls in `projectConfig.ts` to include `{ exitCode: 1 }`, then trigger that error type - You should see `Command failed with exit code 1` instead of the default which is 2.
- [ ] Do something that throws any other kind of error - you should see the generic error message
