### PR TITLE
Add rich text support for CLI

### DIFF
--- a/lib/src/formatters/json.ts
+++ b/lib/src/formatters/json.ts
@@ -51,8 +51,12 @@ export default class JSONFormatter extends applyMixins(
         metadata: { variantId: textItem.variantId || "base" },
       });
       
+      // Use richText if available and configured, otherwise use text
+      const textValue = (this.output.richText && textItem.richText) 
+        ? textItem.richText 
+        : textItem.text;
 
-      outputJsonFiles[fileName].content[textItem.id] = textItem.text;
+      outputJsonFiles[fileName].content[textItem.id] = textValue;
       for (const variableId of textItem.variableIds) {
         const variable = data.variablesById[variableId];
         variablesOutputFile.content[variableId] = variable.data;

--- a/lib/src/formatters/json.ts
+++ b/lib/src/formatters/json.ts
@@ -85,6 +85,10 @@ export default class JSONFormatter extends applyMixins(
       filters.variants = this.output.variants;
     }
 
+    if (this.output.richText) {
+      filters.richText = this.output.richText;
+    }
+
     return filters;
   }
 }

--- a/lib/src/http/textItems.test.ts
+++ b/lib/src/http/textItems.test.ts
@@ -1,0 +1,89 @@
+import fetchText from "./textItems";
+import httpClient from "./client";
+
+jest.mock("./client");
+
+describe("fetchText", () => {
+  const mockHttpClient = httpClient as jest.Mocked<typeof httpClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("richText parameter", () => {
+    it("should parse response with richText field correctly", async () => {
+      const mockResponse = {
+        data: [
+          {
+            id: "text1",
+            text: "Plain text",
+            richText: "<p>Rich <strong>HTML</strong> text</p>",
+            status: "active",
+            notes: "Test note",
+            tags: ["tag1"],
+            variableIds: ["var1"],
+            projectId: "project1",
+            variantId: "variant1",
+          },
+        ],
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await fetchText({
+        richText: "html",
+      });
+
+      expect(result).toEqual([
+        {
+          id: "text1",
+          text: "Plain text",
+          richText: "<p>Rich <strong>HTML</strong> text</p>",
+          status: "active",
+          notes: "Test note",
+          tags: ["tag1"],
+          variableIds: ["var1"],
+          projectId: "project1",
+          variantId: "variant1",
+        },
+      ]);
+    });
+
+    it("should handle response without richText field", async () => {
+      const mockResponse = {
+        data: [
+          {
+            id: "text1",
+            text: "Plain text only",
+            status: "active",
+            notes: "",
+            tags: [],
+            variableIds: [],
+            projectId: "project1",
+            variantId: null,
+          },
+        ],
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await fetchText({
+        richText: "html",
+      });
+
+      expect(result).toEqual([
+        {
+          id: "text1",
+          text: "Plain text only",
+          richText: undefined,
+          status: "active",
+          notes: "",
+          tags: [],
+          variableIds: [],
+          projectId: "project1",
+          variantId: null,
+        },
+      ]);
+    });
+  });
+});

--- a/lib/src/http/textItems.ts
+++ b/lib/src/http/textItems.ts
@@ -11,6 +11,7 @@ const TextItemsResponse = z.array(
   z.object({
     id: z.string(),
     text: z.string(),
+    richText: z.string().optional(),
     status: z.string(),
     notes: z.string(),
     tags: z.array(z.string()),

--- a/lib/src/http/textItems.ts
+++ b/lib/src/http/textItems.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 export interface PullFilters {
   projects?: { id: string }[];
   variants?: { id: string }[];
+  richText?: "html";
 }
 
 const TextItemsResponse = z.array(
@@ -25,10 +26,19 @@ export type TextItemsResponse = z.infer<typeof TextItemsResponse>;
 
 export default async function fetchText(filters?: PullFilters) {
   try {
+    const params: { filter: string; richText?: string } = {
+      filter: JSON.stringify({
+        projects: filters?.projects,
+        variants: filters?.variants,
+      }),
+    };
+    
+    if (filters?.richText) {
+      params.richText = filters.richText;
+    }
+
     const response = await httpClient.get("/v2/textItems", {
-      params: {
-        filter: JSON.stringify(filters),
-      },
+      params,
     });
 
     return TextItemsResponse.parse(response.data);

--- a/lib/src/outputs/shared.ts
+++ b/lib/src/outputs/shared.ts
@@ -8,4 +8,5 @@ export const ZBaseOutputFilters = z.object({
   projects: z.array(z.object({ id: z.string() })).optional(),
   variants: z.array(z.object({ id: z.string() })).optional(),
   outDir: z.string().optional(),
+  richText: z.literal("html").optional(),
 });


### PR DESCRIPTION
## Summary
Adds support for fetching and outputting rich text (HTML) content from the Ditto API.

## Usage
Add `richText: html` to your output configuration:

```yaml
outputs:
  - format: json
    framework: i18next
    richText: html
```

When enabled, the CLI will output HTML-formatted text values in JSON files, falling back to plain text when rich text is unavailable.

Closes DIT-11112