### PR TITLE
[DIT-10167] Update version to 5.0.0-beta.6 and add Vue I18n framework support in …

### DIFF
--- a/lib/src/formatters/frameworks/json/index.ts
+++ b/lib/src/formatters/frameworks/json/index.ts
@@ -1,5 +1,6 @@
 import I18NextFramework from "./i18next";
 import { Output } from "../../../outputs";
+import VueI18nFramework from "./vue-i18n";
 
 export function getFrameworkProcessor(output: Output) {
   if (!output.framework) {
@@ -9,6 +10,8 @@ export function getFrameworkProcessor(output: Output) {
   switch (frameworkType) {
     case "i18next":
       return new I18NextFramework(output);
+    case "vue-i18n":
+      return new VueI18nFramework(output);
     default:
       throw new Error(`Unsupported JSON framework: ${frameworkType}`);
   }

--- a/lib/src/formatters/frameworks/json/vue-i18n.ts
+++ b/lib/src/formatters/frameworks/json/vue-i18n.ts
@@ -1,0 +1,135 @@
+import JavascriptOutputFile from "../../shared/fileTypes/JavascriptOutputFile";
+import OutputFile from "../../shared/fileTypes/OutputFile";
+import { applyMixins } from "../../shared";
+import javascriptCodegenMixin from "../../mixins/javascriptCodegenMixin";
+import JSONOutputFile from "../../shared/fileTypes/JSONOutputFile";
+import BaseFramework from "./base";
+
+export default class VueI18nFramework extends applyMixins(
+  BaseFramework,
+  javascriptCodegenMixin
+) {
+  process(
+    outputJsonFiles: Record<string, JSONOutputFile<{ variantId: string }>>
+  ) {
+    // vue-18n requires single mustaching for their json inputs, so we need to update the json
+    for (const file of Object.values(outputJsonFiles)) {
+      for (const key in file.content) {
+        const content = file.content[key];
+        if (typeof content === "string") {
+          file.content[key] = content
+            .replaceAll(/{{/g, "{")
+            .replaceAll(/}}/g, "}");
+        }
+      }
+    }
+
+    let moduleType: "commonjs" | "module" = "commonjs";
+    if ("type" in this.output && this.output.type) {
+      moduleType = this.output.type;
+    }
+
+    const driverFile = new JavascriptOutputFile({
+      filename: "index",
+      path: this.outDir,
+    });
+
+    const filesGroupedByVariantId = Object.values(outputJsonFiles).reduce(
+      (acc, file) => {
+        const variantId = file.metadata.variantId;
+        acc[variantId] ??= [];
+        acc[variantId].push(file);
+        return acc;
+      },
+      {} as Record<string, OutputFile[]>
+    );
+
+    if (moduleType === "module") {
+      driverFile.content += this.generateImportStatements(outputJsonFiles);
+
+      driverFile.content += `\n`;
+
+      driverFile.content += this.codegenDefaultExport(
+        this.generateExportedObjectString(filesGroupedByVariantId)
+      );
+    } else {
+      driverFile.content += this.generateRequireStatements(outputJsonFiles);
+
+      driverFile.content += `\n`;
+
+      driverFile.content += this.codegenCommonJSModuleExports(
+        this.generateExportedObjectString(filesGroupedByVariantId)
+      );
+    }
+
+    return [driverFile];
+  }
+
+  /**
+   * Generates the import statements for the driver file with type "module". One import per generated json file.
+   * @param outputJsonFiles - The output json files.
+   * @returns The import statements, stringified.
+   */
+  private generateImportStatements(
+    outputJsonFiles: Record<string, JSONOutputFile<{ variantId: string }>>
+  ) {
+    let importStatements = "";
+    for (const file of Object.values(outputJsonFiles)) {
+      importStatements += this.codegenDefaultImport(
+        this.sanitizeStringForJSVariableName(file.filename),
+        `./${file.filenameWithExtension}`
+      );
+    }
+    return importStatements;
+  }
+
+  /**
+   * Generates the require statements for the driver file with type "commonjs". One require per generated json file.
+   * @param outputJsonFiles - The output json files.
+   * @returns The require statements, stringified.
+   */
+  private generateRequireStatements(
+    outputJsonFiles: Record<string, JSONOutputFile<{ variantId: string }>>
+  ) {
+    let requireStatements = "";
+    for (const file of Object.values(outputJsonFiles)) {
+      requireStatements += this.codegenDefaultRequire(
+        this.sanitizeStringForJSVariableName(file.filename),
+        `./${file.filenameWithExtension}`
+      );
+    }
+    return requireStatements;
+  }
+
+  /**
+   * Generates the default export for the driver file. By default this is an object with the json imports grouped by variant id.
+   * @param filesGroupedByVariantId - The files grouped by variant id.
+   * @returns The default export, stringified.
+   */
+  private generateExportedObjectString(
+    filesGroupedByVariantId: Record<string, OutputFile[]>
+  ) {
+    const variantIds = Object.keys(filesGroupedByVariantId);
+
+    let defaultExportObjectString = "{\n";
+
+    for (let i = 0; i < variantIds.length; i++) {
+      const variantId = variantIds[i];
+      const files = filesGroupedByVariantId[variantId];
+
+      defaultExportObjectString += `${this.codegenPad(1)}"${variantId}": {\n`;
+      for (const file of files) {
+        defaultExportObjectString += `${this.codegenPad(
+          2
+        )}...${this.sanitizeStringForJSVariableName(file.filename)},\n`;
+      }
+      defaultExportObjectString += `${this.codegenPad(1)}}${
+        i < variantIds.length - 1 ? `,\n` : `\n`
+      }`;
+    }
+
+    defaultExportObjectString += `}`;
+
+    return defaultExportObjectString;
+  }
+}

--- a/lib/src/outputs/json.ts
+++ b/lib/src/outputs/json.ts
@@ -11,7 +11,13 @@ const Zi18NextJSONOutput = ZBaseJSONOutput.extend({
   type: z.literal("module").or(z.literal("commonjs")).optional(),
 }).strict();
 
+const ZVueI18nJSONOutput = ZBaseJSONOutput.extend({
+  framework: z.literal("vue-i18n"),
+  type: z.literal("module").or(z.literal("commonjs")).optional(),
+}).strict();
+
 export const ZJSONOutput = z.discriminatedUnion("framework", [
   ZBaseJSONOutput,
   Zi18NextJSONOutput,
+  ZVueI18nJSONOutput,
 ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "5.0.0-beta.5",
+  "version": "5.0.0-beta.6",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
   "main": "bin/ditto.js",


### PR DESCRIPTION
## Overview

Adds support for the vue-i18n framework. Adds support for reformatting double mustaches with single mustaches to be compatible (e.g. `{{ variable_name }}` to `{ variable_name }`

## Test Plan

- [ ] Add `vue-i18n` to your config.yml. It should generate json files exactly like i18next but with single `{` `}` mustaches around variables.
