### PR TITLE
[DIT-13008] Implement baseline 'scan' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ For more information on configuring the CLI, see [this documentation section](ht
 
 ## Usage
 
+### Pull
+
 ```bash
 npx @dittowords/cli pull
 ```
@@ -69,6 +71,28 @@ See our demo projects for examples of how to integrate the Ditto CLI in differen
 - [React web app](https://github.com/dittowords/ditto-react-demo)
 - [iOS mobile app](https://github.com/dittowords/ditto-react-demo)
 - [Android mobile app](https://github.com/dittowords/ditto-react-demo)
+
+### Scan
+
+```bash
+npx @dittowords/cli scan <path>
+```
+
+Scans your codebase at `<path>` to identify user-facing text. Results are written to an output directory as a set of structured artifacts.
+
+**Options:**
+
+| Option              | Description                     | Default  |
+| ------------------- | ------------------------------- | -------- |
+| `--out-dir <dir>`   | Directory to write output files | `./out`  |
+| `--prefix <prefix>` | Prefix for output file names    | _(none)_ |
+
+**Output files** (written to `--out-dir`):
+
+- `candidates.ndjson` — all string candidates extracted from the codebase
+- `results.ndjson` — classified results for each candidate
+- `summary.json` — aggregate statistics from the classify phase
+- `resultsToVerify.ndjson` — results flagged for manual review
 
 ## Legacy Setup
 

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -36,7 +36,10 @@ const config = {
 
 async function main() {
   const result = await esbuild.build(config);
-  execSync("tsc -p tsconfig.declarations.json --emitDeclarationOnly", { stdio: "inherit" });
+  execSync(
+    "npx dts-bundle-generator --no-check --out-file bin/ditto.d.ts lib/ditto.ts",
+    { stdio: "inherit" }
+  );
   // Output build metafile so we can analyze the bundle
   // size over time and check if anything unexpected is being bundled in.
   if (process.env.ENV === "production") {

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -1,4 +1,5 @@
 import * as esbuild from "esbuild";
+import { execSync } from "child_process";
 
 let define = {};
 const KEYS_TO_DEFINE = [
@@ -35,6 +36,7 @@ const config = {
 
 async function main() {
   const result = await esbuild.build(config);
+  execSync("tsc -p tsconfig.declarations.json --emitDeclarationOnly", { stdio: "inherit" });
   // Output build metafile so we can analyze the bundle
   // size over time and check if anything unexpected is being bundled in.
   if (process.env.ENV === "production") {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,6 +2,10 @@ import type { Config } from "jest";
 
 const config: Config = {
   transformIgnorePatterns: [],
+  moduleNameMapper: {
+    "^unicorn-magic/node$":
+      "<rootDir>/node_modules/unicorn-magic/node.js",
+  },
   maxWorkers: 1,
   verbose: true,
   testPathIgnorePatterns: [

--- a/lib/ditto.ts
+++ b/lib/ditto.ts
@@ -25,4 +25,6 @@ const main = async () => {
   }
 };
 
+export type * from "./src/scan/types";
+
 main();

--- a/lib/src/commands/scan.ts
+++ b/lib/src/commands/scan.ts
@@ -1,0 +1,187 @@
+import "dotenv/config";
+import fs from "fs/promises";
+import path from "path";
+
+import logger from "../utils/logger";
+import { quit } from "../utils/quit";
+import { DittoScanExtractSummary, runExtract } from "../scan/extract";
+import { DittoScanCandidate, DittoScanResult } from "../scan/types";
+import { preClassify } from "../scan/preClassify";
+import { DittoScanClassifyResult, runClassify } from "../scan/classify";
+
+// Yarn sets INIT_CWD to the directory the user invoked yarn from, which
+// matters when we proxy via `cd product-text-detection && yarn ptd`.
+function resolveUserPath(input: string): string {
+  if (path.isAbsolute(input)) return input;
+  return path.resolve(process.env.INIT_CWD ?? process.cwd(), input);
+}
+
+// Builds the standard output file paths for a given directory and optional
+// prefix. Files are named "{prefix}-{artifact}.ext" when a prefix is given,
+// or just "{artifact}.ext" when omitted.
+function buildOutputPaths(outDir: string, prefix?: string) {
+  const p = prefix ? `${prefix}-` : "";
+  return {
+    candidates: path.join(outDir, `${p}candidates.ndjson`),
+    results: path.join(outDir, `${p}results.ndjson`),
+    summary: path.join(outDir, `${p}summary.json`),
+    verify: path.join(outDir, `${p}resultsToVerify.ndjson`),
+    analysis: path.join(outDir, `${p}analysis.json`),
+    schema: path.join(outDir, `${p}schema.json`),
+    stagings: path.join(outDir, `${p}stagings.ndjson`),
+  };
+}
+
+// Serialize extracted candidates as newline-delimited JSON. Used by both the
+// standalone `extract` command and `run`, which keeps the same artifact on disk.
+async function writeCandidatesNdjson(
+  candidates: DittoScanCandidate[],
+  outputPath: string
+): Promise<void> {
+  await fs.mkdir(path.dirname(path.resolve(outputPath)), { recursive: true });
+  const ndjson =
+    candidates.map((c) => JSON.stringify(c)).join("\n") +
+    (candidates.length > 0 ? "\n" : "");
+  await fs.writeFile(outputPath, ndjson, "utf8");
+}
+
+// Telemetry for the extract phase — framework detection, file counts,
+// per-detection-kind candidate counts, and the output path.
+function logExtractSummary(
+  summary: DittoScanExtractSummary,
+  outputPath: string
+): void {
+  process.stderr.write(
+    `[ditto-cli scan][extract] framework: ${
+      summary.framework.length > 0
+        ? summary.framework.join(", ")
+        : "(none detected)"
+    }\n`
+  );
+  process.stderr.write(
+    `[ditto-cli scan][extract] scanned ${summary.filesScanned} files in ${summary.elapsedMs}ms\n`
+  );
+  if (summary.i18nFileDiscovery) {
+    const d = summary.i18nFileDiscovery;
+    process.stderr.write(
+      `[ditto-cli scan][extract] llm file discovery (${d.task}): ${
+        d.llmConfirmed + d.autoIncluded
+      }/${d.totalCandidates} files matched in ${d.elapsedMs}ms (preFiltered=${
+        d.preFiltered
+      }, autoIncluded=${d.autoIncluded}, llmConsidered=${
+        d.llmConsidered
+      }, llmConfirmed=${d.llmConfirmed}, tokensIn=${
+        d.promptTokens
+      }, tokensOut=${d.completionTokens}, calls=${d.llmCalls})\n`
+    );
+  }
+  for (const [kind, count] of Object.entries(summary.filesByKind)) {
+    process.stderr.write(`  files.${kind}: ${count}\n`);
+  }
+  if (summary.filesSkippedMinified > 0) {
+    process.stderr.write(
+      `  files.skipped_minified: ${summary.filesSkippedMinified}\n`
+    );
+  }
+  process.stderr.write(
+    `[ditto-cli scan][extract] emitted ${summary.candidatesEmitted} candidates -> ${outputPath}\n`
+  );
+  for (const [kind, count] of Object.entries(summary.candidatesByKind)) {
+    if (count > 0) process.stderr.write(`  candidates.${kind}: ${count}\n`);
+  }
+  const { accept, reject, llm } = summary.candidatesByVerdict;
+  if (accept > 0 || reject > 0 || llm > 0) {
+    process.stderr.write(
+      `[ditto-cli scan][extract] rule verdicts: accept=${accept}, reject=${reject}, llm=${llm}\n`
+    );
+    for (const [name, count] of Object.entries(summary.ruleHits)) {
+      process.stderr.write(`  rule.${name}: ${count}\n`);
+    }
+  }
+}
+
+// Telemetry for the classify phase — per-status counts, LLM call/token
+// totals, and the paths to the results and summary artifacts.
+function logClassifySummary(
+  result: DittoScanClassifyResult,
+  summaryPath: string
+): void {
+  process.stderr.write(
+    `[ditto-cli scan][classify] classified ${result.summary.candidate_total} candidates\n`
+  );
+  for (const [status, count] of Object.entries(result.summary.by_status)) {
+    process.stderr.write(`  ${status}: ${count}\n`);
+  }
+  process.stderr.write(
+    `[ditto-cli scan][classify] llm_calls: ${result.summary.llm_calls}, tokens_in: ${result.summary.llm_tokens_in}, tokens_out: ${result.summary.llm_tokens_out}\n`
+  );
+  process.stderr.write(
+    `[ditto-cli scan][classify] to_manually_validate: ${result.summary.num_results_to_manually_verify}\n`
+  );
+  process.stderr.write(
+    `[ditto-cli scan][classify] pct_results_needing_manual_verification: ${result.summary.pct_results_needing_manual_verification}\n`
+  );
+  for (const [status, filePath] of Object.entries(
+    result.writtenPaths.resultsByStatus
+  )) {
+    process.stderr.write(`[ptd classify] results.${status} -> ${filePath}\n`);
+  }
+  process.stderr.write(`[ptd classify] summary  -> ${summaryPath}\n`);
+  if (result.writtenPaths.verify) {
+    process.stderr.write(
+      `[ditto-cli scan][classify] verify   -> ${result.writtenPaths.verify}\n`
+    );
+  }
+}
+
+export const scan = async (
+  path: string,
+  outDir: string = "./out",
+  prefix: string = ""
+) => {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey || apiKey.trim().length === 0) {
+    return await quit(
+      logger.errorText("GEMINI_API_KEY is not set. Aborting."),
+      2
+    );
+  }
+
+  const resolvedInput = resolveUserPath(path);
+  const resolvedOutDir = resolveUserPath(outDir);
+  await fs.mkdir(resolvedOutDir, { recursive: true });
+
+  const {
+    candidates: candidatesPath,
+    results: resultsPath,
+    summary: summaryPath,
+    verify: verifyPath,
+    schema: schemaPath,
+    stagings: stagingsPath,
+  } = buildOutputPaths(resolvedOutDir, prefix);
+
+  const {
+    candidates,
+    verdicts,
+    summary: extractSummary,
+  } = await runExtract({ inputPath: resolvedInput });
+  await writeCandidatesNdjson(candidates, candidatesPath);
+  logExtractSummary(extractSummary, candidatesPath);
+
+  if (candidates.length === 0) {
+    logger.warnText(
+      `[ditto scan] no candidates extracted; writing empty classify output\n`
+    );
+  }
+
+  const { llmCandidates, preClassified } = preClassify(candidates, verdicts);
+
+  const classifyResult = await runClassify({
+    candidates: llmCandidates,
+    preClassified,
+    outputPath: resultsPath,
+    summaryPath,
+    verifyPath,
+  });
+  logClassifySummary(classifyResult, summaryPath);
+};

--- a/lib/src/formatters/mixins/javascriptCodegenMixin.ts
+++ b/lib/src/formatters/mixins/javascriptCodegenMixin.ts
@@ -1,6 +1,6 @@
 import { Constructor } from "../shared";
 
-interface NamedImport {
+export interface NamedImport {
   name: string;
   alias?: string;
 }
@@ -9,9 +9,9 @@ export default function javascriptCodegenMixin<TBase extends Constructor>(
   Base: TBase
 ) {
   return class JavascriptCodegenHelpers extends Base {
-    protected indentSpaces: number = 2;
+    public indentSpaces: number = 2;
 
-    protected sanitizeStringForJSVariableName(str: string) {
+    public sanitizeStringForJSVariableName(str: string) {
       return str.replace(/[^a-zA-Z0-9]/g, "_");
     }
 
@@ -20,7 +20,7 @@ export default function javascriptCodegenMixin<TBase extends Constructor>(
      * @param modules array of { name: string, alias?: string }, each named import
      * @returns a string of comma-separated module names/aliases, sorted
      */
-    protected formatNamedModules(modules: NamedImport[]) {
+    public formatNamedModules(modules: NamedImport[]) {
       return modules
         .map((m) => {
           if (m.alias) {
@@ -39,7 +39,7 @@ export default function javascriptCodegenMixin<TBase extends Constructor>(
      * @param moduleName the name of the file or package to import from
      * @returns i.e `import { foo, bar as name } from "./file";`
      */
-    protected codegenNamedImport(modules: NamedImport[], moduleName: string) {
+    public codegenNamedImport(modules: NamedImport[], moduleName: string) {
       const formattedModules = this.formatNamedModules(modules);
 
       return `import { ${formattedModules} } from "${moduleName}";\n`;
@@ -52,7 +52,7 @@ export default function javascriptCodegenMixin<TBase extends Constructor>(
      * @param moduleName the name of the file or package to import from
      * @returns i.e `const { foo, bar as name } = require("./file");`
      */
-    protected codegenNamedRequire(modules: NamedImport[], moduleName: string) {
+    public codegenNamedRequire(modules: NamedImport[], moduleName: string) {
       const formattedModules = this.formatNamedModules(modules);
 
       return `const { ${formattedModules} } = require("${moduleName}");\n`;
@@ -64,7 +64,7 @@ export default function javascriptCodegenMixin<TBase extends Constructor>(
      * @param moduleName the name of the file or package to import from
      * @returns i.e codegenDefaultImport("item", "./file") => `import item from "./file";`
      */
-    protected codegenDefaultImport(module: string, moduleName: string) {
+    public codegenDefaultImport(module: string, moduleName: string) {
       return `import ${module} from "${moduleName}";\n`;
     }
 
@@ -74,7 +74,7 @@ export default function javascriptCodegenMixin<TBase extends Constructor>(
      * @param moduleName the name of the file or package to import from
      * @returns i.e codegenDefaultRequire("item", "./file") => `const item = require("./file)";`
      */
-    protected codegenDefaultRequire(module: string, moduleName: string) {
+    public codegenDefaultRequire(module: string, moduleName: string) {
       return `const ${module} = require("${moduleName}");\n`;
     }
 
@@ -83,7 +83,7 @@ export default function javascriptCodegenMixin<TBase extends Constructor>(
      * @param module the name of the module to export
      * @returns i.e codegenDefaultExport("item") => "export default item;"
      */
-    protected codegenDefaultExport(module: string) {
+    public codegenDefaultExport(module: string) {
       return `export default ${module};`;
     }
 
@@ -92,11 +92,11 @@ export default function javascriptCodegenMixin<TBase extends Constructor>(
      * @param module the name of the module to export
      * @returns i.e codegenModuleExports("item") => "module.exports = item;"
      */
-    protected codegenCommonJSModuleExports(module: string) {
+    public codegenCommonJSModuleExports(module: string) {
       return `module.exports = ${module};`;
     }
 
-    protected codegenPad(depth: number) {
+    public codegenPad(depth: number) {
       return " ".repeat(depth * this.indentSpaces);
     }
   };

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -3,6 +3,7 @@
 import * as Sentry from "@sentry/node";
 import { program } from "commander";
 import { pull } from "./commands/pull";
+import { scan } from "./commands/scan";
 import { quit } from "./utils/quit";
 import { version } from "../../package.json";
 import logger from "./utils/logger";
@@ -13,122 +14,82 @@ import type commander from "commander";
 import { ErrorType, isDittoError, isDittoErrorType } from "./utils/DittoError";
 import processCommandMetaFlag from "./utils/processCommandMetaFlag";
 
-type Command = "pull";
-
-interface CommandConfig<T extends Command | "add" | "remove"> {
-  name: T;
-  description: string;
-  commands?: CommandConfig<"add" | "remove">[];
-  flags?: {
-    [flag: string]: { description: string; processor?: (value: string) => any };
-  };
-}
-
-const COMMANDS: CommandConfig<Command>[] = [
-  {
-    name: "pull",
-    description: "Sync copy from Ditto",
-    flags: {
-      "-c, --config [value]": {
-        description:
-          "Relative path to the project config file. Defaults to `./ditto/config.yml`. Alternatively, you can set the DITTO_PROJECT_CONFIG_FILE environment variable.",
-      },
-    },
-  },
-];
-
-const setupCommands = () => {
-  program.name("ditto-cli");
-
-  COMMANDS.forEach((commandConfig) => {
-    const cmd = program
-      .command(commandConfig.name)
-      .description(commandConfig.description)
-      .action((options) => {
-        return executeCommand(commandConfig.name, options);
-      });
-
-    if (commandConfig.flags) {
-      Object.entries(commandConfig.flags).forEach(
-        ([flags, { description, processor }]) => {
-          if (processor) {
-            cmd.option(flags, description, processor);
-          } else {
-            cmd.option(flags, description);
-          }
-        }
-      );
-    }
-  });
-};
-
-const setupOptions = () => {
-  program.option("--legacy", "Run in legacy mode");
-  program.option(
-    "-m, --meta <data...>",
-    "Include arbitrary data in requests to the Ditto API. Ex: -m githubActionRequest:true trigger:manual"
-  );
-  program.version(version, "-v, --version", "Output the current version");
-};
-
-const executeCommand = async (
-  commandName: Command | "none",
-  command: commander.Command
-): Promise<void> => {
-  try {
-    const options = command.opts();
-    const token = await initAPIToken();
-    appContext.setApiToken(token);
-
-    await initProjectConfig(options);
-
-    const { meta } = program.opts();
-
-    switch (commandName) {
-      case "none":
-      case "pull": {
-        return await pull(processCommandMetaFlag(meta));
-      }
-      default: {
-        await quit(`Invalid command: ${commandName}. Exiting Ditto CLI...`);
-        return;
-      }
-    }
-  } catch (error) {
-    if (process.env.DEBUG === "true") {
-      console.error(logger.info("Development stack trace:\n"), error);
-    }
-
-    let sentryOptions = undefined;
-    let exitCode = undefined;
-    let errorText =
-      "Something went wrong. Please contact support or try again later.";
-
-    if (isDittoError(error)) {
-      exitCode = error.exitCode;
-
-      if (isDittoErrorType(error, ErrorType.ConfigYamlLoadError)) {
-        errorText = error.message;
-      } else if (isDittoErrorType(error, ErrorType.ConfigParseError)) {
-        errorText = `${error.data.messagePrefix}\n\n${error.data.formattedError}`;
-      }
-
-      sentryOptions = {
-        extra: { message: errorText, ...(error.data || {}) },
-      };
-    }
-
-    const eventId = Sentry.captureException(error, sentryOptions);
-    const eventStr = `\n\nError ID: ${logger.info(eventId)}`;
-
-    return await quit(logger.errorText(errorText) + eventStr, exitCode);
+const handleCommandError = async (error: unknown) => {
+  if (process.env.DEBUG === "true") {
+    console.error(logger.info("Development stack trace:\n"), error);
   }
+
+  let sentryOptions = undefined;
+  let exitCode = undefined;
+  let errorText =
+    "Something went wrong. Please contact support or try again later.";
+
+  if (isDittoError(error)) {
+    exitCode = error.exitCode;
+
+    if (isDittoErrorType(error, ErrorType.ConfigYamlLoadError)) {
+      errorText = error.message;
+    } else if (isDittoErrorType(error, ErrorType.ConfigParseError)) {
+      errorText = `${error.data.messagePrefix}\n\n${error.data.formattedError}`;
+    }
+
+    sentryOptions = {
+      extra: { message: errorText, ...(error.data || {}) },
+    };
+  }
+
+  const eventId = Sentry.captureException(error, sentryOptions);
+  const eventStr = `\n\nError ID: ${logger.info(eventId)}`;
+
+  return await quit(logger.errorText(errorText) + eventStr, exitCode);
 };
 
 const appEntry = async () => {
-  setupCommands();
-  setupOptions();
+  program.name("ditto-cli");
 
+  // ditto pull
+  program
+    .command("pull")
+    .description("Sync copy from Ditto")
+    .option(
+      "-c, --config [value]",
+      "Relative path to the project config file. Defaults to `./ditto/config.yml`. Alternatively, you can set the DITTO_PROJECT_CONFIG_FILE environment variable."
+    )
+    .option(
+      "-m, --meta <data...>",
+      "Include arbitrary data in requests to the Ditto API. Ex: -m githubActionRequest:true trigger:manual"
+    )
+    .option("--legacy", "Run in legacy mode")
+    .action(async (opts: { config?: string; meta?: string[] }) => {
+      try {
+        const token = await initAPIToken();
+        appContext.setApiToken(token);
+        await initProjectConfig(opts);
+        return await pull(processCommandMetaFlag(opts.meta ?? null));
+      } catch (error) {
+        handleCommandError(error);
+      }
+    });
+
+  // ditto scan
+  program
+    .command("scan <path>")
+    .description(
+      "Run extract + classify + infer end-to-end; emits schema.json and stagings.ndjson to --out-dir"
+    )
+    .option("--out-dir <dir>", "output directory", "./out")
+    .option("--prefix <prefix>", "prefix for output files", "")
+    .action(
+      async (inputPath: string, opts: { outDir: string; prefix?: string }) => {
+        try {
+          return await scan(inputPath, opts.outDir, opts.prefix);
+        } catch (error) {
+          handleCommandError(error);
+        }
+      }
+    );
+
+  program.version(version, "-v, --version", "Output the current version");
   program.parse(process.argv);
 };
 

--- a/lib/src/scan/classify.ts
+++ b/lib/src/scan/classify.ts
@@ -1,0 +1,367 @@
+import { createHash } from "crypto";
+import fs from "fs/promises";
+import path from "path";
+import { z } from "zod";
+
+import { callGemini } from "../services/gemini";
+
+import {
+  DittoScanCandidate,
+  DittoScanStatusSchema,
+  type DittoScanResult,
+  type DittoScanStatus,
+  type DittoScanSummary,
+} from "./types";
+import DittoError, { ErrorType } from "../utils/DittoError";
+
+export interface DittoScanClassifyOptions {
+  candidates?: DittoScanCandidate[];
+  // Results already decided by the deterministic rule classifier in
+  // `pre-classify`. Merged into the output file ahead of LLM-decided
+  // results. Their `decided_by` is "rule".
+  preClassified?: DittoScanResult[];
+  inputPath?: string;
+  outputPath: string;
+  summaryPath: string;
+  verifyPath: string;
+}
+
+interface DittoScanClassifyData {
+  results: DittoScanResult[];
+  summary: DittoScanSummary;
+}
+
+export interface DittoScanClassifyResult extends DittoScanClassifyData {
+  writtenPaths: {
+    resultsByStatus: Partial<Record<DittoScanStatus, string>>;
+    verify: string | null;
+  };
+}
+
+const MIN_CONFIDENCE_LEVEL = 0.9;
+const BATCH_SIZE = 10;
+const PARALLEL_BATCHES = 5;
+const CLASSIFY_MODEL = "gemini-2.5-flash";
+
+const SYSTEM_PROMPT = `You are classifying string literals extracted from an application codebase to determine whether they are user-facing (visible to end users in the UI) or not. The application type (web, mobile, desktop, etc.) can be inferred from the framework field on each candidate.
+
+For each candidate examine:
+- value_raw: the actual string literal
+- detection_kind: markup_text (JSX/HTML text content), markup_attr (HTML attribute value), resource_value (value inside a localization resource file), or other (any other code position)
+- context_identifiers: attribute names or identifiers enclosing the string (e.g. "placeholder", "aria-label", "classname", "textid"); for resource_value this is the localization key and any variant labels (e.g. ["greeting"] or ["items", "one"])
+- language: the file's language (tsx, jsx, typescript, javascript, vue, kotlin, swift, ios_strings, android_resources, etc.) — helps interpret the source_context syntax
+- framework: UI frameworks and platforms detected in the project (e.g. ["react"], ["vue"], ["android"], ["ios"]) — a React/Vue/iOS/Android file is far more likely to contain user-facing strings than a plain Node.js utility
+- source_context: surrounding lines of source code with line numbers
+- usage_evidence (if present): how the string constant is used elsewhere in the codebase
+
+Classification statuses:
+- "user-facing": text visible to end users — button labels, form placeholders, error messages shown in the UI, modal titles, headings, aria-labels, tooltip text, etc.
+- "not-user-facing": internal strings — CSS class names, import paths, localStorage keys, API route prefixes, internal error codes used for programmatic comparisons, keyboard key names for event matching (e.g. "Enter"), enum-like string values, Ditto textId references (e.g. "text_630d31..."), etc.
+- "unsure": genuinely ambiguous; use sparingly
+
+Use confidence >= ${MIN_CONFIDENCE_LEVEL} when evidence clearly points one way, 0.6 - ${MIN_CONFIDENCE_LEVEL} when leaning one way with some ambiguity, < 0.6 for truly unclear cases.
+Set info_needed to null unless specific missing context would meaningfully change the verdict.`;
+
+const ZBatchItem = z.object({
+  id: z.string(),
+  status: DittoScanStatusSchema,
+  reason: z.string(),
+  confidence: z.number().min(0).max(1),
+  info_needed: z.string().nullable(),
+});
+
+const ZBatchResponse = z.object({
+  items: z.array(ZBatchItem),
+});
+
+interface Stats {
+  llmCalls: number;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+function formatCandidate(c: DittoScanCandidate, index: number): string {
+  const parts = [
+    `[Candidate ${index + 1}]`,
+    `id: ${JSON.stringify(c.id)}`,
+    `value_raw: ${JSON.stringify(c.value_raw)}`,
+    `detection_kind: ${c.detection_kind}`,
+    `context_identifiers: [${c.context_identifiers
+      .map((x) => JSON.stringify(x))
+      .join(", ")}]`,
+    `language: ${c.language}`,
+    `framework: [${c.framework.map((f) => JSON.stringify(f)).join(", ")}]`,
+    `source_context:\n${c.source_context}`,
+  ];
+  if (c.usage_evidence?.length) {
+    parts.push(
+      `usage_evidence:\n${c.usage_evidence
+        .map((e) => `  ${e.file}:${e.line}: ${e.excerpt}`)
+        .join("\n")}`
+    );
+  }
+  parts.push(`[/Candidate ${index + 1}]`);
+  return parts.join("\n");
+}
+
+async function classifyBatch(
+  batch: DittoScanCandidate[],
+  stats: Stats
+): Promise<z.infer<typeof ZBatchItem>[] | null> {
+  const userPrompt = [
+    `Classify the following ${batch.length} string literal candidates.`,
+    `Return a JSON object with an "items" array containing one classification per candidate, in the same order.`,
+    "",
+    batch.map((c, i) => formatCandidate(c, i)).join("\n\n"),
+  ].join("\n");
+
+  try {
+    const result = await callGemini(userPrompt, ZBatchResponse, SYSTEM_PROMPT);
+
+    if (!result) return null;
+
+    stats.llmCalls++;
+    stats.tokensIn +=
+      result.metadata.geminiUsageMetadata?.promptTokenCount ?? 0;
+    stats.tokensOut +=
+      result.metadata.geminiUsageMetadata?.candidatesTokenCount ?? 0;
+
+    if (result.data.items.length !== batch.length) {
+      process.stderr.write(
+        `[classify] response had ${result.data.items.length} items for ${batch.length} candidates\n`
+      );
+      return null;
+    }
+    return result.data.items;
+  } catch (e: any) {
+    process.stderr.write(
+      `[classify/gemini] error: ${e.message ?? String(e)}\n`
+    );
+    return null;
+  }
+}
+
+async function classifyWithRecovery(
+  batch: DittoScanCandidate[],
+  stats: Stats
+): Promise<DittoScanResult[]> {
+  let items = await classifyBatch(batch, stats);
+
+  if (!items) {
+    process.stderr.write(`[classify] retrying batch of ${batch.length}...\n`);
+    items = await classifyBatch(batch, stats);
+  }
+
+  if (items) {
+    const byId = new Map(items.map((item) => [item.id, item]));
+    return batch.flatMap((c) => {
+      const item = byId.get(c.id);
+      if (!item) return [];
+      return [
+        {
+          ...c,
+          status: item.status,
+          reason: item.reason,
+          confidence: item.confidence,
+          info_needed: item.info_needed,
+          decided_by: "llm" as const,
+        },
+      ];
+    });
+  }
+
+  if (batch.length > 1) {
+    process.stderr.write(
+      `[classify] splitting batch of ${batch.length} after failure\n`
+    );
+    const mid = Math.ceil(batch.length / 2);
+    const left = await classifyWithRecovery(batch.slice(0, mid), stats);
+    const right = await classifyWithRecovery(batch.slice(mid), stats);
+    return [...left, ...right];
+  }
+
+  process.stderr.write(
+    `[classify] marking candidate ${batch[0].id} as error\n`
+  );
+  return [
+    {
+      ...batch[0],
+      status: "error" as DittoScanStatus,
+      reason: "LLM classification failed after retries",
+      confidence: 0,
+      info_needed: null,
+      decided_by: "llm" as const,
+    },
+  ];
+}
+
+async function classify(
+  candidates: DittoScanCandidate[],
+  preClassified: DittoScanResult[] = []
+): Promise<DittoScanClassifyData> {
+  const startedAt = new Date().toISOString();
+  const promptHash = createHash("sha1")
+    .update(SYSTEM_PROMPT)
+    .digest("hex")
+    .slice(0, 12);
+  const stats: Stats = { llmCalls: 0, tokensIn: 0, tokensOut: 0 };
+  const llmResults: DittoScanResult[] = [];
+
+  const allBatches: DittoScanCandidate[][] = [];
+  for (let i = 0; i < candidates.length; i += BATCH_SIZE) {
+    allBatches.push(candidates.slice(i, i + BATCH_SIZE));
+  }
+
+  for (let i = 0; i < allBatches.length; i += PARALLEL_BATCHES) {
+    const chunk = allBatches.slice(i, i + PARALLEL_BATCHES);
+    const chunkResults = await Promise.all(
+      chunk.map((batch, j) => {
+        const batchIdx = i + j + 1;
+        process.stderr.write(
+          `[classify] batch ${batchIdx}/${allBatches.length} (${batch.length} candidates)\n`
+        );
+        return classifyWithRecovery(batch, stats);
+      })
+    );
+    for (const batchResult of chunkResults) {
+      llmResults.push(...batchResult);
+    }
+  }
+
+  // Rule-decided results lead so they appear first in the output file.
+  // by_status / counts reflect the union.
+  const results: DittoScanResult[] = [...preClassified, ...llmResults];
+
+  const byStatus: Partial<Record<DittoScanStatus, number>> = {
+    unsure: 0,
+    error: 0,
+  };
+  // by_rule keys are `${language}:${reason}` so rule names that appear in
+  // multiple languages (e.g. `logger_call` in JS / Kotlin / Swift) stay
+  // distinguishable. Each rule file owns one logical concept per language;
+  // collapsing across languages would hide which implementation is doing
+  // the work.
+  const byRule: Record<string, number> = {};
+  let ruleCount = 0;
+  let llmCount = 0;
+  for (const r of results) {
+    byStatus[r.status] = (byStatus[r.status] ?? 0) + 1;
+    if (r.decided_by === "rule") {
+      ruleCount++;
+      const key = `${r.language}:${r.reason}`;
+      byRule[key] = (byRule[key] ?? 0) + 1;
+    } else {
+      llmCount++;
+    }
+  }
+
+  const numResultsToManuallyValidate = results.filter(
+    (r) => r.confidence < MIN_CONFIDENCE_LEVEL
+  ).length;
+
+  const finishedAt = new Date().toISOString();
+  const summary: DittoScanSummary = {
+    run_id: createHash("sha1")
+      .update(`${startedAt}:${promptHash}`)
+      .digest("hex")
+      .slice(0, 16),
+    started_at: startedAt,
+    finished_at: finishedAt,
+    model: CLASSIFY_MODEL,
+    prompt_hash: promptHash,
+    candidate_total: results.length,
+    by_status: byStatus,
+    num_results_to_manually_verify: numResultsToManuallyValidate,
+    pct_results_needing_manual_verification:
+      results.length > 0
+        ? (numResultsToManuallyValidate / results.length) * 100
+        : 0,
+    llm_calls: stats.llmCalls,
+    llm_tokens_in: stats.tokensIn,
+    llm_tokens_out: stats.tokensOut,
+    decided_by: { rule: ruleCount, llm: llmCount },
+    by_rule: byRule,
+  };
+
+  return { results, summary };
+}
+
+export async function runClassify(
+  options: DittoScanClassifyOptions
+): Promise<DittoScanClassifyResult> {
+  let candidates: DittoScanCandidate[];
+
+  if (options.candidates) {
+    candidates = options.candidates;
+  } else if (options.inputPath) {
+    const raw = await fs.readFile(options.inputPath, "utf8");
+    candidates = raw
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as DittoScanCandidate);
+  } else {
+    const errorMessage =
+      "Invalid inputs. Missing both 'candidates' and 'inputPath'";
+    throw new DittoError({
+      type: ErrorType.ScanError,
+      data: { rawErrorMessage: errorMessage },
+      message: errorMessage,
+    });
+  }
+
+  const result = await classify(candidates, options.preClassified);
+
+  const parsedOutput = path.parse(options.outputPath);
+  const ext = parsedOutput.ext;
+  const base = path.join(parsedOutput.dir, parsedOutput.name);
+
+  const allStatuses: DittoScanStatus[] = [
+    "user-facing",
+    "not-user-facing",
+    "unsure",
+    "error",
+  ];
+  const resultsByStatus: Partial<Record<DittoScanStatus, string>> = {};
+  await Promise.all(
+    allStatuses.map(async (status) => {
+      const statusResults = result.results.filter((r) => r.status === status);
+      const filePath = `${base}-${status}${ext}`;
+      if (statusResults.length === 0) {
+        await fs.rm(filePath, { force: true });
+        return;
+      }
+      await fs.writeFile(
+        filePath,
+        statusResults.map((r) => JSON.stringify(r)).join("\n") + "\n",
+        "utf8"
+      );
+      resultsByStatus[status] = filePath;
+    })
+  );
+
+  await fs.writeFile(
+    options.summaryPath,
+    JSON.stringify(result.summary, null, 2) + "\n",
+    "utf8"
+  );
+
+  const toVerify = result.results.filter(
+    (r) => r.confidence < MIN_CONFIDENCE_LEVEL
+  );
+  let writtenVerifyPath: string | null = null;
+  if (toVerify.length > 0) {
+    await fs.writeFile(
+      options.verifyPath,
+      toVerify.map((r) => JSON.stringify(r)).join("\n") + "\n",
+      "utf8"
+    );
+    writtenVerifyPath = options.verifyPath;
+  } else {
+    await fs.rm(options.verifyPath, { force: true });
+  }
+
+  return {
+    ...result,
+    writtenPaths: { resultsByStatus, verify: writtenVerifyPath },
+  };
+}

--- a/lib/src/scan/extract.ts
+++ b/lib/src/scan/extract.ts
@@ -1,0 +1,330 @@
+import fs from "fs/promises";
+import { globby } from "globby";
+import path from "path";
+
+import {
+  DittoScanDetectionKindSchema,
+  type DittoScanCandidate,
+  type DittoScanDetectionKind,
+} from "./types";
+import { createHash } from "crypto";
+import type { LlmFileTaskStats } from "./lang/llm-file-discovery";
+import { getClassificationVerdict, shouldEmit, type Verdict } from "./rules";
+import { walkCodebase } from "./walk";
+
+export interface DittoScanExtractOptions {
+  inputPath: string;
+}
+
+export interface DittoScanExtractResult {
+  candidates: DittoScanCandidate[];
+  verdicts: Map<string, Verdict>;
+  summary: DittoScanExtractSummary;
+}
+
+export interface DittoScanExtractSummary {
+  filesScanned: number;
+  filesByKind: Record<string, number>;
+  filesSkippedMinified: number;
+  candidatesEmitted: number;
+  candidatesByKind: Record<DittoScanDetectionKind, number>;
+  candidatesByVerdict: { accept: number; reject: number; llm: number };
+  ruleHits: Record<string, number>;
+  framework: string[];
+  elapsedMs: number;
+  i18nFileDiscovery: LlmFileTaskStats | null;
+}
+
+const CONTEXT_LINES = 3;
+const MAX_CONTEXT_LINE_CHARS = 200;
+
+// Maps a dependency name in package.json to the framework token we surface
+// to the LLM. Only frameworks that meaningfully shift the user-facing
+// likelihood of strings are listed (UI frameworks, server frameworks).
+const FRAMEWORK_MARKERS: ReadonlyArray<
+  readonly [pattern: RegExp, token: string]
+> = [
+  [/^react-native$/, "react-native"],
+  [/^react(-dom)?$/, "react"],
+  [/^next$/, "next"],
+  [/^@remix-run\//, "remix"],
+  [/^vue$/, "vue"],
+  [/^nuxt$/, "nuxt"],
+  [/^svelte$/, "svelte"],
+  [/^@sveltejs\/kit$/, "sveltekit"],
+  [/^@angular\/core$/, "angular"],
+  [/^solid-js$/, "solid"],
+  [/^preact$/, "preact"],
+  [/^astro$/, "astro"],
+  [/^express$/, "express"],
+  [/^fastify$/, "fastify"],
+  [/^koa$/, "koa"],
+  [/^@nestjs\/core$/, "nestjs"],
+  [/^@hapi\/hapi$/, "hapi"],
+];
+
+function zeroKindCounts(): Record<DittoScanDetectionKind, number> {
+  return Object.fromEntries(
+    DittoScanDetectionKindSchema.options.map((k) => [k, 0])
+  ) as Record<DittoScanDetectionKind, number>;
+}
+
+function buildSourceContext(lines: string[], targetLine: number): string {
+  const start = Math.max(1, targetLine - CONTEXT_LINES);
+  const end = Math.min(lines.length, targetLine + CONTEXT_LINES);
+  const out: string[] = [];
+  for (let i = start; i <= end; i++) {
+    const raw = lines[i - 1] ?? "";
+    const text =
+      raw.length > MAX_CONTEXT_LINE_CHARS
+        ? raw.slice(0, MAX_CONTEXT_LINE_CHARS) + "…(truncated)"
+        : raw;
+    out.push(`${i}: ${text}`);
+  }
+  return out.join("\n");
+}
+
+const VCS_MARKERS = [".git", ".hg", ".svn"] as const;
+
+// Aggregates deps from every package.json:
+//   - Walking *up* from inputPath to the repo root, since monorepo
+//     subpackages often have a near-empty package.json with the real
+//     deps living one or more levels up.
+//   - Walking *down* from inputPath via gitignore-aware globby, since
+//     the inverse is also common: pnpm/yarn workspace monorepos where
+//     the root package.json is empty and react/vue/etc. live in
+//     `packages/*/package.json`. Without this pass, large frontend
+//     monorepos (excalidraw, nx-style repos) would surface
+//     `framework: (none detected)`.
+//
+// On top of the package.json passes, we sniff for native Android/iOS
+// project markers anywhere under inputPath so a Gradle-only or
+// Xcode-only project still surfaces an `android` / `ios` token to the
+// LLM. We never read the marker contents — presence alone is the signal.
+async function detectFramework(inputPath: string): Promise<string[]> {
+  const tokens = new Set<string>();
+
+  const ingestPackageJson = (raw: string) => {
+    let pkg: {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    try {
+      pkg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    for (const name of Object.keys({
+      ...(pkg.dependencies ?? {}),
+      ...(pkg.devDependencies ?? {}),
+    })) {
+      for (const [pattern, token] of FRAMEWORK_MARKERS) {
+        if (pattern.test(name)) tokens.add(token);
+      }
+    }
+  };
+
+  // Upward walk (inputPath → repo root).
+  let dir = path.resolve(inputPath);
+  while (true) {
+    try {
+      ingestPackageJson(
+        await fs.readFile(path.join(dir, "package.json"), "utf8")
+      );
+    } catch {
+      // no package.json here, keep walking
+    }
+    if (await isRepoRoot(dir)) break;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  // Downward walk (inputPath/**/package.json). Honors .gitignore and
+  // skips the usual large-directory denylist so we don't spelunk through
+  // node_modules / build artifacts.
+  const nested = await globby(["**/package.json"], {
+    cwd: path.resolve(inputPath),
+    gitignore: true,
+    onlyFiles: true,
+    ignore: [
+      "**/node_modules/**",
+      "**/.git/**",
+      "**/build/**",
+      "**/dist/**",
+      "**/.next/**",
+      "**/.nuxt/**",
+    ],
+    followSymbolicLinks: false,
+    suppressErrors: true,
+    absolute: true,
+  });
+  for (const pkgPath of nested) {
+    try {
+      ingestPackageJson(await fs.readFile(pkgPath, "utf8"));
+    } catch {
+      // unreadable / malformed, ignore
+    }
+  }
+
+  for (const platformToken of await detectMobilePlatforms(inputPath)) {
+    tokens.add(platformToken);
+  }
+
+  return [...tokens].sort();
+}
+
+const ANDROID_MARKER_RE =
+  /(?:^|\/)(?:AndroidManifest\.xml|build\.gradle(?:\.kts)?|settings\.gradle(?:\.kts)?)$/;
+const IOS_MARKER_RE =
+  /(?:^|\/)(?:[^/]+\.xcodeproj\/project\.pbxproj|Package\.swift|Podfile)$/;
+
+async function detectMobilePlatforms(inputPath: string): Promise<string[]> {
+  const tokens = new Set<string>();
+  const matches = await globby(
+    [
+      "**/AndroidManifest.xml",
+      "**/build.gradle",
+      "**/build.gradle.kts",
+      "**/settings.gradle",
+      "**/settings.gradle.kts",
+      "**/*.xcodeproj/project.pbxproj",
+      "**/Package.swift",
+      "**/Podfile",
+    ],
+    {
+      cwd: path.resolve(inputPath),
+      gitignore: true,
+      onlyFiles: true,
+      ignore: ["**/node_modules/**", "**/.git/**", "**/build/**", "**/Pods/**"],
+      followSymbolicLinks: false,
+      suppressErrors: true,
+    }
+  );
+  for (const m of matches) {
+    if (ANDROID_MARKER_RE.test(m)) tokens.add("android");
+    if (IOS_MARKER_RE.test(m)) tokens.add("ios");
+  }
+  return [...tokens];
+}
+
+async function isRepoRoot(dir: string): Promise<boolean> {
+  for (const marker of VCS_MARKERS) {
+    try {
+      await fs.access(path.join(dir, marker));
+      return true;
+    } catch {
+      // marker not present, try the next one
+    }
+  }
+  return false;
+}
+
+// Deterministic id for a candidate so the same string in the same place gets
+// the same id across runs.
+export function makeCandidateId(
+  file: string,
+  line: number,
+  column: number,
+  value: string
+): string {
+  return createHash("sha1")
+    .update(`${file}:${line}:${column}:${value}`)
+    .digest("hex")
+    .slice(0, 12);
+}
+
+export async function runExtract(
+  opts: DittoScanExtractOptions
+): Promise<DittoScanExtractResult> {
+  const t0 = Date.now();
+  const framework = await detectFramework(opts.inputPath);
+  const { files, filesSkippedMinified, i18nFileDiscovery } = await walkCodebase(
+    opts.inputPath
+  );
+
+  const filesByKind: Record<string, number> = {};
+  for (const f of files)
+    filesByKind[f.language.id] = (filesByKind[f.language.id] ?? 0) + 1;
+
+  const candidatesByKind = zeroKindCounts();
+  const candidates: DittoScanCandidate[] = [];
+  const verdicts = new Map<string, Verdict>();
+  const candidatesByVerdict = { accept: 0, reject: 0, llm: 0 };
+  const ruleHits: Record<string, number> = {};
+
+  for (const file of files) {
+    const lang = file.language;
+    let hits;
+    try {
+      hits = await lang.extractor.extract({
+        source: file.source,
+        kind: lang.id,
+      });
+    } catch (e) {
+      process.stderr.write(
+        `[ptd extract] failed on ${file.relPath} (${lang.id}): ${
+          (e as Error).message
+        }\n`
+      );
+      continue;
+    }
+
+    const lines = file.source.split(/\r?\n/);
+
+    for (const hit of hits) {
+      if (!shouldEmit(hit.value, hit.context)) continue;
+      const candidate: DittoScanCandidate = {
+        id: makeCandidateId(
+          file.relPath,
+          hit.location.line,
+          hit.location.column,
+          hit.value
+        ),
+        value_raw: hit.value,
+        detection_kind: hit.context.parentRole,
+        location: {
+          file: file.relPath,
+          line: hit.location.line,
+          column: hit.location.column,
+        },
+        language: file.languageLabel,
+        framework,
+        source_context: buildSourceContext(lines, hit.location.line),
+        context_identifiers: hit.context.identifiers,
+        usage_evidence: null,
+      };
+      candidates.push(candidate);
+      candidatesByKind[hit.context.parentRole]++;
+
+      const verdict = getClassificationVerdict({
+        candidate,
+        context: hit.context,
+      });
+      verdicts.set(candidate.id, verdict);
+      if (verdict.kind === "accept" || verdict.kind === "reject") {
+        candidatesByVerdict[verdict.kind]++;
+        ruleHits[verdict.rule] = (ruleHits[verdict.rule] ?? 0) + 1;
+      } else {
+        candidatesByVerdict.llm++;
+      }
+    }
+  }
+
+  return {
+    candidates,
+    verdicts,
+    summary: {
+      filesScanned: files.length,
+      filesByKind,
+      filesSkippedMinified,
+      candidatesEmitted: candidates.length,
+      candidatesByKind,
+      candidatesByVerdict,
+      ruleHits,
+      framework,
+      elapsedMs: Date.now() - t0,
+      i18nFileDiscovery,
+    },
+  };
+}

--- a/lib/src/scan/lang/extractors/android-resources.test.ts
+++ b/lib/src/scan/lang/extractors/android-resources.test.ts
@@ -1,0 +1,67 @@
+import { androidResourceExtractor } from "./android-resources";
+
+const extract = (source: string) => androidResourceExtractor.extract({ source, kind: "android_resources" });
+
+describe("androidResourceExtractor", () => {
+  test("emits <string> values keyed by name", async () => {
+    const source = [
+      `<?xml version="1.0" encoding="utf-8"?>`,
+      `<resources>`,
+      `  <string name="hello">Hello, world!</string>`,
+      `  <string name="goodbye">Goodbye</string>`,
+      `</resources>`,
+      ``,
+    ].join("\n");
+    const hits = await extract(source);
+    expect(hits.map((h) => ({ v: h.value, ids: h.context.identifiers }))).toEqual([
+      { v: "Hello, world!", ids: ["hello"] },
+      { v: "Goodbye", ids: ["goodbye"] },
+    ]);
+    expect(hits[0].context.parentRole).toBe("resource_value");
+  });
+
+  test("emits one hit per <plurals> item, tagged with the quantity", async () => {
+    const source = [
+      `<resources>`,
+      `  <plurals name="items">`,
+      `    <item quantity="one">%d item</item>`,
+      `    <item quantity="other">%d items</item>`,
+      `  </plurals>`,
+      `</resources>`,
+      ``,
+    ].join("\n");
+    const hits = await extract(source);
+    expect(hits).toHaveLength(2);
+    expect(hits[0].context.identifiers).toEqual(["items", "one"]);
+    expect(hits[1].context.identifiers).toEqual(["items", "other"]);
+  });
+
+  test("emits one hit per <string-array> item, indexed numerically", async () => {
+    const source = [
+      `<resources>`,
+      `  <string-array name="planets">`,
+      `    <item>Mercury</item>`,
+      `    <item>Venus</item>`,
+      `  </string-array>`,
+      `</resources>`,
+      ``,
+    ].join("\n");
+    const hits = await extract(source);
+    expect(hits.map((h) => h.value)).toEqual(["Mercury", "Venus"]);
+    expect(hits[0].context.identifiers).toEqual(["planets", "0"]);
+    expect(hits[1].context.identifiers).toEqual(["planets", "1"]);
+  });
+
+  test("recovers CDATA-wrapped values via the regex sweep", async () => {
+    const source = [
+      `<resources>`,
+      `  <string name="welcome"><![CDATA[<b>Welcome</b>]]></string>`,
+      `</resources>`,
+      ``,
+    ].join("\n");
+    const hits = await extract(source);
+    const welcome = hits.find((h) => h.value === "<b>Welcome</b>");
+    expect(welcome).toBeDefined();
+    expect(welcome?.context.identifiers).toEqual(["welcome"]);
+  });
+});

--- a/lib/src/scan/lang/extractors/android-resources.ts
+++ b/lib/src/scan/lang/extractors/android-resources.ts
@@ -1,0 +1,110 @@
+import { Lang, parse, type SgNode } from "@ast-grep/napi";
+
+import type { ExtractedHit, LanguageExtractor } from "../types";
+import { offsetToLineCol } from "./util";
+import { elementAttribute, emitTextHit, findCdataElements, tagName } from "./xml";
+
+/**
+ * Android `res/values/*.xml` resource files. Three top-level shapes:
+ *
+ *   <string name="hello">Hello, world!</string>
+ *   <plurals name="items">
+ *     <item quantity="one">%d item</item>
+ *     <item quantity="other">%d items</item>
+ *   </plurals>
+ *   <string-array name="planets">
+ *     <item>Mercury</item>
+ *     <item>Venus</item>
+ *   </string-array>
+ *
+ * Every value is intentional product copy, so all hits flow out as
+ * `resource_value`. The resource key (and the variant for plurals or the
+ * index for arrays) is surfaced through `identifiers` so downstream sees
+ * what's going on without re-parsing.
+ */
+export const androidResourceExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const root = parse(Lang.Html, source).root();
+    const out: ExtractedHit[] = [];
+
+    for (const el of root.findAll({ rule: { kind: "element" } })) {
+      const tag = tagName(el);
+      if (tag === "string") {
+        emitStringElement(el, out, source);
+      } else if (tag === "plurals" || tag === "string-array") {
+        const parentName = elementAttribute(el, "name") ?? "";
+        let index = 0;
+        for (const child of el.children()) {
+          if (child.kind() !== "element" || tagName(child) !== "item") continue;
+          const variant = tag === "plurals" ? elementAttribute(child, "quantity") ?? "" : String(index);
+          emitTextHit(child, [parentName, variant], out, source);
+          index++;
+        }
+      }
+    }
+
+    emitCdataValues(source, out);
+
+    return out;
+  },
+};
+
+const NAME_ATTR_RE = /\bname\s*=\s*"([^"]*)"/;
+const QUANTITY_ATTR_RE = /\bquantity\s*=\s*"([^"]*)"/;
+
+function emitCdataValues(source: string, out: ExtractedHit[]): void {
+  for (const m of findCdataElements(source, ["string", "item"])) {
+    const name = NAME_ATTR_RE.exec(m.attrsRaw)?.[1];
+    const quantity = QUANTITY_ATTR_RE.exec(m.attrsRaw)?.[1];
+    const parent = m.tag === "item" ? findEnclosingResourceParent(source, m.offset) : null;
+    if (m.tag === "item" && !parent) continue;
+    const { line, column } = offsetToLineCol(source, m.valueOffset);
+    out.push({
+      value: m.value,
+      location: { line, column },
+      context: {
+        parentRole: "resource_value",
+        identifiers: buildItemIdentifiers({ name, quantity, parent }),
+      },
+    });
+  }
+}
+
+function buildItemIdentifiers({
+  name,
+  quantity,
+  parent,
+}: {
+  name: string | undefined;
+  quantity: string | undefined;
+  parent: string | null;
+}): string[] {
+  // `<string name="...">` CDATA: name carries the identity directly.
+  if (name) return quantity ? [name, quantity] : [name];
+  // `<item>` CDATA inside <plurals>/<string-array>: use the enclosing parent's
+  // name so the identifier matches the non-CDATA path's [parentName, variant].
+  // The array-item index isn't reconstructable from a regex sweep, so plain
+  // <string-array> items collapse to just [parentName].
+  if (parent) return quantity ? [parent, quantity] : [parent];
+  return quantity ? [quantity] : [];
+}
+
+// Walks open/close tags up to `before` and returns the `name` of the
+// innermost active `<plurals>`/`<string-array>` ancestor, or null if there
+// is no enclosing one.
+function findEnclosingResourceParent(source: string, before: number): string | null {
+  const re = /<(plurals|string-array)\b([^>]*)>|<\/(plurals|string-array)>/g;
+  const stack: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) {
+    if (m.index >= before) break;
+    if (m[1]) stack.push(NAME_ATTR_RE.exec(m[2])?.[1] ?? "");
+    else stack.pop();
+  }
+  return stack[stack.length - 1] ?? null;
+}
+
+function emitStringElement(el: SgNode, out: ExtractedHit[], source: string): void {
+  const name = elementAttribute(el, "name");
+  emitTextHit(el, name ? [name] : [], out, source);
+}

--- a/lib/src/scan/lang/extractors/arb.ts
+++ b/lib/src/scan/lang/extractors/arb.ts
@@ -1,0 +1,23 @@
+import type { LanguageExtractor } from "../types";
+import { jsonI18nExtractor } from "./json-i18n";
+
+/**
+ * Flutter Application Resource Bundles (`.arb`). ARB is plain JSON with one
+ * convention: keys prefixed with `@` are metadata, not product copy.
+ *
+ *   {
+ *     "@@locale": "en",
+ *     "hello": "Hello",
+ *     "@hello": { "description": "greeting", "placeholders": {...} }
+ *   }
+ *
+ * `@@locale` / `@@last_modified` are file-level metadata; `@<key>` holds the
+ * description and placeholder spec for `<key>`. Reuse the JSON walker and
+ * drop any hit whose identifier chain crosses an `@`-prefixed key.
+ */
+export const arbExtractor: LanguageExtractor = {
+  async extract(opts) {
+    const hits = await jsonI18nExtractor.extract(opts);
+    return hits.filter((h) => !h.context.identifiers.some((id) => id.startsWith("@")));
+  },
+};

--- a/lib/src/scan/lang/extractors/fallback.test.ts
+++ b/lib/src/scan/lang/extractors/fallback.test.ts
@@ -1,0 +1,41 @@
+import { fallbackExtractor } from "./fallback";
+
+const extract = (source: string) => fallbackExtractor.extract({ source, kind: "regex_fallback" });
+
+describe("fallbackExtractor", () => {
+  test("emits one hit per quoted literal with 1-based line/column", async () => {
+    const hits = await extract(`const greeting = "Hello, world";\n`);
+    expect(hits).toEqual([
+      {
+        value: "Hello, world",
+        location: { line: 1, column: 18 },
+        context: { parentRole: "other", identifiers: [] },
+      },
+    ]);
+  });
+
+  test("handles single, double, and backtick quotes", async () => {
+    const hits = await extract(`x = "a"\ny = 'b'\nz = \`c\`\n`);
+    expect(hits.map((h) => h.value)).toEqual(["a", "b", "c"]);
+    expect(hits.map((h) => h.location.line)).toEqual([1, 2, 3]);
+  });
+
+  test("emits multiple literals on the same line", async () => {
+    const hits = await extract(`pair("a", "b")\n`);
+    expect(hits).toHaveLength(2);
+    expect(hits[0].value).toBe("a");
+    expect(hits[1].value).toBe("b");
+    expect(hits[0].location.column).toBeLessThan(hits[1].location.column);
+  });
+
+  test("respects escaped quotes inside a literal", async () => {
+    const hits = await extract(`msg = "He said \\"hi\\""\n`);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].value).toBe('He said \\"hi\\"');
+  });
+
+  test("returns an empty array when no literals are present", async () => {
+    const hits = await extract(`const x = 42;\n// no strings here\n`);
+    expect(hits).toEqual([]);
+  });
+});

--- a/lib/src/scan/lang/extractors/fallback.ts
+++ b/lib/src/scan/lang/extractors/fallback.ts
@@ -1,0 +1,43 @@
+import type { ExtractedHit, LanguageExtractor } from "../types";
+
+/**
+ * Regex-based string finder used for any source file that isn't supported by
+ * one of our extractors.
+ *
+ * Scan each line for `"..."`, `'...'`, or `` `...` `` literals
+ * and emit them with `parentRole: "other"`. The LLM
+ * phase reads `source_context` to decide whether each hit is user-facing.
+ *
+ * Known limitations - anything caught here is acceptable noise that
+ * downstream filters or the LLM will handle:
+ *   - Multi-line strings (Python triple-quoted, Go backticks, etc.) get
+ *     truncated at the first newline.
+ *   - Block comments are not stripped; string-like content inside `\/* *\/`
+ *     or `"""..."""` leaks through.
+ *   - Line comments are not stripped either — strings inside `# foo`,
+ *     `// foo`, `-- foo` leak through. (Stripping these would also drop
+ *     real strings like `"#abc"` or `"https://..."`, so we don't bother.)
+ *   - Escape sequences inside strings are matched but not interpreted.
+ */
+const STRING_RE = /(["'`])((?:(?!\1)[^\\\n]|\\.)*)\1/g;
+
+export const fallbackExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const out: ExtractedHit[] = [];
+    const lines = source.split(/\r?\n/);
+
+    for (let i = 0; i < lines.length; i++) {
+      STRING_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = STRING_RE.exec(lines[i])) !== null) {
+        out.push({
+          value: m[2],
+          location: { line: i + 1, column: m.index + 1 },
+          context: { parentRole: "other", identifiers: [] },
+        });
+      }
+    }
+
+    return out;
+  },
+};

--- a/lib/src/scan/lang/extractors/html-markup.test.ts
+++ b/lib/src/scan/lang/extractors/html-markup.test.ts
@@ -1,0 +1,50 @@
+import { htmlMarkupExtractor } from "./html-markup";
+
+const extract = (source: string) => htmlMarkupExtractor.extract({ source, kind: "html" });
+
+describe("htmlMarkupExtractor", () => {
+  test("emits element text as markup_text tagged with its parent tag", async () => {
+    const hits = await extract(`<p>Welcome home</p>\n`);
+    const text = hits.find((h) => h.value.trim() === "Welcome home");
+    expect(text?.context.parentRole).toBe("markup_text");
+    expect(text?.context.parentTag).toBe("p");
+  });
+
+  test("emits plain attribute values as markup_attr with attribute name", async () => {
+    const hits = await extract(`<input placeholder="Email" type="text" />\n`);
+    const email = hits.find((h) => h.value === "Email");
+    expect(email?.context.parentRole).toBe("markup_attr");
+    expect(email?.context.identifiers).toEqual(["placeholder"]);
+  });
+
+  test("skips contents of <script> and <style>", async () => {
+    const hits = await extract(
+      `<style>body { color: "red"; }</style>\n<script>const msg = "Hi";</script>\n<p>Real copy</p>\n`
+    );
+    const values = hits.map((h) => h.value.trim());
+    expect(values).toContain("Real copy");
+    expect(values).not.toContain("Hi");
+  });
+
+  test("skips framework directive attributes (`@click`, `:foo`, `v-on`)", async () => {
+    const hits = await extract(`<button @click="onClick" :class="cls" v-bind:id="id">Go</button>\n`);
+    const attrNames = hits.filter((h) => h.context.parentRole === "markup_attr").flatMap((h) => h.context.identifiers);
+    expect(attrNames).not.toContain("@click");
+    expect(attrNames).not.toContain(":class");
+    expect(attrNames).not.toContain("v-bind:id");
+    expect(hits.some((h) => h.value.trim() === "Go")).toBe(true);
+  });
+
+  test("suppresses parentTag for descendants of <code>/<pre>", async () => {
+    const hits = await extract(`<pre><span>foo bar</span></pre>\n`);
+    const inner = hits.find((h) => h.value.trim() === "foo bar");
+    expect(inner?.context.parentRole).toBe("markup_text");
+    expect(inner?.context.parentTag).toBeUndefined();
+  });
+
+  test("extracts inner literals from template interpolation expressions", async () => {
+    const hits = await extract(`<p>{{ isFollowing ? 'Unfollow' : 'Follow' }}</p>\n`);
+    const values = hits.filter((h) => h.context.parentRole === "markup_text").map((h) => h.value);
+    expect(values).toEqual(expect.arrayContaining(["Unfollow", "Follow"]));
+  });
+});

--- a/lib/src/scan/lang/extractors/html-markup.ts
+++ b/lib/src/scan/lang/extractors/html-markup.ts
@@ -1,0 +1,181 @@
+import { Lang, parse, type SgNode } from "@ast-grep/napi";
+
+import type { ExtractedHit, LanguageExtractor } from "../types";
+
+// Tags whose contents are code-shaped, not human copy. If the candidate
+// sits inside any of these up the ancestor chain we suppress parentTag so
+// the markup_text accept rule falls through to the LLM.
+const CODE_LIKE_HTML_ANCESTORS: ReadonlySet<string> = new Set(["pre", "code", "kbd", "samp", "var", "script", "style"]);
+const INTERPOLATION_LITERAL_RE = /(["'`])((?:\\.|(?!\1).)+?)\1/g;
+
+export const htmlMarkupExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    return extractHtmlMarkup(source);
+  },
+};
+
+export function extractHtmlMarkup(source: string): ExtractedHit[] {
+  const root = parse(Lang.Html, source).root();
+  const out: ExtractedHit[] = [];
+
+  for (const el of root.findAll({ rule: { kind: "element" } })) {
+    if (isInsideScriptOrStyle(el)) continue;
+    emitElementMarkup(el, out);
+  }
+
+  return out;
+}
+
+/**
+ * `<script>` and `<style>` contents are not markup copy. SFC extractors can
+ * parse script bodies separately with the appropriate language grammar.
+ */
+function isInsideScriptOrStyle(node: SgNode): boolean {
+  for (let cur = node.parent(); cur; cur = cur.parent()) {
+    const k = cur.kind();
+    if (k === "script_element" || k === "style_element") return true;
+  }
+  return false;
+}
+
+/**
+ * For one HTML element, emit:
+ *
+ *   1. One hit per plain attribute value.
+ *   2. One hit per non-empty direct text child.
+ *
+ * Framework-specific directives are skipped because their values are code
+ * expressions, not literal product copy.
+ */
+function emitElementMarkup(el: SgNode, out: ExtractedHit[]): void {
+  const elementTag = elementTagName(el);
+  const parentTag = hasCodeLikeHtmlAncestor(el) ? undefined : elementTag;
+  for (const child of el.children()) {
+    const k = child.kind();
+    if (k === "start_tag" || k === "self_closing_tag") {
+      for (const attr of child.children()) {
+        if (attr.kind() === "attribute") emitAttribute(attr, out);
+      }
+    } else if (k === "text") {
+      emitText(child, parentTag, out);
+    }
+  }
+}
+
+function emitText(textNode: SgNode, parentTag: string | undefined, out: ExtractedHit[]): void {
+  const text = textNode.text();
+  if (text.trim().length === 0) return;
+
+  // Template languages often put literal fallback/display copy inside
+  // interpolation expressions:
+  //   {{ isFollowing ? 'Unfollow' : 'Follow' }}
+  //   {{ _('%(count)d followers') }}
+  // Emit those inner literals instead of the whole code expression.
+  if (isTemplateExpressionText(text)) {
+    const extracted = emitInterpolationLiterals(textNode, parentTag, out);
+    if (extracted > 0) return;
+  }
+
+  const start = textNode.range().start;
+  out.push({
+    value: text,
+    location: { line: start.line + 1, column: start.column + 1 },
+    context: { parentRole: "markup_text", identifiers: [], parentTag },
+  });
+}
+
+function isTemplateExpressionText(text: string): boolean {
+  return /[{%][{%]|[%}][}%]/.test(text);
+}
+
+function emitInterpolationLiterals(textNode: SgNode, parentTag: string | undefined, out: ExtractedHit[]): number {
+  const text = textNode.text();
+  const start = textNode.range().start;
+  let count = 0;
+  for (const match of text.matchAll(INTERPOLATION_LITERAL_RE)) {
+    const value = match[2];
+    if (value.trim().length === 0) continue;
+    const offset = (match.index ?? 0) + 1;
+    const loc = offsetToLineCol(text, offset);
+    out.push({
+      value,
+      location: {
+        line: start.line + loc.line,
+        column: loc.line === 0 ? start.column + loc.column + 1 : loc.column + 1,
+      },
+      context: { parentRole: "markup_text", identifiers: [], parentTag },
+    });
+    count++;
+  }
+  return count;
+}
+
+function offsetToLineCol(source: string, offset: number): { line: number; column: number } {
+  let line = 0;
+  let lastNl = -1;
+  for (let i = 0; i < offset; i++) {
+    if (source.charCodeAt(i) === 10) {
+      line++;
+      lastNl = i;
+    }
+  }
+  return { line, column: offset - lastNl - 1 };
+}
+
+function elementTagName(el: SgNode): string | undefined {
+  for (const c of el.children()) {
+    if (c.kind() !== "start_tag" && c.kind() !== "self_closing_tag") continue;
+    for (const inner of c.children()) {
+      if (inner.kind() === "tag_name") return inner.text().toLowerCase();
+    }
+  }
+  return undefined;
+}
+
+function hasCodeLikeHtmlAncestor(el: SgNode): boolean {
+  for (let cur: SgNode | null = el.parent(); cur; cur = cur.parent()) {
+    if (cur.kind() !== "element") continue;
+    const tag = elementTagName(cur);
+    if (tag && CODE_LIKE_HTML_ANCESTORS.has(tag)) return true;
+  }
+  return false;
+}
+
+function emitAttribute(attr: SgNode, out: ExtractedHit[]): void {
+  const named = attr.children().filter((c) => c.isNamed());
+  const nameNode = named.find((c) => c.kind() === "attribute_name");
+  if (!nameNode) return;
+  const rawName = nameNode.text();
+  if (isDirectiveAttribute(rawName)) return;
+
+  let valueNode: SgNode | undefined;
+  let valueText: string | null = null;
+  for (const c of named) {
+    if (c.kind() === "quoted_attribute_value") {
+      valueNode = c;
+      valueText =
+        c
+          .children()
+          .find((cc) => cc.kind() === "attribute_value")
+          ?.text() ?? "";
+      break;
+    }
+    if (c.kind() === "attribute_value") {
+      valueNode = c;
+      valueText = c.text();
+      break;
+    }
+  }
+  if (valueText === null) return; // Boolean attribute (e.g., `disabled`).
+
+  const start = (valueNode ?? attr).range().start;
+  out.push({
+    value: valueText,
+    location: { line: start.line + 1, column: start.column + 1 },
+    context: { parentRole: "markup_attr", identifiers: [rawName.toLowerCase()] },
+  });
+}
+
+function isDirectiveAttribute(name: string): boolean {
+  return /^[:@#]|^v-|^\*|^\[|^\(|^bind-|^on-/.test(name);
+}

--- a/lib/src/scan/lang/extractors/javascript.test.ts
+++ b/lib/src/scan/lang/extractors/javascript.test.ts
@@ -1,0 +1,76 @@
+import { Lang } from "@ast-grep/napi";
+
+import { javascriptExtractor } from "./javascript";
+
+const ts = javascriptExtractor(Lang.TypeScript);
+const tsx = javascriptExtractor(Lang.Tsx);
+
+describe("javascriptExtractor", () => {
+  test("tags import paths as `import` and bare module argv too", async () => {
+    const hits = await ts.extract({ source: `import x from "y";\nrequire("z");\n`, kind: "typescript" });
+    const roles = hits.map((h) => h.context.parentRole);
+    expect(roles).toEqual(["import", "import"]);
+  });
+
+  test("tags `new RegExp(...)` arg as regex_pattern", async () => {
+    const hits = await ts.extract({ source: `const r = new RegExp("^foo$");\n`, kind: "typescript" });
+    const re = hits.find((h) => h.value === '"^foo$"');
+    expect(re?.context.parentRole).toBe("regex_pattern");
+  });
+
+  test("tags object keys as object_key and values as other", async () => {
+    const hits = await ts.extract({ source: `const o = { "label": "Hello" };\n`, kind: "typescript" });
+    const label = hits.find((h) => h.value === '"label"');
+    const hello = hits.find((h) => h.value === '"Hello"');
+    expect(label?.context.parentRole).toBe("object_key");
+    expect(hello?.context.parentRole).toBe("other");
+  });
+
+  test("tags switch cases and equality checks as type_tag", async () => {
+    const source = `function f(x: string) {\n  if (x === "foo") return 1;\n  switch (x) { case "bar": return 2; }\n  return 0;\n}\n`;
+    const hits = await ts.extract({ source, kind: "typescript" });
+    const foo = hits.find((h) => h.value === '"foo"');
+    const bar = hits.find((h) => h.value === '"bar"');
+    expect(foo?.context.parentRole).toBe("type_tag");
+    expect(bar?.context.parentRole).toBe("type_tag");
+  });
+
+  test("captures callee/calleeMember for member-expression calls", async () => {
+    const hits = await ts.extract({ source: `console.log("hi");\nt("welcome");\n`, kind: "typescript" });
+    const hi = hits.find((h) => h.value === '"hi"');
+    const welcome = hits.find((h) => h.value === '"welcome"');
+    expect(hi?.context).toMatchObject({ parentRole: "other", callee: "console", calleeMember: "log" });
+    expect(welcome?.context).toMatchObject({ parentRole: "other", callee: "t" });
+    expect(welcome?.context.calleeMember).toBeUndefined();
+  });
+
+  test("emits jsx_text as markup_text with the enclosing tag", async () => {
+    const hits = await tsx.extract({
+      source: `const e = <button>Save</button>;\n`,
+      kind: "tsx",
+    });
+    const save = hits.find((h) => h.value.trim() === "Save");
+    expect(save?.context.parentRole).toBe("markup_text");
+    expect(save?.context.parentTag).toBe("button");
+  });
+
+  test("emits JSX attribute string as markup_attr with attribute name in identifiers", async () => {
+    const hits = await tsx.extract({
+      source: `const e = <input placeholder="Email" />;\n`,
+      kind: "tsx",
+    });
+    const email = hits.find((h) => h.value === '"Email"');
+    expect(email?.context.parentRole).toBe("markup_attr");
+    expect(email?.context.identifiers).toEqual(["placeholder"]);
+  });
+
+  test("suppresses parentTag inside code-shaped JSX ancestors", async () => {
+    const hits = await tsx.extract({
+      source: `const e = <pre><span>npm install</span></pre>;\n`,
+      kind: "tsx",
+    });
+    const inner = hits.find((h) => h.value.trim() === "npm install");
+    expect(inner?.context.parentRole).toBe("markup_text");
+    expect(inner?.context.parentTag).toBeUndefined();
+  });
+});

--- a/lib/src/scan/lang/extractors/javascript.ts
+++ b/lib/src/scan/lang/extractors/javascript.ts
@@ -1,0 +1,410 @@
+import { Lang, parse, type SgNode } from "@ast-grep/napi";
+
+import type { DittoScanEnclosingContext } from "../../types";
+import type { ExtractedHit, LanguageExtractor } from "../types";
+import { extractHtmlMarkup } from "./html-markup";
+
+/**
+ * AST node kinds we treat as candidate strings.
+ *
+ *   `string`           covers `"..."` and `'...'`.
+ *   `template_string`  covers backticks, including ones with `${...}`
+ *                      substitutions. We just keep the raw text.
+ *   `jsx_text`         is the text content between JSX tags. For example,
+ *                      the `Save` in `<button>Save</button>`.
+ */
+const STRING_KINDS = ["string", "template_string", "jsx_text"] as const;
+
+/**
+ * Build an extractor for one of the JavaScript-family grammars supported
+ * by ast-grep:
+ *
+ *   `Lang.JavaScript`  for plain `.js`, `.cjs`, `.mjs` (no JSX).
+ *   `Lang.TypeScript`  for `.ts`, `.cts`, `.mts` (types but no JSX).
+ *   `Lang.Tsx`         for `.tsx` and `.jsx`. ast-grep's JS grammar does
+ *                      not parse JSX, so we use the Tsx grammar for both.
+ *
+ * The returned extractor walks the AST, emits one `ExtractedHit` per
+ * string node, and tags each hit with what kind of position it's in. See
+ * `classifyJsParent` for the keep/drop decisions.
+ */
+export function javascriptExtractor(langId: Lang): LanguageExtractor {
+  return {
+    async extract({ source }) {
+      const root = parse(langId, source).root();
+      const out: ExtractedHit[] = [];
+
+      for (const kind of STRING_KINDS) {
+        for (const node of root.findAll({ rule: { kind } })) {
+          if (
+            node.kind() === "template_string" &&
+            isInlineMarkupTemplateValue(node)
+          ) {
+            const htmlHits = extractInlineMarkupTemplate(node);
+            if (htmlHits.length > 0) {
+              out.push(...htmlHits);
+              continue;
+            }
+          }
+          const value = nodeValue(node);
+          if (value === null) continue;
+          const { line, column } = node.range().start;
+          out.push({
+            value,
+            location: { line: line + 1, column: column + 1 },
+            context: classifyJsParent(node),
+          });
+        }
+      }
+
+      return out;
+    },
+  };
+}
+
+function extractInlineMarkupTemplate(node: SgNode): ExtractedHit[] {
+  const raw = node.text();
+  if (raw.length < 2 || raw[0] !== "`" || raw[raw.length - 1] !== "`")
+    return [];
+  const body = raw.slice(1, -1);
+  if (!looksLikeMarkup(body)) return [];
+
+  const start = node.range().start;
+  const padded = "\n".repeat(start.line) + " ".repeat(start.column + 1) + body;
+  return extractHtmlMarkup(padded);
+}
+
+function looksLikeMarkup(value: string): boolean {
+  return /<\/?[A-Za-z][^>]*>/.test(value);
+}
+
+function isInlineMarkupTemplateValue(node: SgNode): boolean {
+  const parent = node.parent();
+  if (parent?.kind() !== "pair") return false;
+  const named = parent.children().filter((c) => c.isNamed());
+  const key = named[0];
+  const value = named[named.length - 1];
+  return rangesMatch(value, node) && keyName(key) === "template";
+}
+
+function keyName(node: SgNode | undefined): string | null {
+  if (!node) return null;
+  if (node.kind() === "property_identifier" || node.kind() === "identifier")
+    return node.text();
+  if (node.kind() === "string") {
+    const text = node.text();
+    return text.length >= 2 ? text.slice(1, -1) : text;
+  }
+  return null;
+}
+
+/**
+ * Returns the raw source text for the node, or null if it should be
+ * skipped. The only thing we skip here is whitespace-only `jsx_text`.
+ * tree-sitter emits a `jsx_text` node for the literal whitespace between
+ * elements (the newline and indent between `<p>` and `<span>` in
+ * pretty-printed JSX), and those are not real candidates.
+ *
+ * We deliberately do not strip quotes, unescape `\n`, or normalize
+ * `${...}` substitutions. The LLM reads `source_context` and handles raw
+ * source fine, and a clean post-processing pass would just be lossy.
+ */
+function nodeValue(node: SgNode): string | null {
+  const text = node.text();
+  if (node.kind() === "jsx_text" && text.trim().length === 0) return null;
+  return text;
+}
+
+/**
+ * Look at the AST node that contains the string and decide what kind of
+ * position the string is sitting in. The output drives two things:
+ *
+ *   1. The keep/drop decision in `shouldEmit`. Five `parentRole` values
+ *      are in the excluded set and never reach the LLM:
+ *
+ *        `import`         `import x from "y"`, `require("y")`, etc.
+ *        `regex_pattern`  `new RegExp("...")`
+ *        `object_key`     `{ "key": value }`
+ *        `index_access`   `obj["key"]`
+ *        `type_tag`       `case "foo":`, `x === "foo"`,
+ *                         `type T = "foo"`, etc.
+ *
+ *   2. The hints surfaced to the LLM: `markup_text`, `markup_attr` (with
+ *      the attribute name in `identifiers`), or `other`.
+ *
+ * Anything we don't recognize falls through to `other`. The LLM has the
+ * source context, so we don't need to classify every shape. We just need
+ * to be confident about the cheap exclusions.
+ */
+function classifyJsParent(node: SgNode): DittoScanEnclosingContext {
+  // jsx_text is always direct content inside a JSX element. No need to
+  // walk the parent chain to find the parent role, but we do walk up to
+  // capture the wrapping tag name so the markup_text accept rule can
+  // honor its parent-tag denylist (`<code>`, `<pre>`, ...).
+  if (node.kind() === "jsx_text") {
+    return {
+      parentRole: "markup_text",
+      identifiers: [],
+      parentTag: enclosingJsxTag(node),
+    };
+  }
+
+  const parent = node.parent();
+  if (!parent) return { parentRole: "other", identifiers: [] };
+  const pk = parent.kind() as string;
+
+  switch (pk) {
+    // Rare. A bare string literal directly under a JSX element. Most JSX
+    // content arrives via jsx_text (handled above) or jsx_expression.
+    case "jsx_element":
+      return {
+        parentRole: "markup_text",
+        identifiers: [],
+        parentTag: enclosingJsxTag(node),
+      };
+
+    // `{expr}` braces inside JSX. The interesting question is what the
+    // braces themselves are nested in:
+    //
+    //   <p>{"Hello"}</p>                  markup_text
+    //   <input placeholder={"Email"}/>    markup_attr (placeholder)
+    //   const x = {"foo"};                other (not real JSX)
+    case "jsx_expression": {
+      const grand = parent.parent();
+      const gk = grand?.kind();
+      if (gk === "jsx_element") {
+        return {
+          parentRole: "markup_text",
+          identifiers: [],
+          parentTag: enclosingJsxTag(node),
+        };
+      }
+      if (gk === "jsx_attribute") {
+        const name = jsxAttributeName(grand!);
+        return {
+          parentRole: "markup_attr",
+          identifiers: name ? [name.toLowerCase()] : [],
+        };
+      }
+      return { parentRole: "other", identifiers: [] };
+    }
+
+    // Direct attribute value: <input placeholder="Email" />. We surface
+    // the attribute name so `shouldEmit` can drop structural attrs like
+    // `className`, `style`, `data-testid`, etc.
+    case "jsx_attribute": {
+      const name = jsxAttributeName(parent);
+      return {
+        parentRole: "markup_attr",
+        identifiers: name ? [name.toLowerCase()] : [],
+      };
+    }
+
+    // The string is a function call argument. `arguments` is the parent
+    // for `foo(...)`, `new Foo(...)`, and `import(...)`. We special-case
+    // a few known shapes:
+    //
+    //   new RegExp("...")    regex_pattern (dropped)
+    //   require("...")       import (dropped)
+    //   import("...")        import (dropped, dynamic import)
+    //
+    // Everything else (`t("..")`, `throw new Error("..")`, etc.) is
+    // `other`. We tag it with the callee identifier when the receiver is
+    // a bare identifier, so the rule classifier can match `console.log`,
+    // `JSON.parse`, etc., without affecting the LLM-visible payload.
+    case "arguments": {
+      const call = parent.parent();
+      const head = call ? firstNamedChild(call) : null;
+      if (call?.kind() === "new_expression") {
+        if (head?.kind() === "identifier" && head.text() === "RegExp") {
+          return { parentRole: "regex_pattern", identifiers: [] };
+        }
+      } else if (call?.kind() === "call_expression") {
+        if (head?.kind() === "identifier" && head.text() === "require") {
+          return { parentRole: "import", identifiers: [] };
+        }
+        if (head?.kind() === "import") {
+          return { parentRole: "import", identifiers: [] };
+        }
+      }
+      const { callee, calleeMember } = extractJsCallee(head);
+      return { parentRole: "other", identifiers: [], callee, calleeMember };
+    }
+
+    // Object literal entry: `{ key: value }`. ast-grep models both the
+    // key and the value as children of a `pair` node, so we check
+    // whether our string IS the first named child (the key) or sits in
+    // the value slot.
+    //
+    //   { "label": "Hello" }    "label" is object_key (dropped),
+    //                           "Hello" is other (emitted)
+    case "pair": {
+      const firstNamed = firstNamedChild(parent);
+      const isKey = firstNamed && rangesMatch(firstNamed, node);
+      return { parentRole: isKey ? "object_key" : "other", identifiers: [] };
+    }
+
+    // `obj["key"]`. The string is being used as a property name lookup,
+    // never user-facing.
+    case "subscript_expression":
+      return { parentRole: "index_access", identifiers: [] };
+
+    // `x === "foo"` and the !=/==/!== variants. This is almost always a
+    // type or tag narrowing check against a fixed token, not displayable
+    // text. We detect the equality operator by looking for an unnamed
+    // child token matching the operator. Anything else under a
+    // binary_expression (for example `prefix + "suffix"` for string
+    // concat) is ambiguous, so we let it through as `other`.
+    case "binary_expression":
+      for (const child of parent.children()) {
+        if (!child.isNamed() && /^(===?|!==?)$/.test(child.text())) {
+          return { parentRole: "type_tag", identifiers: [] };
+        }
+      }
+      return { parentRole: "other", identifiers: [] };
+
+    // `case "foo":` and `default:`. Switch discriminants are tags, not
+    // user-facing text.
+    case "switch_case":
+    case "switch_default":
+      return { parentRole: "type_tag", identifiers: [] };
+
+    // All forms of import/export specifier and module path. The string
+    // here is a module path, never user-facing.
+    //
+    //   import x from "y";   import { x } from "y";   require("y");
+    //   export * from "y";   export { x } from "y";
+    case "import_statement":
+    case "import_specifier":
+    case "import_clause":
+    case "import_require_clause":
+    case "namespace_import":
+    case "export_statement":
+    case "export_specifier":
+      return { parentRole: "import", identifiers: [] };
+
+    // TypeScript type-level positions. Strings here are part of the type
+    // system, not runtime text.
+    //
+    //   type T = "foo";                          (literal_type / type_alias_declaration)
+    //   type T = "a" | "b";                      (union_type)
+    //   type T = ["a", "b"];                     (tuple_type)
+    //   type T = { a: "x" } & { b: "y" };        (intersection_type)
+    case "literal_type":
+    case "type_alias_declaration":
+    case "tuple_type":
+    case "union_type":
+    case "intersection_type":
+      return { parentRole: "type_tag", identifiers: [] };
+
+    // Anything we don't have a specific opinion about: variable
+    // declarations, return statements, throw arguments, JSX children
+    // arrays, ternaries, etc. The LLM gets these as `other` and reads
+    // the source.
+    default:
+      return { parentRole: "other", identifiers: [] };
+  }
+}
+
+/** First child that's a real grammar node. Skips punctuation tokens. */
+function firstNamedChild(node: SgNode): SgNode | null {
+  for (const c of node.children()) if (c.isNamed()) return c;
+  return null;
+}
+
+/**
+ * Pull the callee identifier(s) off a call_expression / new_expression head.
+ * Only recognizes top-level identifiers — `foo(...)` and `Foo.bar(...)`
+ * where `Foo` is itself a bare identifier. `this.log.warn(...)`,
+ * `Logger().info(...)`, and other deeper chains return `{}` so the rule
+ * classifier sees no callee and falls through to the LLM.
+ */
+function extractJsCallee(head: SgNode | null): {
+  callee?: string;
+  calleeMember?: string;
+} {
+  if (!head) return {};
+  if (head.kind() === "identifier") return { callee: head.text() };
+  if (head.kind() === "member_expression") {
+    const named = head.children().filter((c) => c.isNamed());
+    if (named.length < 2) return {};
+    const receiver = named[0];
+    const property = named[named.length - 1];
+    if (receiver.kind() === "identifier") {
+      return { callee: receiver.text(), calleeMember: property.text() };
+    }
+  }
+  return {};
+}
+
+/** True iff two nodes cover exactly the same source range. */
+function rangesMatch(a: SgNode, b: SgNode): boolean {
+  const ra = a.range();
+  const rb = b.range();
+  return ra.start.index === rb.start.index && ra.end.index === rb.end.index;
+}
+
+/** Text of an attribute's name child: `placeholder` from `placeholder="…"`. */
+function jsxAttributeName(attr: SgNode): string | null {
+  return firstNamedChild(attr)?.text() ?? null;
+}
+
+// JSX/HTML tags whose contents are code-shaped, not human copy.
+// If the candidate sits inside one of these anywhere up the chain we
+// suppress parentTag entirely so `markup_text_safe` falls through to the
+// LLM, even when the innermost wrapping tag is something like `<span>`
+// (common in syntax-highlighted code blocks: `<pre><span>...</span></pre>`).
+const CODE_LIKE_JSX_ANCESTORS: ReadonlySet<string> = new Set([
+  "pre",
+  "code",
+  "kbd",
+  "samp",
+  "var",
+  "script",
+  "style",
+]);
+
+/**
+ * For a string-bearing node sitting under JSX, find the immediate
+ * wrapping `jsx_element` and return its tag name, lowercased.
+ * Returns undefined for:
+ *
+ *   - Fragments `<>…</>` (no tag name)
+ *   - Component element names like `<Foo.Bar>` (member expressions);
+ *     the markup_text rule keys on lowercase HTML tag names anyway, so
+ *     missing one of these just routes to the LLM, which is the safe
+ *     default.
+ *   - Nodes inside a code-shaped ancestor (`<pre>`, `<code>`, etc.) even
+ *     when the innermost wrapping tag is otherwise a copy-bearing tag.
+ */
+function enclosingJsxTag(node: SgNode): string | undefined {
+  let candidate = node.parent();
+  if (candidate?.kind() === "jsx_expression") candidate = candidate.parent();
+  if (candidate?.kind() !== "jsx_element") return undefined;
+  if (hasCodeLikeJsxAncestor(candidate)) return undefined;
+  const opening = candidate
+    .children()
+    .find((c) => c.kind() === "jsx_opening_element");
+  if (!opening) return undefined;
+  for (const c of opening.children()) {
+    if (c.kind() === "identifier" || c.kind() === "jsx_identifier")
+      return c.text().toLowerCase();
+  }
+  return undefined;
+}
+
+function hasCodeLikeJsxAncestor(jsxElement: SgNode): boolean {
+  for (let cur: SgNode | null = jsxElement.parent(); cur; cur = cur.parent()) {
+    if (cur.kind() !== "jsx_element") continue;
+    const opening = cur
+      .children()
+      .find((c) => c.kind() === "jsx_opening_element");
+    if (!opening) continue;
+    for (const c of opening.children()) {
+      if (c.kind() !== "identifier" && c.kind() !== "jsx_identifier") continue;
+      if (CODE_LIKE_JSX_ANCESTORS.has(c.text().toLowerCase())) return true;
+      break;
+    }
+  }
+  return false;
+}

--- a/lib/src/scan/lang/extractors/json-i18n.test.ts
+++ b/lib/src/scan/lang/extractors/json-i18n.test.ts
@@ -1,0 +1,60 @@
+import { jsonI18nExtractor } from "./json-i18n";
+
+const extract = (source: string) => jsonI18nExtractor.extract({ source, kind: "json_i18n" });
+
+describe("jsonI18nExtractor", () => {
+  test("emits flat key/value pairs with the key in identifiers", async () => {
+    const source = JSON.stringify({ "home.title": "Welcome", "home.subtitle": "Sign in" }, null, 2);
+    const hits = await extract(source);
+    expect(hits.map((h) => ({ v: h.value, ids: h.context.identifiers }))).toEqual([
+      { v: "Welcome", ids: ["home.title"] },
+      { v: "Sign in", ids: ["home.subtitle"] },
+    ]);
+    expect(hits.every((h) => h.context.parentRole === "resource_value")).toBe(true);
+  });
+
+  test("descends into nested objects, accumulating the key path", async () => {
+    const source = JSON.stringify({ labels: { paste: "Paste", copy: "Copy" } }, null, 2);
+    const hits = await extract(source);
+    expect(hits.map((h) => h.context.identifiers)).toEqual([
+      ["labels", "paste"],
+      ["labels", "copy"],
+    ]);
+  });
+
+  test("splits `_one` / `_other` suffix into [base, variant]", async () => {
+    const source = JSON.stringify({ item_one: "1 item", item_other: "{count} items" }, null, 2);
+    const hits = await extract(source);
+    expect(hits.map((h) => h.context.identifiers)).toEqual([
+      ["item", "one"],
+      ["item", "other"],
+    ]);
+  });
+
+  test("nested plural form keeps the explicit identifier path", async () => {
+    const source = JSON.stringify({ item: { one: "1 item", other: "{count} items" } }, null, 2);
+    const hits = await extract(source);
+    expect(hits.map((h) => h.context.identifiers)).toEqual([
+      ["item", "one"],
+      ["item", "other"],
+    ]);
+  });
+
+  test("emits ICU-shaped values as a single candidate", async () => {
+    const source = JSON.stringify({ item: "{count, plural, one {# item} other {# items}}" }, null, 2);
+    const hits = await extract(source);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].value).toBe("{count, plural, one {# item} other {# items}}");
+  });
+
+  test("skips empty values and non-string leaves", async () => {
+    const source = JSON.stringify({ a: "", b: "  ", c: 42, d: true, e: null, f: "real" });
+    const hits = await extract(source);
+    expect(hits.map((h) => h.value)).toEqual(["real"]);
+  });
+
+  test("returns empty for invalid JSON or a non-object root", async () => {
+    expect(await extract(`not json`)).toEqual([]);
+    expect(await extract(`["a", "b"]`)).toEqual([]);
+  });
+});

--- a/lib/src/scan/lang/extractors/json-i18n.ts
+++ b/lib/src/scan/lang/extractors/json-i18n.ts
@@ -1,0 +1,270 @@
+import type { ExtractedHit, LanguageExtractor } from "../types";
+import { offsetToLineCol } from "./util";
+
+/**
+ * Web i18n JSON catalogs. Covers the formats used by i18next, react-intl /
+ * formatjs, react-i18next, vue-i18n, next-intl, etc.
+ *
+ * Two top-level shapes are accepted:
+ *
+ *   Flat (formatjs / react-intl default):
+ *     { "home.title": "Welcome", "home.subtitle": "Sign in" }
+ *
+ *   Nested (i18next default):
+ *     { "labels": { "paste": "Paste" }, "errors": { "fileTooBig": "..." } }
+ *
+ * Plural variants come in three flavours:
+ *   - i18next suffix:  { "item_one": "1 item", "item_other": "{count} items" }
+ *   - i18next nested:  { "item": { "one": "1 item", "other": "{count} items" } }
+ *   - ICU MessageFormat: { "item": "{count, plural, one {# item} other {# items}}" }
+ *
+ * The suffix form is split into [base, variant] so it surfaces the same way
+ * as the nested form ([key, variant]). ICU strings are emitted as a single
+ * candidate without parsing the body — the downstream LLM phase handles it.
+ *
+ * Positions come from a location-aware JSON parser so identical string
+ * values under different keys still get unique (line, column) — required
+ * for stable candidate ids.
+ */
+// No content-shape gate: the walker only dispatches this extractor on
+// files the LLM has already confirmed as i18n, so we emit every string
+// leaf even when localized text is mixed with numeric/array metadata.
+export const jsonI18nExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const root = parseJson(source);
+    if (!root || root.kind !== "object") return [];
+    const out: ExtractedHit[] = [];
+    walk(root, [], source, out);
+    return out;
+  },
+};
+
+const PLURAL_SUFFIX_RE = /^(.+)_(zero|one|two|few|many|other)$/;
+
+function walk(node: JsonNode, path: string[], source: string, out: ExtractedHit[]): void {
+  if (node.kind === "string") {
+    if (node.value.trim().length === 0) return;
+    let identifiers = path;
+    if (path.length > 0) {
+      const m = PLURAL_SUFFIX_RE.exec(path[path.length - 1]);
+      if (m) identifiers = [...path.slice(0, -1), m[1], m[2]];
+    }
+    out.push({
+      value: node.value,
+      location: offsetToLineCol(source, node.start),
+      context: { parentRole: "resource_value", identifiers },
+    });
+    return;
+  }
+  if (node.kind === "object") {
+    for (const entry of node.entries) {
+      walk(entry.value, [...path, entry.key], source, out);
+    }
+    return;
+  }
+  if (node.kind === "array") {
+    for (let i = 0; i < node.items.length; i++) {
+      walk(node.items[i], [...path, String(i)], source, out);
+    }
+  }
+  // Numbers, bool, null: not user-facing copy at the leaf level.
+}
+
+interface JsonString {
+  kind: "string";
+  value: string;
+  start: number;
+  end: number;
+}
+interface JsonObject {
+  kind: "object";
+  entries: Array<{ key: string; value: JsonNode }>;
+  start: number;
+  end: number;
+}
+interface JsonArray {
+  kind: "array";
+  items: JsonNode[];
+  start: number;
+  end: number;
+}
+interface JsonAtom {
+  kind: "number" | "bool" | "null";
+  start: number;
+  end: number;
+}
+type JsonNode = JsonString | JsonObject | JsonArray | JsonAtom;
+
+function parseJson(source: string): JsonNode | null {
+  const ctx = { src: source, i: 0 };
+  skipWs(ctx);
+  try {
+    const node = parseValue(ctx);
+    skipWs(ctx);
+    if (ctx.i !== ctx.src.length) return null;
+    return node;
+  } catch {
+    return null;
+  }
+}
+
+interface Ctx {
+  src: string;
+  i: number;
+}
+
+function parseValue(ctx: Ctx): JsonNode {
+  skipWs(ctx);
+  const ch = ctx.src[ctx.i];
+  if (ch === '"') return parseString(ctx);
+  if (ch === "{") return parseObject(ctx);
+  if (ch === "[") return parseArray(ctx);
+  if (ch === "t" || ch === "f") return parseBool(ctx);
+  if (ch === "n") return parseNull(ctx);
+  return parseNumber(ctx);
+}
+
+function parseString(ctx: Ctx): JsonString {
+  const start = ctx.i;
+  if (ctx.src[ctx.i] !== '"') throw new Error("expected string");
+  ctx.i++;
+  let value = "";
+  while (ctx.i < ctx.src.length) {
+    const ch = ctx.src[ctx.i];
+    if (ch === "\\") {
+      const next = ctx.src[ctx.i + 1];
+      ctx.i += 2;
+      switch (next) {
+        case '"':
+          value += '"';
+          break;
+        case "\\":
+          value += "\\";
+          break;
+        case "/":
+          value += "/";
+          break;
+        case "b":
+          value += "\b";
+          break;
+        case "f":
+          value += "\f";
+          break;
+        case "n":
+          value += "\n";
+          break;
+        case "r":
+          value += "\r";
+          break;
+        case "t":
+          value += "\t";
+          break;
+        case "u": {
+          const hex = ctx.src.slice(ctx.i, ctx.i + 4);
+          ctx.i += 4;
+          value += String.fromCharCode(parseInt(hex, 16));
+          break;
+        }
+        default:
+          value += next ?? "";
+      }
+      continue;
+    }
+    if (ch === '"') {
+      ctx.i++;
+      return { kind: "string", value, start, end: ctx.i };
+    }
+    value += ch;
+    ctx.i++;
+  }
+  throw new Error("unterminated string");
+}
+
+function parseObject(ctx: Ctx): JsonObject {
+  const start = ctx.i;
+  ctx.i++; // {
+  skipWs(ctx);
+  const entries: Array<{ key: string; value: JsonNode }> = [];
+  if (ctx.src[ctx.i] === "}") {
+    ctx.i++;
+    return { kind: "object", entries, start, end: ctx.i };
+  }
+  while (ctx.i < ctx.src.length) {
+    skipWs(ctx);
+    const keyNode = parseString(ctx);
+    skipWs(ctx);
+    if (ctx.src[ctx.i] !== ":") throw new Error("expected colon");
+    ctx.i++;
+    const value = parseValue(ctx);
+    entries.push({ key: keyNode.value, value });
+    skipWs(ctx);
+    if (ctx.src[ctx.i] === ",") {
+      ctx.i++;
+      continue;
+    }
+    if (ctx.src[ctx.i] === "}") {
+      ctx.i++;
+      break;
+    }
+    throw new Error("expected , or }");
+  }
+  return { kind: "object", entries, start, end: ctx.i };
+}
+
+function parseArray(ctx: Ctx): JsonArray {
+  const start = ctx.i;
+  ctx.i++; // [
+  skipWs(ctx);
+  const items: JsonNode[] = [];
+  if (ctx.src[ctx.i] === "]") {
+    ctx.i++;
+    return { kind: "array", items, start, end: ctx.i };
+  }
+  while (ctx.i < ctx.src.length) {
+    items.push(parseValue(ctx));
+    skipWs(ctx);
+    if (ctx.src[ctx.i] === ",") {
+      ctx.i++;
+      continue;
+    }
+    if (ctx.src[ctx.i] === "]") {
+      ctx.i++;
+      break;
+    }
+    throw new Error("expected , or ]");
+  }
+  return { kind: "array", items, start, end: ctx.i };
+}
+
+function parseBool(ctx: Ctx): JsonAtom {
+  const start = ctx.i;
+  if (ctx.src.startsWith("true", ctx.i)) ctx.i += 4;
+  else if (ctx.src.startsWith("false", ctx.i)) ctx.i += 5;
+  else throw new Error("expected bool");
+  return { kind: "bool", start, end: ctx.i };
+}
+
+function parseNull(ctx: Ctx): JsonAtom {
+  const start = ctx.i;
+  if (!ctx.src.startsWith("null", ctx.i)) throw new Error("expected null");
+  ctx.i += 4;
+  return { kind: "null", start, end: ctx.i };
+}
+
+function parseNumber(ctx: Ctx): JsonAtom {
+  const start = ctx.i;
+  const re = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
+  re.lastIndex = ctx.i;
+  const m = re.exec(ctx.src);
+  if (!m) throw new Error("expected number");
+  ctx.i += m[0].length;
+  return { kind: "number", start, end: ctx.i };
+}
+
+function skipWs(ctx: Ctx): void {
+  while (ctx.i < ctx.src.length) {
+    const ch = ctx.src.charCodeAt(ctx.i);
+    if (ch === 32 || ch === 9 || ch === 10 || ch === 13) ctx.i++;
+    else break;
+  }
+}

--- a/lib/src/scan/lang/extractors/kotlin.test.ts
+++ b/lib/src/scan/lang/extractors/kotlin.test.ts
@@ -1,0 +1,55 @@
+// Side-effect import: registers the dynamic Kotlin grammar with ast-grep.
+import "../registry";
+
+import { kotlinExtractor } from "./kotlin";
+
+const extract = (source: string) => kotlinExtractor.extract({ source, kind: "kotlin" });
+
+describe("kotlinExtractor", () => {
+  test("equality and `when` arms are type_tag", async () => {
+    const source = [
+      `fun f(x: String): Int {`,
+      `  if (x == "foo") return 1`,
+      `  return when (x) { "bar" -> 2; else -> 0 }`,
+      `}`,
+      ``,
+    ].join("\n");
+    const hits = await extract(source);
+    const foo = hits.find((h) => h.value === '"foo"');
+    const bar = hits.find((h) => h.value === '"bar"');
+    expect(foo?.context.parentRole).toBe("type_tag");
+    expect(bar?.context.parentRole).toBe("type_tag");
+  });
+
+  test('mapOf `"k" to v` marks the left operand as object_key', async () => {
+    const source = `val m = mapOf("alpha" to 1, "beta" to 2)\n`;
+    const hits = await extract(source);
+    const alpha = hits.find((h) => h.value === '"alpha"');
+    expect(alpha?.context.parentRole).toBe("object_key");
+  });
+
+  test("Regex constructor argument is regex_pattern", async () => {
+    const hits = await extract(`val r = Regex("^foo$")\n`);
+    const pat = hits.find((h) => h.value === '"^foo$"');
+    expect(pat?.context.parentRole).toBe("regex_pattern");
+  });
+
+  test("captures callee/calleeMember/methodName for known call shapes", async () => {
+    const source = [
+      `fun f() {`,
+      `  println("a")`,
+      `  Log.d(TAG, "b")`,
+      `  AlertDialog.Builder(ctx).setTitle("c")`,
+      `}`,
+      ``,
+    ].join("\n");
+    const hits = await extract(source);
+    const a = hits.find((h) => h.value === '"a"');
+    const b = hits.find((h) => h.value === '"b"');
+    const c = hits.find((h) => h.value === '"c"');
+    expect(a?.context).toMatchObject({ parentRole: "other", callee: "println" });
+    expect(b?.context).toMatchObject({ parentRole: "other", callee: "Log", calleeMember: "d", methodName: "d" });
+    expect(c?.context).toMatchObject({ parentRole: "other", methodName: "setTitle" });
+    expect(c?.context.callee).toBeUndefined();
+  });
+});

--- a/lib/src/scan/lang/extractors/kotlin.ts
+++ b/lib/src/scan/lang/extractors/kotlin.ts
@@ -1,0 +1,215 @@
+import { parse, type SgNode } from "@ast-grep/napi";
+
+import type { DittoScanEnclosingContext } from "../../types";
+import type { ExtractedHit, LanguageExtractor } from "../types";
+
+/**
+ * Kotlin string extractor. Tree-sitter's Kotlin grammar models all
+ * string forms (`"..."`, `"""..."""`, and interpolated `"hi $x"`) as a
+ * single `string_literal` node. We emit one hit per literal and let the
+ * raw source — interpolation markers and all — flow through unchanged,
+ * the same way the JS extractor handles `template_string`.
+ *
+ * Character literals (`'a'`) are not strings and are skipped.
+ */
+export const kotlinExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const root = parse("kotlin", source).root();
+    const out: ExtractedHit[] = [];
+
+    for (const node of root.findAll({ rule: { kind: "string_literal" } })) {
+      // Skip nested string literals inside interpolations — they will be
+      // visited as their own top-level hit by the same `findAll` scan.
+      if (isInsideInterpolation(node)) continue;
+      const { line, column } = node.range().start;
+      out.push({
+        value: node.text(),
+        location: { line: line + 1, column: column + 1 },
+        context: classifyKtParent(node),
+      });
+    }
+
+    return out;
+  },
+};
+
+/**
+ * `"outer ${ "inner" }"` produces two `string_literal` nodes — the
+ * outer one and the inner one inside the `interpolated_expression`.
+ * We want the outer literal only; the inner is part of its source text.
+ */
+function isInsideInterpolation(node: SgNode): boolean {
+  for (let cur = node.parent(); cur; cur = cur.parent()) {
+    if (cur.kind() === "interpolated_expression") return true;
+  }
+  return false;
+}
+
+/**
+ * Look at the AST node that contains the string and decide what kind of
+ * position the string is sitting in. Mirrors `classifyJsParent` in
+ * `javascript.ts`: cheap, confident exclusions only. Everything we don't
+ * have an opinion about falls through to `other` and the LLM gets to
+ * read `source_context`.
+ *
+ *   `import`         `import com.foo.Bar`, `package com.foo`
+ *   `regex_pattern`  `Regex("...")`
+ *   `object_key`     `"key" to value` in `mapOf(...)` and other pair builders
+ *   `index_access`   `map["key"]`
+ *   `type_tag`       `x == "foo"`, `when (x) { "foo" -> ... }`,
+ *                    annotation arguments (`@Foo("x")`)
+ */
+function classifyKtParent(node: SgNode): DittoScanEnclosingContext {
+  const parent = node.parent();
+  if (!parent) return { parentRole: "other", identifiers: [] };
+  const pk = parent.kind() as string;
+
+  switch (pk) {
+    case "package_header":
+    case "import_header":
+      return { parentRole: "import", identifiers: [] };
+
+    case "equality_expression":
+      return { parentRole: "type_tag", identifiers: [] };
+
+    case "when_condition":
+      return { parentRole: "type_tag", identifiers: [] };
+
+    case "indexing_suffix":
+      return { parentRole: "index_access", identifiers: [] };
+
+    // `"k" to v` inside `mapOf(...)`. The infix operator is the
+    // identifier `to`; if our string is the left operand it's a key.
+    case "infix_expression": {
+      const opIsTo = parent
+        .children()
+        .filter((c) => c.kind() === "simple_identifier")
+        .some((c) => c.text() === "to");
+      if (!opIsTo) return { parentRole: "other", identifiers: [] };
+      const firstNamed = firstNamedChild(parent);
+      const isLeft = firstNamed !== null && rangesMatch(firstNamed, node);
+      return { parentRole: isLeft ? "object_key" : "other", identifiers: [] };
+    }
+
+    // Direct argument to a call. We special-case the `Regex("...")`
+    // constructor; everything else (`println("...")`, `Log.d(...)`,
+    // `Text("Compose hello")`, ...) is `other` but gets tagged with the
+    // bare-identifier callee so reject/accept rules can match.
+    case "value_argument": {
+      const args = parent.parent(); // value_arguments
+      const suffix = args?.parent(); // call_suffix
+      const call = suffix?.parent(); // call_expression
+      if (call?.kind() === "call_expression") {
+        const head = firstNamedChild(call);
+        if (head?.kind() === "simple_identifier" && head.text() === "Regex") {
+          return { parentRole: "regex_pattern", identifiers: [] };
+        }
+        const { callee, calleeMember, methodName } = extractKtCallee(head);
+        if (callee || methodName) {
+          return {
+            parentRole: "other",
+            identifiers: [],
+            callee,
+            calleeMember,
+            methodName,
+          };
+        }
+      }
+      return { parentRole: "other", identifiers: [] };
+    }
+
+    // Annotation arguments parse as a `prefix_expression` whose children
+    // are the `annotation` (just `@Name`) and a `parenthesized_expression`
+    // holding the actual args. Anything sitting inside that paren group is
+    // an annotation argument.
+    case "parenthesized_expression": {
+      const grand = parent.parent();
+      if (grand?.kind() === "prefix_expression") {
+        const hasAnnotation = grand
+          .children()
+          .some((c) => c.kind() === "annotation");
+        if (hasAnnotation) return { parentRole: "type_tag", identifiers: [] };
+      }
+      return { parentRole: "other", identifiers: [] };
+    }
+
+    default:
+      return { parentRole: "other", identifiers: [] };
+  }
+}
+
+function firstNamedChild(node: SgNode): SgNode | null {
+  for (const c of node.children()) if (c.isNamed()) return c;
+  return null;
+}
+
+/**
+ * Pull identifying pieces off a Kotlin call_expression head. Returns three
+ * fields with different match strictness:
+ *
+ *   `callee` / `calleeMember`  — set only when the receiver is a bare
+ *     identifier (or absent). Strict; used by reject rules where receiver
+ *     certainty matters.
+ *   `methodName`               — set whenever the head is a navigation_
+ *     expression with a final method identifier, regardless of receiver
+ *     shape. Lets accept rules match chained calls like
+ *     `AlertDialog.Builder(ctx).setTitle("X")` or `label.setText("X")`.
+ *
+ * Examples:
+ *
+ *   `println("x")`                   callee="println"
+ *   `Log.d(TAG, "x")`                callee="Log", calleeMember="d", methodName="d"
+ *   `Timber.d("x")`                  callee="Timber", calleeMember="d", methodName="d"
+ *   `myObj.warn("x")`                callee="myObj", calleeMember="warn", methodName="warn"
+ *   `Builder(ctx).setTitle("x")`     methodName="setTitle"        (no callee — receiver is a call)
+ *   `foo.bar.baz("x")`               methodName="baz"             (no callee — receiver is a navigation)
+ *
+ * The receiver-is-bare trade-off on `callee`/`calleeMember` is unchanged:
+ * an instance variable named `Log` or `Timber` would still misclassify
+ * (variables of those names would be unusual).
+ */
+function extractKtCallee(head: SgNode | null): {
+  callee?: string;
+  calleeMember?: string;
+  methodName?: string;
+} {
+  if (!head) return {};
+  if (head.kind() === "simple_identifier") return { callee: head.text() };
+  if (head.kind() === "navigation_expression") {
+    const named = head.children().filter((c) => c.isNamed());
+    if (named.length < 2) return {};
+    const receiver = named[0];
+    const last = named[named.length - 1];
+    const methodName = navigationFinalIdentifier(last);
+    if (!methodName) return {};
+    if (receiver.kind() === "simple_identifier") {
+      return { callee: receiver.text(), calleeMember: methodName, methodName };
+    }
+    return { methodName };
+  }
+  return {};
+}
+
+/**
+ * Read the trailing identifier off a navigation_expression's last named
+ * child. Handles both the `simple_identifier` case (`foo.bar` where the
+ * final child is `bar`) and the wrapped `navigation_suffix` case
+ * (`foo.bar` parsed with the suffix containing `bar` as its inner
+ * identifier).
+ */
+function navigationFinalIdentifier(last: SgNode): string | undefined {
+  if (last.kind() === "simple_identifier") return last.text();
+  if (last.kind() === "navigation_suffix") {
+    const inner = last
+      .children()
+      .filter((c) => c.isNamed() && c.kind() === "simple_identifier")[0];
+    if (inner) return inner.text();
+  }
+  return undefined;
+}
+
+function rangesMatch(a: SgNode, b: SgNode): boolean {
+  const ra = a.range();
+  const rb = b.range();
+  return ra.start.index === rb.start.index && ra.end.index === rb.end.index;
+}

--- a/lib/src/scan/lang/extractors/po.test.ts
+++ b/lib/src/scan/lang/extractors/po.test.ts
@@ -1,0 +1,69 @@
+import { poExtractor } from "./po";
+
+const extract = (source: string) => poExtractor.extract({ source, kind: "po" });
+
+describe("poExtractor", () => {
+  test("emits msgstr when present, falls back to msgid when empty", async () => {
+    const source = [
+      `msgid ""`,
+      `msgstr ""`,
+      ``,
+      `msgid "Hello"`,
+      `msgstr "Bonjour"`,
+      ``,
+      `msgid "Goodbye"`,
+      `msgstr ""`,
+      ``,
+    ].join("\n");
+    const hits = await extract(source);
+    expect(hits).toHaveLength(2);
+    expect(hits[0].value).toBe("Bonjour");
+    expect(hits[0].context.identifiers).toEqual(["Hello"]);
+    expect(hits[1].value).toBe("Goodbye");
+    expect(hits[1].context.identifiers).toEqual(["Goodbye"]);
+    expect(hits[0].context.parentRole).toBe("resource_value");
+  });
+
+  test("skips the empty header entry", async () => {
+    const hits = await extract(`msgid ""\nmsgstr "Content-Type: text/plain"\n`);
+    expect(hits).toEqual([]);
+  });
+
+  test("emits one hit per plural index, tagged plural:N", async () => {
+    const source = [
+      `msgid "%d item"`,
+      `msgid_plural "%d items"`,
+      `msgstr[0] "%d item"`,
+      `msgstr[1] "%d items"`,
+      ``,
+    ].join("\n");
+    const hits = await extract(source);
+    expect(hits).toHaveLength(2);
+    expect(hits[0].value).toBe("%d item");
+    expect(hits[0].context.identifiers).toEqual(["%d item", "plural:0"]);
+    expect(hits[1].value).toBe("%d items");
+    expect(hits[1].context.identifiers).toEqual(["%d item", "plural:1"]);
+  });
+
+  test("includes msgctxt as the first identifier when present", async () => {
+    const source = [`msgctxt "menu"`, `msgid "File"`, `msgstr "Fichier"`, ``].join("\n");
+    const hits = await extract(source);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].context.identifiers).toEqual(["menu", "File"]);
+  });
+
+  test("concatenates continuation lines", async () => {
+    const source = [`msgid "Hello, "`, `"world"`, `msgstr "Bonjour, "`, `"le monde"`, ``].join("\n");
+    const hits = await extract(source);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].value).toBe("Bonjour, le monde");
+    expect(hits[0].context.identifiers).toEqual(["Hello, world"]);
+  });
+
+  test("ignores PO comments", async () => {
+    const source = [`# translator comment`, `#. extracted`, `msgid "Save"`, `msgstr "Save"`, ``].join("\n");
+    const hits = await extract(source);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].value).toBe("Save");
+  });
+});

--- a/lib/src/scan/lang/extractors/po.ts
+++ b/lib/src/scan/lang/extractors/po.ts
@@ -1,0 +1,208 @@
+import type { ExtractedHit, LanguageExtractor } from "../types";
+
+// Gettext `.po` files (Lingui, GNU gettext, Django, Crowdin, …).
+//
+// PO uses `msgid` as both the lookup key and the source-language text;
+// `msgstr` holds the locale-specific translation. We emit:
+//   value_raw            msgstr if non-empty, else msgid
+//   context_identifiers  [msgctxt?, msgid, plural_tag?]
+// Putting msgid in identifiers collapses the same logical entry across
+// locale files when downstream groups by identifiers.
+//
+// Plural entries (msgid + msgid_plural) emit one candidate per plural
+// index, tagged `plural:<idx>` (0 = singular, 1 = plural, additional
+// indexes for languages with more forms). The empty `msgid ""` header
+// is skipped.
+export const poExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const lines = source.split(/\r?\n/);
+    const out: ExtractedHit[] = [];
+
+    let entry: PoEntry | null = null;
+    const flush = () => {
+      if (entry) emit(entry, out);
+      entry = null;
+    };
+
+    let i = 0;
+    while (i < lines.length) {
+      const rawLine = lines[i];
+      const line = rawLine.trim();
+
+      if (line === "") {
+        flush();
+        i++;
+        continue;
+      }
+
+      // PO comments (`#`, `#.`, `#:`, `#,`, `#|`).
+      if (line.startsWith("#")) {
+        i++;
+        continue;
+      }
+
+      const keyword = matchKeyword(line);
+      if (!keyword) {
+        i++;
+        continue;
+      }
+
+      if (!entry) entry = {};
+
+      // PO strings may continue on adjacent double-quoted lines.
+      const initial = parsePoString(line.slice(keyword.consumed));
+      let acc = initial ?? "";
+      const startLine = i + 1; // 1-based
+      let j = i + 1;
+      while (j < lines.length) {
+        const nextTrim = lines[j].trim();
+        if (!nextTrim.startsWith('"')) break;
+        const continued = parsePoString(nextTrim);
+        if (continued === null) break;
+        acc += continued;
+        j++;
+      }
+      i = j;
+
+      switch (keyword.kind) {
+        case "msgctxt":
+          entry.msgctxt = acc;
+          break;
+        case "msgid":
+          entry.msgid = acc;
+          entry.msgidLine = startLine;
+          break;
+        case "msgid_plural":
+          entry.msgidPlural = acc;
+          entry.msgidPluralLine = startLine;
+          break;
+        case "msgstr":
+          entry.msgstr = acc;
+          break;
+        case "msgstr_indexed":
+          if (!entry.msgstrPlural) entry.msgstrPlural = new Map();
+          entry.msgstrPlural.set(keyword.index ?? 0, acc);
+          break;
+      }
+    }
+    flush();
+
+    return out;
+  },
+};
+
+interface PoEntry {
+  msgctxt?: string;
+  msgid?: string;
+  msgidLine?: number;
+  msgidPlural?: string;
+  msgidPluralLine?: number;
+  msgstr?: string;
+  msgstrPlural?: Map<number, string>;
+}
+
+function emit(entry: PoEntry, out: ExtractedHit[]): void {
+  // Skip header entry (`msgid ""`).
+  if (entry.msgid === undefined || entry.msgid === "") return;
+
+  const ctxtIds = entry.msgctxt ? [entry.msgctxt] : [];
+
+  if (entry.msgidPlural !== undefined) {
+    const plural = entry.msgstrPlural ?? new Map<number, string>();
+    // Always consider indexes 0 (singular) and 1 (plural) even when no
+    // translation is present, so the source msgid/msgidPlural still
+    // surface in base-locale catalogs.
+    const indexes = new Set<number>([0, 1, ...plural.keys()]);
+    for (const idx of [...indexes].sort((a, b) => a - b)) {
+      const source = idx === 0 ? entry.msgid : entry.msgidPlural;
+      if (source === undefined) continue;
+      const value = pickNonEmpty(plural.get(idx), source);
+      if (value === null) continue;
+      const line = idx === 0 ? entry.msgidLine : entry.msgidPluralLine;
+      if (line === undefined) continue;
+      out.push({
+        value,
+        location: { line, column: 1 },
+        context: { parentRole: "resource_value", identifiers: [...ctxtIds, entry.msgid, `plural:${idx}`] },
+      });
+    }
+    return;
+  }
+
+  const value = pickNonEmpty(entry.msgstr, entry.msgid);
+  if (value === null || entry.msgidLine === undefined) return;
+  out.push({
+    value,
+    location: { line: entry.msgidLine, column: 1 },
+    context: { parentRole: "resource_value", identifiers: [...ctxtIds, entry.msgid] },
+  });
+}
+
+function pickNonEmpty(translated: string | undefined, source: string): string | null {
+  if (translated !== undefined && translated.trim().length > 0) return translated;
+  if (source.trim().length > 0) return source;
+  return null;
+}
+
+interface KeywordMatch {
+  kind: "msgctxt" | "msgid" | "msgid_plural" | "msgstr" | "msgstr_indexed";
+  consumed: number;
+  index?: number;
+}
+
+// Longest-prefix-first so `msgid_plural` doesn't match as `msgid` and
+// `msgstr[N]` doesn't match as plain `msgstr`.
+const KEYWORD_RE = /^(msgctxt|msgid_plural|msgid|msgstr\[(\d+)\]|msgstr)\s+/;
+
+function matchKeyword(line: string): KeywordMatch | null {
+  const m = KEYWORD_RE.exec(line);
+  if (!m) return null;
+  const raw = m[1];
+  if (raw === "msgctxt") return { kind: "msgctxt", consumed: m[0].length };
+  if (raw === "msgid_plural") return { kind: "msgid_plural", consumed: m[0].length };
+  if (raw === "msgid") return { kind: "msgid", consumed: m[0].length };
+  if (raw === "msgstr") return { kind: "msgstr", consumed: m[0].length };
+  return { kind: "msgstr_indexed", consumed: m[0].length, index: Number(m[2]) };
+}
+
+// Returns null if the input isn't a complete double-quoted PO string.
+function parsePoString(s: string): string | null {
+  const trimmed = s.trim();
+  if (!trimmed.startsWith('"')) return null;
+  let value = "";
+  let i = 1;
+  while (i < trimmed.length) {
+    const ch = trimmed[i];
+    if (ch === "\\") {
+      const next = trimmed[i + 1];
+      i += 2;
+      switch (next) {
+        case "n":
+          value += "\n";
+          break;
+        case "t":
+          value += "\t";
+          break;
+        case "r":
+          value += "\r";
+          break;
+        case "\\":
+          value += "\\";
+          break;
+        case '"':
+          value += '"';
+          break;
+        case "0":
+          value += "\0";
+          break;
+        default:
+          value += next ?? "";
+      }
+      continue;
+    }
+    if (ch === '"') return value;
+    value += ch;
+    i++;
+  }
+  return null;
+}

--- a/lib/src/scan/lang/extractors/properties.ts
+++ b/lib/src/scan/lang/extractors/properties.ts
@@ -1,0 +1,93 @@
+import type { ExtractedHit, LanguageExtractor } from "../types";
+
+/**
+ * Java `.properties` resource bundles (messages_en.properties, labels.properties, …).
+ *
+ * Format: each logical line is `KEY<sep>VALUE` where `<sep>` is `=`, `:`, or
+ * unescaped whitespace. Lines starting with `#` or `!` are comments. A value
+ * continues onto the next physical line when the previous one ends with an
+ * unescaped trailing `\`.
+ *
+ * The walker only dispatches this extractor on files the LLM has confirmed
+ * as i18n (i.e. not Spring/log4j config), so every key-value pair emits a
+ * `resource_value` hit. Escapes (`\n`, `\\`, `\uXXXX`, …) are kept verbatim
+ * in the value — same approach as the iOS .strings extractor.
+ */
+export const propertiesExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const out: ExtractedHit[] = [];
+    const lines = source.split(/\r?\n/);
+    let i = 0;
+    while (i < lines.length) {
+      const startIdx = i;
+      const first = lines[i];
+      const stripped = stripLeadingWs(first);
+      if (stripped === "" || stripped.startsWith("#") || stripped.startsWith("!")) {
+        i++;
+        continue;
+      }
+
+      let logical = stripped;
+      i++;
+      while (endsWithContinuation(logical) && i < lines.length) {
+        logical = logical.slice(0, -1) + stripLeadingWs(lines[i]);
+        i++;
+      }
+
+      const parsed = splitKeyValue(logical);
+      if (!parsed) continue;
+      const { key, value } = parsed;
+      if (value.trim().length === 0) continue;
+
+      const keyColumn = first.length - stripped.length + 1;
+      out.push({
+        value,
+        location: { line: startIdx + 1, column: keyColumn },
+        context: { parentRole: "resource_value", identifiers: [key] },
+      });
+    }
+    return out;
+  },
+};
+
+function stripLeadingWs(line: string): string {
+  let i = 0;
+  while (i < line.length) {
+    const ch = line.charCodeAt(i);
+    if (ch === 32 || ch === 9 || ch === 12) i++;
+    else break;
+  }
+  return line.slice(i);
+}
+
+function endsWithContinuation(line: string): boolean {
+  let backslashes = 0;
+  for (let i = line.length - 1; i >= 0; i--) {
+    if (line[i] === "\\") backslashes++;
+    else break;
+  }
+  return backslashes % 2 === 1;
+}
+
+// Splits at the first unescaped `=`, `:`, or whitespace. Flanking
+// whitespace and an optional `=`/`:` are dropped per the spec.
+function splitKeyValue(line: string): { key: string; value: string } | null {
+  let i = 0;
+  let key = "";
+  while (i < line.length) {
+    const ch = line[i];
+    if (ch === "\\" && i + 1 < line.length) {
+      key += ch + line[i + 1];
+      i += 2;
+      continue;
+    }
+    if (ch === "=" || ch === ":" || ch === " " || ch === "\t" || ch === "\f") break;
+    key += ch;
+    i++;
+  }
+  if (key === "") return null;
+  while (i < line.length && (line[i] === " " || line[i] === "\t" || line[i] === "\f")) i++;
+  if (i < line.length && (line[i] === "=" || line[i] === ":")) i++;
+  while (i < line.length && (line[i] === " " || line[i] === "\t" || line[i] === "\f")) i++;
+  return { key, value: line.slice(i) };
+}

--- a/lib/src/scan/lang/extractors/resx.ts
+++ b/lib/src/scan/lang/extractors/resx.ts
@@ -1,0 +1,84 @@
+import { Lang, parse, type SgNode } from "@ast-grep/napi";
+
+import type { ExtractedHit, LanguageExtractor } from "../types";
+import { offsetToLineCol } from "./util";
+import { elementAttribute, emitTextHit, tagName } from "./xml";
+
+/**
+ * .NET resource files (`.resx` / `.resw`). Format:
+ *
+ *   <root>
+ *     <resheader name="version"><value>2.0</value></resheader>     <!-- file metadata -->
+ *     <data name="hello" xml:space="preserve">
+ *       <value>Hello</value>
+ *       <comment>greeting</comment>
+ *     </data>
+ *     <data name="logo" type="System.Resources.ResXFileRef, ...">  <!-- non-string -->
+ *       <value>logo.png;System.Drawing.Bitmap, ...</value>
+ *     </data>
+ *     <data name="blob" mimetype="application/x-microsoft.net.object.bytearray.base64">
+ *       <value>iVBORw0KGgo...</value>                               <!-- binary -->
+ *     </data>
+ *   </root>
+ *
+ * Emit `<value>` text for `<data>` entries with neither `type` nor
+ * `mimetype` set (the string-valued ones). `<resheader>` and `<comment>`
+ * children are skipped.
+ */
+export const resxExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const root = parse(Lang.Html, source).root();
+    const out: ExtractedHit[] = [];
+
+    for (const el of root.findAll({ rule: { kind: "element" } })) {
+      if (tagName(el) !== "data") continue;
+      if (elementAttribute(el, "type") !== null) continue;
+      if (elementAttribute(el, "mimetype") !== null) continue;
+      const name = elementAttribute(el, "name") ?? "";
+      const valueEl = findChildElement(el, "value");
+      if (!valueEl) continue;
+      emitTextHit(valueEl, [name], out, source);
+    }
+
+    emitCdataValues(source, out);
+    return out;
+  },
+};
+
+function findChildElement(parent: SgNode, name: string): SgNode | null {
+  for (const child of parent.children()) {
+    if (child.kind() !== "element") continue;
+    if (tagName(child) === name) return child;
+  }
+  return null;
+}
+
+// CDATA recovery for `<data name="..."><value><![CDATA[...]]></value>…</data>`.
+// Has to be parent-aware (regex includes the surrounding <data>) to read the
+// `name` and to skip typed/binary entries whose CDATA isn't user-facing copy.
+// `[\s\S]*?` between </value> and </data> tolerates sibling children like
+// <comment>.
+const DATA_CDATA_RE = /<data\b([^>]*)>\s*<value\b[^>]*>\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*<\/value>[\s\S]*?<\/data>/g;
+const CDATA_MARKER = "<![CDATA[";
+const NAME_ATTR_RE = /\bname\s*=\s*"([^"]*)"/;
+const TYPE_ATTR_RE = /\btype\s*=\s*"/;
+const MIMETYPE_ATTR_RE = /\bmimetype\s*=\s*"/;
+
+function emitCdataValues(source: string, out: ExtractedHit[]): void {
+  for (const m of source.matchAll(DATA_CDATA_RE)) {
+    const attrs = m[1];
+    if (TYPE_ATTR_RE.test(attrs) || MIMETYPE_ATTR_RE.test(attrs)) continue;
+    const value = m[2];
+    if (value === "") continue;
+    const name = NAME_ATTR_RE.exec(attrs)?.[1] ?? "";
+    const matchOffset = m.index ?? 0;
+    const cdataPos = m[0].indexOf(CDATA_MARKER);
+    const valueOffset = cdataPos === -1 ? matchOffset : matchOffset + cdataPos + CDATA_MARKER.length;
+    const { line, column } = offsetToLineCol(source, valueOffset);
+    out.push({
+      value,
+      location: { line, column },
+      context: { parentRole: "resource_value", identifiers: [name] },
+    });
+  }
+}

--- a/lib/src/scan/lang/extractors/strings.test.ts
+++ b/lib/src/scan/lang/extractors/strings.test.ts
@@ -1,0 +1,52 @@
+import { stringsExtractor } from "./strings";
+
+const extract = (source: string) => stringsExtractor.extract({ source, kind: "ios_strings" });
+
+describe("stringsExtractor (.strings)", () => {
+  test("emits one resource_value per key=value pair", async () => {
+    const hits = await extract(`"greeting" = "Hello, world";\n"farewell" = "Goodbye";\n`);
+    expect(hits).toEqual([
+      {
+        value: "Hello, world",
+        location: { line: 1, column: 14 },
+        context: { parentRole: "resource_value", identifiers: ["greeting"] },
+      },
+      {
+        value: "Goodbye",
+        location: { line: 2, column: 14 },
+        context: { parentRole: "resource_value", identifiers: ["farewell"] },
+      },
+    ]);
+  });
+
+  test("skips // line comments and /* block comments */", async () => {
+    const source = [
+      `// header`,
+      `/* multi`,
+      `   line comment */`,
+      `"a" = "alpha";`,
+      `// trailing`,
+      `"b" = "beta";`,
+      ``,
+    ].join("\n");
+    const hits = await extract(source);
+    expect(hits.map((h) => h.value)).toEqual(["alpha", "beta"]);
+    expect(hits.map((h) => h.context.identifiers[0])).toEqual(["a", "b"]);
+  });
+
+  test("preserves escape sequences verbatim in value", async () => {
+    const hits = await extract(`"k" = "line1\\nline2 with \\"quote\\"";\n`);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].value).toBe('line1\\nline2 with \\"quote\\"');
+  });
+
+  test("returns no hits for malformed input", async () => {
+    const hits = await extract(`this is not a strings file\n`);
+    expect(hits).toEqual([]);
+  });
+
+  test("handles missing trailing semicolon", async () => {
+    const hits = await extract(`"k" = "v"\n"k2" = "v2";\n`);
+    expect(hits.map((h) => h.value)).toEqual(["v", "v2"]);
+  });
+});

--- a/lib/src/scan/lang/extractors/strings.ts
+++ b/lib/src/scan/lang/extractors/strings.ts
@@ -1,0 +1,128 @@
+import type { ExtractedHit, LanguageExtractor } from "../types";
+import { offsetToLineCol } from "./util";
+
+/**
+ * iOS `.strings` files (Localizable.strings, InfoPlist.strings, etc.).
+ *
+ * Format is a sequence of `"key" = "value";` pairs with `// line` and
+ * `/* block *\/` comments. There's no AST grammar shipped for this in
+ * @ast-grep/napi, and the format is simple enough that a hand-rolled
+ * lexer is the cleanest path. Every value is intentional user-facing
+ * copy, so every pair emits a `resource_value` hit. Escapes (`\"`,
+ * `\n`, etc.) are kept verbatim in the value — mirrors the JS extractor
+ * which keeps `template_string` source as-is.
+ */
+export const stringsExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const out: ExtractedHit[] = [];
+    for (const pair of parseStringsFile(source)) {
+      out.push({
+        value: pair.value,
+        location: pair.location,
+        context: { parentRole: "resource_value", identifiers: [pair.key] },
+      });
+    }
+    return out;
+  },
+};
+
+interface StringPair {
+  key: string;
+  value: string;
+  location: { line: number; column: number };
+}
+
+function parseStringsFile(source: string): StringPair[] {
+  const out: StringPair[] = [];
+  let i = 0;
+
+  while (i < source.length) {
+    i = skipWhitespaceAndComments(source, i);
+    if (i >= source.length) break;
+    if (source[i] !== '"') {
+      // Recover from malformed input: skip one character and retry.
+      i++;
+      continue;
+    }
+
+    const key = readQuoted(source, i);
+    if (!key) break;
+    i = key.endIndex;
+
+    i = skipWhitespaceAndComments(source, i);
+    if (source[i] !== "=") continue;
+    i++;
+
+    i = skipWhitespaceAndComments(source, i);
+    if (source[i] !== '"') continue;
+
+    const value = readQuoted(source, i);
+    if (!value) break;
+
+    out.push({
+      key: key.content,
+      value: value.content,
+      location: offsetToLineCol(source, value.startIndex),
+    });
+    i = value.endIndex;
+
+    i = skipWhitespaceAndComments(source, i);
+    if (source[i] === ";") i++;
+  }
+
+  return out;
+}
+
+function skipWhitespaceAndComments(source: string, start: number): number {
+  let i = start;
+  while (i < source.length) {
+    const ch = source.charCodeAt(i);
+    if (ch === 32 || ch === 9 || ch === 10 || ch === 13) {
+      i++;
+      continue;
+    }
+    if (source[i] === "/" && source[i + 1] === "/") {
+      while (i < source.length && source[i] !== "\n") i++;
+      continue;
+    }
+    if (source[i] === "/" && source[i + 1] === "*") {
+      const end = source.indexOf("*/", i + 2);
+      if (end === -1) return source.length;
+      i = end + 2;
+      continue;
+    }
+    break;
+  }
+  return i;
+}
+
+interface QuotedRead {
+  content: string;
+  startIndex: number;
+  endIndex: number;
+}
+
+/**
+ * Read a `"..."` token, honoring `\` escapes so an embedded `\"` does
+ * not terminate the string. The `content` excludes the surrounding
+ * quotes; escape sequences are kept literally in the returned text.
+ */
+function readQuoted(source: string, openQuote: number): QuotedRead | null {
+  if (source[openQuote] !== '"') return null;
+  let i = openQuote + 1;
+  let content = "";
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === "\\" && i + 1 < source.length) {
+      content += ch + source[i + 1];
+      i += 2;
+      continue;
+    }
+    if (ch === '"') {
+      return { content, startIndex: openQuote, endIndex: i + 1 };
+    }
+    content += ch;
+    i++;
+  }
+  return null;
+}

--- a/lib/src/scan/lang/extractors/stringsdict.test.ts
+++ b/lib/src/scan/lang/extractors/stringsdict.test.ts
@@ -1,0 +1,55 @@
+import { stringsdictExtractor } from "./stringsdict";
+
+const extract = (source: string) => stringsdictExtractor.extract({ source, kind: "ios_stringsdict" });
+
+const sample = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>%d items</key>
+  <dict>
+    <key>NSStringLocalizedFormatKey</key>
+    <string>%#@items@</string>
+    <key>items</key>
+    <dict>
+      <key>NSStringFormatSpecTypeKey</key>
+      <string>NSStringPluralRuleType</string>
+      <key>NSStringFormatValueTypeKey</key>
+      <string>d</string>
+      <key>one</key>
+      <string>%d item</string>
+      <key>other</key>
+      <string>%d items</string>
+    </dict>
+  </dict>
+</dict>
+</plist>
+`;
+
+describe("stringsdictExtractor", () => {
+  test("emits format key + each plural variant", async () => {
+    const hits = await extract(sample);
+    const values = hits.map((h) => h.value).sort();
+    expect(values).toEqual(["%#@items@", "%d item", "%d items"]);
+  });
+
+  test("skips NSStringFormatSpecTypeKey and NSStringFormatValueTypeKey metadata", async () => {
+    const hits = await extract(sample);
+    const values = hits.map((h) => h.value);
+    expect(values).not.toContain("NSStringPluralRuleType");
+    expect(values).not.toContain("d");
+  });
+
+  test("includes plural variant in identifiers under the top-level key", async () => {
+    const hits = await extract(sample);
+    const one = hits.find((h) => h.value === "%d item");
+    const other = hits.find((h) => h.value === "%d items");
+    expect(one?.context.identifiers).toEqual(["%d items", "items", "one"]);
+    expect(other?.context.identifiers).toEqual(["%d items", "items", "other"]);
+    expect(one?.context.parentRole).toBe("resource_value");
+  });
+
+  test("returns empty for an empty plist", async () => {
+    const hits = await extract(`<?xml version="1.0"?>\n<plist version="1.0"><dict></dict></plist>\n`);
+    expect(hits).toEqual([]);
+  });
+});

--- a/lib/src/scan/lang/extractors/stringsdict.ts
+++ b/lib/src/scan/lang/extractors/stringsdict.ts
@@ -1,0 +1,105 @@
+import { Lang, parse, type SgNode } from "@ast-grep/napi";
+
+import type { ExtractedHit, LanguageExtractor } from "../types";
+
+/**
+ * iOS `.stringsdict` plurals file. The format is plist XML:
+ *
+ *   <plist>
+ *     <dict>
+ *       <key>%d items</key>          <- top-level localization key
+ *       <dict>
+ *         <key>NSStringLocalizedFormatKey</key>
+ *         <string>%#@items@</string>  <- a real format string
+ *         <key>items</key>
+ *         <dict>
+ *           <key>NSStringFormatSpecTypeKey</key>
+ *           <string>NSStringPluralRuleType</string>  <- metadata, skip
+ *           <key>one</key>
+ *           <string>%d item</string>   <- a real plural variant
+ *           <key>other</key>
+ *           <string>%d items</string>  <- a real plural variant
+ *         </dict>
+ *       </dict>
+ *     </dict>
+ *   </plist>
+ *
+ * Strategy: walk the dict tree pairwise (`<key>K</key>` followed by the
+ * value element). Only emit `<string>` values when their immediate key
+ * is one of the CLDR plural categories or `NSStringLocalizedFormatKey`.
+ * Everything else (`NSStringFormatSpecTypeKey`, type tokens, etc.) is
+ * configuration metadata, not user-facing text.
+ */
+const USER_FACING_KEYS: ReadonlySet<string> = new Set([
+  "zero",
+  "one",
+  "two",
+  "few",
+  "many",
+  "other",
+  "NSStringLocalizedFormatKey",
+]);
+
+export const stringsdictExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const root = parse(Lang.Html, source).root();
+    const out: ExtractedHit[] = [];
+
+    for (const dict of root.findAll({ rule: { kind: "element" } })) {
+      if (tagName(dict) !== "dict") continue;
+      // Only walk top-level dicts; the recursive call handles nesting.
+      if (hasAncestorTag(dict, "dict")) continue;
+      walkDict(dict, [], out);
+    }
+
+    return out;
+  },
+};
+
+function walkDict(dictEl: SgNode, path: string[], out: ExtractedHit[]): void {
+  const items = dictEl.children().filter((c) => c.kind() === "element");
+  for (let i = 0; i + 1 < items.length; i += 2) {
+    const keyEl = items[i];
+    const valueEl = items[i + 1];
+    if (tagName(keyEl) !== "key") continue;
+    const key = elementText(keyEl);
+    if (key === null) continue;
+    const tag = tagName(valueEl);
+    if (tag === "dict") {
+      walkDict(valueEl, [...path, key], out);
+    } else if (tag === "string") {
+      if (!USER_FACING_KEYS.has(key)) continue;
+      const value = elementText(valueEl);
+      if (value === null || value.trim().length === 0) continue;
+      const textNode = valueEl.children().find((c) => c.kind() === "text");
+      const range = (textNode ?? valueEl).range();
+      out.push({
+        value,
+        location: { line: range.start.line + 1, column: range.start.column + 1 },
+        context: { parentRole: "resource_value", identifiers: [...path, key] },
+      });
+    }
+  }
+}
+
+function tagName(el: SgNode): string | null {
+  const start = el.children().find((c) => c.kind() === "start_tag");
+  return (
+    start
+      ?.children()
+      .find((c) => c.kind() === "tag_name")
+      ?.text() ?? null
+  );
+}
+
+function elementText(el: SgNode): string | null {
+  const text = el.children().find((c) => c.kind() === "text");
+  return text?.text() ?? null;
+}
+
+function hasAncestorTag(node: SgNode, name: string): boolean {
+  for (let cur = node.parent(); cur; cur = cur.parent()) {
+    if (cur.kind() === "element" && tagName(cur) === name) return true;
+  }
+  return false;
+}

--- a/lib/src/scan/lang/extractors/swift.test.ts
+++ b/lib/src/scan/lang/extractors/swift.test.ts
@@ -1,0 +1,55 @@
+import "../registry";
+
+import { swiftExtractor } from "./swift";
+
+const extract = (source: string) => swiftExtractor.extract({ source, kind: "swift" });
+
+describe("swiftExtractor", () => {
+  test("equality and switch case patterns are type_tag", async () => {
+    const source = [
+      `func f(x: String) -> Int {`,
+      `  if x == "foo" { return 1 }`,
+      `  switch x { case "bar": return 2; default: return 0 }`,
+      `}`,
+      ``,
+    ].join("\n");
+    const hits = await extract(source);
+    expect(hits.find((h) => h.value === '"foo"')?.context.parentRole).toBe("type_tag");
+    expect(hits.find((h) => h.value === '"bar"')?.context.parentRole).toBe("type_tag");
+  });
+
+  test("enum raw values and attribute arguments are type_tag", async () => {
+    const source = [`enum E: String { case a = "alpha"; case b = "beta" }`, `@objc("Bridged") class C {}`, ``].join(
+      "\n"
+    );
+    const hits = await extract(source);
+    expect(hits.find((h) => h.value === '"alpha"')?.context.parentRole).toBe("type_tag");
+    expect(hits.find((h) => h.value === '"Bridged"')?.context.parentRole).toBe("type_tag");
+  });
+
+  test("dictionary keys are object_key, values are other", async () => {
+    const hits = await extract(`let d = ["k": "v"]\n`);
+    const k = hits.find((h) => h.value === '"k"');
+    const v = hits.find((h) => h.value === '"v"');
+    expect(k?.context.parentRole).toBe("object_key");
+    expect(v?.context.parentRole).toBe("other");
+  });
+
+  test("NSRegularExpression and Regex arguments are regex_pattern", async () => {
+    const hits = await extract(`let r = Regex("^foo$")\nlet n = NSRegularExpression(pattern: "bar")\n`);
+    expect(hits.find((h) => h.value === '"^foo$"')?.context.parentRole).toBe("regex_pattern");
+    expect(hits.find((h) => h.value === '"bar"')?.context.parentRole).toBe("regex_pattern");
+  });
+
+  test("captures callee/methodName for call expressions", async () => {
+    const source = [`func f() {`, `  print("a")`, `  button.setTitle("b", for: .normal)`, `}`, ``].join("\n");
+    const hits = await extract(source);
+    expect(hits.find((h) => h.value === '"a"')?.context).toMatchObject({ parentRole: "other", callee: "print" });
+    expect(hits.find((h) => h.value === '"b"')?.context).toMatchObject({
+      parentRole: "other",
+      callee: "button",
+      calleeMember: "setTitle",
+      methodName: "setTitle",
+    });
+  });
+});

--- a/lib/src/scan/lang/extractors/swift.ts
+++ b/lib/src/scan/lang/extractors/swift.ts
@@ -1,0 +1,210 @@
+import { parse, type SgNode } from "@ast-grep/napi";
+
+import type { DittoScanEnclosingContext } from "../../types";
+import type { ExtractedHit, LanguageExtractor } from "../types";
+
+/**
+ * Swift string-literal node kinds.
+ *
+ *   `line_string_literal`        `"..."`            (with `\(expr)` interpolation)
+ *   `multi_line_string_literal`  `"""..."""`
+ *   `raw_string_literal`         `#"..."#`, `##"..."##`, etc.
+ */
+const STRING_KINDS = [
+  "line_string_literal",
+  "multi_line_string_literal",
+  "raw_string_literal",
+] as const;
+
+export const swiftExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const root = parse("swift", source).root();
+    const out: ExtractedHit[] = [];
+
+    for (const kind of STRING_KINDS) {
+      for (const node of root.findAll({ rule: { kind } })) {
+        // `"\(name)"` puts inner string literals (if any) under an
+        // `interpolated_expression`. We emit only the outer literal; the
+        // inner shows up as part of its source text.
+        if (isInsideInterpolation(node)) continue;
+        const { line, column } = node.range().start;
+        out.push({
+          value: node.text(),
+          location: { line: line + 1, column: column + 1 },
+          context: classifySwiftParent(node),
+        });
+      }
+    }
+
+    return out;
+  },
+};
+
+function isInsideInterpolation(node: SgNode): boolean {
+  for (let cur = node.parent(); cur; cur = cur.parent()) {
+    if (cur.kind() === "interpolated_expression") return true;
+  }
+  return false;
+}
+
+/**
+ * Cheap, confident exclusions only. Anything we don't classify falls
+ * through as `other` and the LLM reads `source_context`.
+ *
+ *   `import`         `import Foundation`
+ *   `regex_pattern`  `NSRegularExpression(pattern: "...")`, `Regex("...")`
+ *   `object_key`     `["k": v]` literal-position key
+ *   `index_access`   `dict["k"]`
+ *   `type_tag`       `x == "foo"`, `switch x { case "foo": ... }`,
+ *                    enum raw values (`case x = "foo"`),
+ *                    Swift attribute arguments (`@objc("name")`).
+ */
+function classifySwiftParent(node: SgNode): DittoScanEnclosingContext {
+  const parent = node.parent();
+  if (!parent) return { parentRole: "other", identifiers: [] };
+  const pk = parent.kind() as string;
+
+  switch (pk) {
+    case "import_declaration":
+      return { parentRole: "import", identifiers: [] };
+
+    case "equality_expression":
+      return { parentRole: "type_tag", identifiers: [] };
+
+    // `enum E: String { case a = "alpha" }` — raw values are tags, not text.
+    case "enum_entry":
+      return { parentRole: "type_tag", identifiers: [] };
+
+    // `@objc("Name")`, `@available(...)`, etc. The string sits directly
+    // inside the `attribute` node alongside the user_type identifying it.
+    case "attribute":
+      return { parentRole: "type_tag", identifiers: [] };
+
+    // `["k": v, ...]`. Keys and values alternate as named children.
+    // Even-indexed named children are keys; odd are values.
+    case "dictionary_literal": {
+      const named = parent.children().filter((c) => c.isNamed());
+      const idx = named.findIndex((c) => rangesMatch(c, node));
+      return {
+        parentRole: idx >= 0 && idx % 2 === 0 ? "object_key" : "other",
+        identifiers: [],
+      };
+    }
+
+    // `switch s { case "foo": ... }` parses as
+    //   switch_entry → switch_pattern → pattern → line_string_literal
+    case "pattern": {
+      const grand = parent.parent();
+      if (grand?.kind() === "switch_pattern")
+        return { parentRole: "type_tag", identifiers: [] };
+      return { parentRole: "other", identifiers: [] };
+    }
+
+    // Function call or subscript argument. tree-sitter-swift folds both
+    // `f(x)` and `obj[x]` into `call_expression` and distinguishes them
+    // by the opener token on `value_arguments` (`(` vs `[`).
+    case "value_argument": {
+      const args = parent.parent(); // value_arguments
+      const suffix = args?.parent(); // call_suffix
+      const call = suffix?.parent(); // call_expression
+      if (call?.kind() === "call_expression") {
+        const opener = args
+          ?.children()
+          .find((c) => !c.isNamed())
+          ?.text();
+        if (opener === "[")
+          return { parentRole: "index_access", identifiers: [] };
+
+        const head = firstNamedChild(call);
+        const bareName =
+          head?.kind() === "simple_identifier" ? head.text() : null;
+        if (bareName === "NSRegularExpression" || bareName === "Regex") {
+          return { parentRole: "regex_pattern", identifiers: [] };
+        }
+        const { callee, calleeMember, methodName } = extractSwiftCallee(head);
+        if (callee || methodName) {
+          return {
+            parentRole: "other",
+            identifiers: [],
+            callee,
+            calleeMember,
+            methodName,
+          };
+        }
+      }
+      return { parentRole: "other", identifiers: [] };
+    }
+
+    default:
+      return { parentRole: "other", identifiers: [] };
+  }
+}
+
+function firstNamedChild(node: SgNode): SgNode | null {
+  for (const c of node.children()) if (c.isNamed()) return c;
+  return null;
+}
+
+/**
+ * Pull identifying pieces off a Swift call_expression head. Mirrors the
+ * Kotlin extractor's `extractKtCallee` and follows the same contract:
+ *
+ *   `callee` / `calleeMember`  — set only when the receiver is a bare
+ *     identifier (or the call has no receiver). Strict; reject rules can
+ *     trust the receiver identity.
+ *   `methodName`               — set whenever the head is a navigation_
+ *     expression with a final method identifier, regardless of receiver
+ *     shape. Accept rules can match chained setter calls like
+ *     `button.setTitle("X", for: .normal)` or `someView.someChild.text(...)`.
+ *
+ * Examples:
+ *
+ *   `print("x")`                          callee="print"
+ *   `NSLog("x")`                          callee="NSLog"
+ *   `button.setTitle("x", for: .normal)`  callee="button", calleeMember="setTitle", methodName="setTitle"
+ *   `Logger.shared.info("x")`             methodName="info"        (receiver is itself a navigation)
+ */
+function extractSwiftCallee(head: SgNode | null): {
+  callee?: string;
+  calleeMember?: string;
+  methodName?: string;
+} {
+  if (!head) return {};
+  if (head.kind() === "simple_identifier") return { callee: head.text() };
+  if (head.kind() === "navigation_expression") {
+    const named = head.children().filter((c) => c.isNamed());
+    if (named.length < 2) return {};
+    const receiver = named[0];
+    const last = named[named.length - 1];
+    const methodName = navigationFinalIdentifier(last);
+    if (!methodName) return {};
+    if (receiver.kind() === "simple_identifier") {
+      return { callee: receiver.text(), calleeMember: methodName, methodName };
+    }
+    return { methodName };
+  }
+  return {};
+}
+
+/**
+ * Read the trailing identifier off a navigation_expression's last named
+ * child. Handles the wrapped `navigation_suffix` shape (`foo.bar` where
+ * the suffix wraps a `simple_identifier` for `bar`) and the bare
+ * `simple_identifier` shape.
+ */
+function navigationFinalIdentifier(last: SgNode): string | undefined {
+  if (last.kind() === "simple_identifier") return last.text();
+  if (last.kind() === "navigation_suffix") {
+    const inner = last
+      .children()
+      .filter((c) => c.isNamed() && c.kind() === "simple_identifier")[0];
+    if (inner) return inner.text();
+  }
+  return undefined;
+}
+
+function rangesMatch(a: SgNode, b: SgNode): boolean {
+  const ra = a.range();
+  const rb = b.range();
+  return ra.start.index === rb.start.index && ra.end.index === rb.end.index;
+}

--- a/lib/src/scan/lang/extractors/util.ts
+++ b/lib/src/scan/lang/extractors/util.ts
@@ -1,0 +1,13 @@
+// 1-based (line, column) from a byte offset into a UTF-16 source string.
+// Treats LF as the line break; CR-only sources will report a single line.
+export function offsetToLineCol(source: string, offset: number): { line: number; column: number } {
+  let line = 1;
+  let lastNewline = -1;
+  for (let i = 0; i < offset; i++) {
+    if (source.charCodeAt(i) === 10) {
+      line++;
+      lastNewline = i;
+    }
+  }
+  return { line, column: offset - lastNewline };
+}

--- a/lib/src/scan/lang/extractors/vue.test.ts
+++ b/lib/src/scan/lang/extractors/vue.test.ts
@@ -1,0 +1,47 @@
+import { vueExtractor } from "./vue";
+
+const extract = (source: string) => vueExtractor.extract({ source, kind: "vue" });
+
+describe("vueExtractor", () => {
+  test("emits template text as markup_text and script literals as other", async () => {
+    const source = [
+      `<template>`,
+      `  <p>Hello world</p>`,
+      `</template>`,
+      `<script lang="ts">`,
+      `  const greeting = "Hi from script";`,
+      `</script>`,
+      ``,
+    ].join("\n");
+    const hits = await extract(source);
+
+    const hello = hits.find((h) => h.value.trim() === "Hello world");
+    expect(hello?.context.parentRole).toBe("markup_text");
+    expect(hello?.context.parentTag).toBe("p");
+
+    const fromScript = hits.find((h) => h.value === '"Hi from script"');
+    expect(fromScript?.context.parentRole).toBe("other");
+  });
+
+  test("script positions are reported against the original .vue file", async () => {
+    const source = [`<template><p>Hi</p></template>`, `<script>`, `const s = "row2";`, `</script>`, ``].join("\n");
+    const hits = await extract(source);
+    const fromScript = hits.find((h) => h.value === '"row2"');
+    expect(fromScript?.location.line).toBe(3);
+  });
+
+  test("ignores <style> contents", async () => {
+    const source = [`<template><p>Visible</p></template>`, `<style>.x::after { content: "hidden"; }</style>`, ``].join(
+      "\n"
+    );
+    const hits = await extract(source);
+    const values = hits.map((h) => h.value.trim());
+    expect(values).toContain("Visible");
+    expect(values).not.toContain("hidden");
+  });
+
+  test("returns empty array for an empty SFC", async () => {
+    const hits = await extract(`<template></template>\n<script></script>\n`);
+    expect(hits).toEqual([]);
+  });
+});

--- a/lib/src/scan/lang/extractors/vue.ts
+++ b/lib/src/scan/lang/extractors/vue.ts
@@ -1,0 +1,89 @@
+import { Lang, parse, type SgNode } from "@ast-grep/napi";
+
+import type { ExtractedHit, LanguageExtractor } from "../types";
+import { extractHtmlMarkup } from "./html-markup";
+import { javascriptExtractor } from "./javascript";
+
+/**
+ * Vue Single-File Component (SFC) extractor. A `.vue` file has three
+ * top-level blocks:
+ *
+ *   <template>      <!-- HTML-ish markup with Vue directives          -->
+ *   <script>...     // JS or TS module that exports the component
+ *   <style>...      /* Scoped CSS. We never scan this.               *\/
+ *
+ * Strategy: parse the whole file as HTML, then handle each block.
+ *
+ *   1. Template or top-level HTML. Emit the text content of every
+ *      element (`<p>Hello</p>` becomes `Hello`) and the value of every
+ *      plain attribute (`<input placeholder="Email"/>` becomes `Email`).
+ *      Vue directives (`:foo`, `@click`, `v-bind`, `#slot`) are skipped
+ *      because their "values" are actually JS expressions, not text.
+ *   2. `<script>`. Re-parse its contents using the JS/TS extractor.
+ *   3. `<style>`. Skipped entirely. CSS is never user-facing copy.
+ */
+export const vueExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const root = parse(Lang.Html, source).root();
+    const out: ExtractedHit[] = extractHtmlMarkup(source);
+    for (const script of root.findAll({ rule: { kind: "script_element" } })) {
+      out.push(...(await emitScript(script)));
+    }
+
+    return out;
+  },
+};
+
+/**
+ * Run the embedded `<script>` body through the JavaScript extractor.
+ *
+ * Trick: we left-pad the script body with newlines and spaces so the
+ * character positions inside the padded slice line up with the original
+ * SFC. That way the JS extractor's reported line and column numbers
+ * point straight back into the `.vue` file without any per-hit offset
+ * math.
+ */
+async function emitScript(script: SgNode): Promise<ExtractedHit[]> {
+  const rawText = script.children().find((c) => c.kind() === "raw_text");
+  if (!rawText || rawText.text().trim().length === 0) return [];
+
+  const langId = detectScriptLang(script);
+  const start = rawText.range().start;
+  const padded = "\n".repeat(start.line) + " ".repeat(start.column) + rawText.text();
+  return javascriptExtractor(langId).extract({ source: padded, kind: "vue-script" });
+}
+
+/**
+ * Read the `lang` attribute off the `<script>` opening tag to decide
+ * which JS grammar to use:
+ *
+ *   <script>                       JavaScript
+ *   <script lang="ts">              TypeScript
+ *   <script lang="typescript">      TypeScript
+ *   <script lang="tsx">             Tsx
+ *
+ * Anything else (including `lang="js"`) falls back to JavaScript.
+ */
+function detectScriptLang(script: SgNode): Lang {
+  for (const tag of script.children()) {
+    if (tag.kind() !== "start_tag") continue;
+    for (const attr of tag.children()) {
+      if (attr.kind() !== "attribute") continue;
+      const named = attr.children().filter((c) => c.isNamed());
+      const name = named
+        .find((c) => c.kind() === "attribute_name")
+        ?.text()
+        .toLowerCase();
+      if (name !== "lang") continue;
+      const value = named
+        .find((c) => c.kind() === "quoted_attribute_value")
+        ?.children()
+        .find((c) => c.kind() === "attribute_value")
+        ?.text()
+        .toLowerCase();
+      if (value === "ts" || value === "typescript") return Lang.TypeScript;
+      if (value === "tsx") return Lang.Tsx;
+    }
+  }
+  return Lang.JavaScript;
+}

--- a/lib/src/scan/lang/extractors/xcstrings.test.ts
+++ b/lib/src/scan/lang/extractors/xcstrings.test.ts
@@ -1,0 +1,70 @@
+import { xcstringsExtractor } from "./xcstrings";
+
+const extract = (source: string) => xcstringsExtractor.extract({ source, kind: "ios_xcstrings" });
+
+describe("xcstringsExtractor", () => {
+  test("emits one hit per locale's stringUnit value", async () => {
+    const source = JSON.stringify(
+      {
+        sourceLanguage: "en",
+        strings: {
+          hello: {
+            localizations: {
+              en: { stringUnit: { value: "Hello" } },
+              es: { stringUnit: { value: "Hola" } },
+            },
+          },
+        },
+      },
+      null,
+      2
+    );
+    const hits = await extract(source);
+    expect(hits.map((h) => h.value).sort()).toEqual(["Hello", "Hola"]);
+    expect(hits.every((h) => h.context.parentRole === "resource_value")).toBe(true);
+    expect(hits.every((h) => h.context.identifiers[0] === "hello")).toBe(true);
+  });
+
+  test("walks plural variations and accumulates variant labels in identifiers", async () => {
+    const source = JSON.stringify(
+      {
+        strings: {
+          items_plural: {
+            localizations: {
+              en: {
+                variations: {
+                  plural: {
+                    one: { stringUnit: { value: "%d item" } },
+                    other: { stringUnit: { value: "%d items" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      null,
+      2
+    );
+    const hits = await extract(source);
+    expect(hits.map((h) => h.value).sort()).toEqual(["%d item", "%d items"]);
+    const one = hits.find((h) => h.value === "%d item");
+    expect(one?.context.identifiers).toEqual(["items_plural", "plural", "one"]);
+  });
+
+  test("skips empty/whitespace-only values", async () => {
+    const source = JSON.stringify({
+      strings: {
+        empty: { localizations: { en: { stringUnit: { value: "  " } } } },
+        ok: { localizations: { en: { stringUnit: { value: "Real" } } } },
+      },
+    });
+    const hits = await extract(source);
+    expect(hits.map((h) => h.value)).toEqual(["Real"]);
+  });
+
+  test("returns empty for invalid or non-catalog JSON", async () => {
+    expect(await extract(`not json`)).toEqual([]);
+    expect(await extract(`{"strings": []}`)).toEqual([]);
+  });
+});

--- a/lib/src/scan/lang/extractors/xcstrings.ts
+++ b/lib/src/scan/lang/extractors/xcstrings.ts
@@ -1,0 +1,297 @@
+import type { ExtractedHit, LanguageExtractor } from "../types";
+import { offsetToLineCol } from "./util";
+
+/**
+ * Xcode String Catalog (`.xcstrings`). JSON format introduced in Xcode 15.
+ *
+ *   {
+ *     "sourceLanguage": "en",
+ *     "strings": {
+ *       "hello": {
+ *         "localizations": {
+ *           "en": { "stringUnit": { "value": "Hello" } },
+ *           "es": { "stringUnit": { "value": "Hola" } }
+ *         }
+ *       },
+ *       "items_plural": {
+ *         "localizations": {
+ *           "en": {
+ *             "variations": {
+ *               "plural": {
+ *                 "one":   { "stringUnit": { "value": "%d item"  } },
+ *                 "other": { "stringUnit": { "value": "%d items" } }
+ *               }
+ *             }
+ *           }
+ *         }
+ *       }
+ *     }
+ *   }
+ *
+ * Every locale present in the file flows through (source + translations);
+ * downstream groups candidates by their resource key, which lives in
+ * `identifiers`. The locale itself is discoverable from `source_context`
+ * (the surrounding JSON shows the `"en":` / `"fr":` / ... wrapping key).
+ *
+ * Variations (`plural`, `device`, `width`) may be nested arbitrarily; we
+ * recurse, accumulating the variant labels into `identifiers` after the
+ * top-level key so downstream sees the full path.
+ *
+ * Positions are tracked by a minimal location-aware JSON parser so each
+ * candidate gets a unique (line, column) — required for stable IDs when
+ * the same string value appears under multiple keys (e.g. several keys
+ * mapping to "OK").
+ */
+export const xcstringsExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const root = parseJson(source);
+    if (!root || root.kind !== "object") return [];
+
+    const out: ExtractedHit[] = [];
+    const strings = objectGet(root, "strings");
+    if (!strings || strings.kind !== "object") return out;
+
+    for (const entry of strings.entries) {
+      const key = entry.key;
+      const localizations = entry.value.kind === "object" ? objectGet(entry.value, "localizations") : null;
+      if (!localizations || localizations.kind !== "object") continue;
+      for (const locale of localizations.entries) {
+        if (locale.value.kind !== "object") continue;
+        emitLocalization(locale.value, [key], source, out);
+      }
+    }
+
+    return out;
+  },
+};
+
+function emitLocalization(node: JsonObject, identifiers: string[], source: string, out: ExtractedHit[]): void {
+  const stringUnit = objectGet(node, "stringUnit");
+  if (stringUnit && stringUnit.kind === "object") {
+    const value = objectGet(stringUnit, "value");
+    if (value && value.kind === "string" && value.value.trim().length > 0) {
+      out.push({
+        value: value.value,
+        location: offsetToLineCol(source, value.start),
+        context: { parentRole: "resource_value", identifiers },
+      });
+    }
+  }
+  const variations = objectGet(node, "variations");
+  if (variations && variations.kind === "object") {
+    // variations: { plural: { one: {...}, other: {...} }, device: { iphone: {...} }, ... }
+    for (const variationType of variations.entries) {
+      if (variationType.value.kind !== "object") continue;
+      for (const variant of variationType.value.entries) {
+        if (variant.value.kind !== "object") continue;
+        emitLocalization(variant.value, [...identifiers, variationType.key, variant.key], source, out);
+      }
+    }
+  }
+}
+
+interface JsonString {
+  kind: "string";
+  value: string;
+  start: number;
+  end: number;
+}
+interface JsonObject {
+  kind: "object";
+  entries: Array<{ key: string; value: JsonNode }>;
+  start: number;
+  end: number;
+}
+interface JsonArray {
+  kind: "array";
+  items: JsonNode[];
+  start: number;
+  end: number;
+}
+interface JsonAtom {
+  kind: "number" | "bool" | "null";
+  start: number;
+  end: number;
+}
+type JsonNode = JsonString | JsonObject | JsonArray | JsonAtom;
+
+function objectGet(obj: JsonObject, key: string): JsonNode | null {
+  for (const entry of obj.entries) if (entry.key === key) return entry.value;
+  return null;
+}
+
+/**
+ * Lenient JSON parser that records each string's source offset. Returns
+ * null if the input isn't valid JSON; callers must check.
+ */
+function parseJson(source: string): JsonNode | null {
+  const ctx = { src: source, i: 0 };
+  skipWs(ctx);
+  try {
+    const node = parseValue(ctx);
+    return node;
+  } catch {
+    return null;
+  }
+}
+
+interface Ctx {
+  src: string;
+  i: number;
+}
+
+function parseValue(ctx: Ctx): JsonNode {
+  skipWs(ctx);
+  const ch = ctx.src[ctx.i];
+  if (ch === '"') return parseString(ctx);
+  if (ch === "{") return parseObject(ctx);
+  if (ch === "[") return parseArray(ctx);
+  if (ch === "t" || ch === "f") return parseBool(ctx);
+  if (ch === "n") return parseNull(ctx);
+  return parseNumber(ctx);
+}
+
+function parseString(ctx: Ctx): JsonString {
+  const start = ctx.i;
+  if (ctx.src[ctx.i] !== '"') throw new Error("expected string");
+  ctx.i++;
+  let value = "";
+  while (ctx.i < ctx.src.length) {
+    const ch = ctx.src[ctx.i];
+    if (ch === "\\") {
+      const next = ctx.src[ctx.i + 1];
+      ctx.i += 2;
+      switch (next) {
+        case '"':
+          value += '"';
+          break;
+        case "\\":
+          value += "\\";
+          break;
+        case "/":
+          value += "/";
+          break;
+        case "b":
+          value += "\b";
+          break;
+        case "f":
+          value += "\f";
+          break;
+        case "n":
+          value += "\n";
+          break;
+        case "r":
+          value += "\r";
+          break;
+        case "t":
+          value += "\t";
+          break;
+        case "u": {
+          const hex = ctx.src.slice(ctx.i, ctx.i + 4);
+          ctx.i += 4;
+          value += String.fromCharCode(parseInt(hex, 16));
+          break;
+        }
+        default:
+          value += next ?? "";
+      }
+      continue;
+    }
+    if (ch === '"') {
+      ctx.i++;
+      return { kind: "string", value, start, end: ctx.i };
+    }
+    value += ch;
+    ctx.i++;
+  }
+  throw new Error("unterminated string");
+}
+
+function parseObject(ctx: Ctx): JsonObject {
+  const start = ctx.i;
+  ctx.i++; // {
+  skipWs(ctx);
+  const entries: Array<{ key: string; value: JsonNode }> = [];
+  if (ctx.src[ctx.i] === "}") {
+    ctx.i++;
+    return { kind: "object", entries, start, end: ctx.i };
+  }
+  while (ctx.i < ctx.src.length) {
+    skipWs(ctx);
+    const keyNode = parseString(ctx);
+    skipWs(ctx);
+    if (ctx.src[ctx.i] !== ":") throw new Error("expected colon");
+    ctx.i++;
+    const value = parseValue(ctx);
+    entries.push({ key: keyNode.value, value });
+    skipWs(ctx);
+    if (ctx.src[ctx.i] === ",") {
+      ctx.i++;
+      continue;
+    }
+    if (ctx.src[ctx.i] === "}") {
+      ctx.i++;
+      break;
+    }
+    throw new Error("expected , or }");
+  }
+  return { kind: "object", entries, start, end: ctx.i };
+}
+
+function parseArray(ctx: Ctx): JsonArray {
+  const start = ctx.i;
+  ctx.i++; // [
+  skipWs(ctx);
+  const items: JsonNode[] = [];
+  if (ctx.src[ctx.i] === "]") {
+    ctx.i++;
+    return { kind: "array", items, start, end: ctx.i };
+  }
+  while (ctx.i < ctx.src.length) {
+    items.push(parseValue(ctx));
+    skipWs(ctx);
+    if (ctx.src[ctx.i] === ",") {
+      ctx.i++;
+      continue;
+    }
+    if (ctx.src[ctx.i] === "]") {
+      ctx.i++;
+      break;
+    }
+    throw new Error("expected , or ]");
+  }
+  return { kind: "array", items, start, end: ctx.i };
+}
+
+function parseBool(ctx: Ctx): JsonAtom {
+  const start = ctx.i;
+  if (ctx.src.startsWith("true", ctx.i)) ctx.i += 4;
+  else if (ctx.src.startsWith("false", ctx.i)) ctx.i += 5;
+  else throw new Error("expected bool");
+  return { kind: "bool", start, end: ctx.i };
+}
+
+function parseNull(ctx: Ctx): JsonAtom {
+  const start = ctx.i;
+  if (!ctx.src.startsWith("null", ctx.i)) throw new Error("expected null");
+  ctx.i += 4;
+  return { kind: "null", start, end: ctx.i };
+}
+
+function parseNumber(ctx: Ctx): JsonAtom {
+  const start = ctx.i;
+  const re = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
+  re.lastIndex = ctx.i;
+  const m = re.exec(ctx.src);
+  if (!m) throw new Error("expected number");
+  ctx.i += m[0].length;
+  return { kind: "number", start, end: ctx.i };
+}
+
+function skipWs(ctx: Ctx): void {
+  while (ctx.i < ctx.src.length) {
+    const ch = ctx.src.charCodeAt(ctx.i);
+    if (ch === 32 || ch === 9 || ch === 10 || ch === 13) ctx.i++;
+    else break;
+  }
+}

--- a/lib/src/scan/lang/extractors/xliff.ts
+++ b/lib/src/scan/lang/extractors/xliff.ts
@@ -1,0 +1,51 @@
+import { Lang, parse } from "@ast-grep/napi";
+
+import type { ExtractedHit, LanguageExtractor } from "../types";
+import { offsetToLineCol } from "./util";
+import { elementAttribute, emitTextHit, findCdataElements, tagName } from "./xml";
+
+/**
+ * XLIFF translation interchange (`.xliff` / `.xlf`). Two on-the-wire shapes:
+ *
+ *   1.2: <trans-unit id="hello"><source>Hello</source><target>Bonjour</target></trans-unit>
+ *   2.0: <unit id="hello"><segment><source>Hello</source><target>Bonjour</target></segment></unit>
+ *
+ * Each `<source>` and `<target>` text is emitted as `resource_value`, tagged
+ * with `[unitId, "source"|"target"]`. `<note>` (translator comments) and
+ * metadata elements are skipped. CDATA-wrapped content is recovered via a
+ * regex sweep — ast-grep's HTML grammar drops CDATA text nodes.
+ */
+export const xliffExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    const root = parse(Lang.Html, source).root();
+    const out: ExtractedHit[] = [];
+
+    for (const unit of root.findAll({ rule: { kind: "element" } })) {
+      const tag = tagName(unit);
+      if (tag !== "trans-unit" && tag !== "unit") continue;
+      const id = elementAttribute(unit, "id") ?? "";
+      for (const el of unit.findAll({ rule: { kind: "element" } })) {
+        const innerTag = tagName(el);
+        if (innerTag !== "source" && innerTag !== "target") continue;
+        emitTextHit(el, [id, innerTag], out, source);
+      }
+    }
+
+    emitCdataValues(source, out);
+    return out;
+  },
+};
+
+// CDATA sweep can't see the surrounding <trans-unit id=...> easily — the
+// regex only captures the immediate parent (<source>/<target>). The unit id
+// is left blank for these; downstream still groups by value.
+function emitCdataValues(source: string, out: ExtractedHit[]): void {
+  for (const m of findCdataElements(source, ["source", "target"])) {
+    const { line, column } = offsetToLineCol(source, m.valueOffset);
+    out.push({
+      value: m.value,
+      location: { line, column },
+      context: { parentRole: "resource_value", identifiers: ["", m.tag] },
+    });
+  }
+}

--- a/lib/src/scan/lang/extractors/xml.ts
+++ b/lib/src/scan/lang/extractors/xml.ts
@@ -1,0 +1,100 @@
+import { type SgNode } from "@ast-grep/napi";
+
+import type { ExtractedHit } from "../types";
+
+export function tagName(element: SgNode): string | null {
+  const start = element.children().find((c) => c.kind() === "start_tag");
+  return (
+    start
+      ?.children()
+      .find((c) => c.kind() === "tag_name")
+      ?.text() ?? null
+  );
+}
+
+export function elementAttribute(element: SgNode, name: string): string | null {
+  const start = element.children().find((c) => c.kind() === "start_tag");
+  if (!start) return null;
+  for (const attr of start.children()) {
+    if (attr.kind() !== "attribute") continue;
+    const nameNode = attr.children().find((c) => c.kind() === "attribute_name");
+    if (nameNode?.text() !== name) continue;
+    const quoted = attr.children().find((c) => c.kind() === "quoted_attribute_value");
+    const value = quoted
+      ?.children()
+      .find((c) => c.kind() === "attribute_value")
+      ?.text();
+    if (value !== undefined) return value;
+    return (
+      attr
+        .children()
+        .find((c) => c.kind() === "attribute_value")
+        ?.text() ?? null
+    );
+  }
+  return null;
+}
+
+// Emit a `resource_value` hit from `element`'s first text child. No-op when
+// the element has no direct text node, the text is whitespace-only, or the
+// element contains a CDATA section (handled by `findCdataElements`). The
+// HTML grammar parses CDATA inconsistently when its body looks like markup
+// — `<![CDATA[Hi <b>x</b>]]>` can surface `]]` as a stray text node.
+// Skipping any element whose source range contains `<![CDATA[` is simpler
+// and matches the CDATA sweep, which recovers the real value.
+export function emitTextHit(element: SgNode, identifiers: string[], out: ExtractedHit[], source?: string): void {
+  if (source !== undefined && elementContainsCdata(element, source)) return;
+  const text = element.children().find((c) => c.kind() === "text");
+  if (!text) return;
+  const value = text.text();
+  if (value.trim().length === 0) return;
+  const range = text.range();
+  out.push({
+    value,
+    location: { line: range.start.line + 1, column: range.start.column + 1 },
+    context: { parentRole: "resource_value", identifiers },
+  });
+}
+
+function elementContainsCdata(element: SgNode, source: string): boolean {
+  const range = element.range();
+  const idx = source.indexOf("<![CDATA[", range.start.index);
+  return idx !== -1 && idx < range.end.index;
+}
+
+export interface CdataMatch {
+  tag: string;
+  attrsRaw: string;
+  value: string;
+  // Offset of the matched outer tag, e.g. `<source ...><![CDATA[...]]></source>`.
+  offset: number;
+  // Offset of the CDATA payload itself (the char after `<![CDATA[`). Use this
+  // for hit locations so they point at the extracted text rather than the tag.
+  valueOffset: number;
+}
+
+const CDATA_MARKER = "<![CDATA[";
+
+// ast-grep's HTML grammar drops CDATA text nodes silently, so an AST walk
+// over `<value><![CDATA[...]]></value>` sees no text child at all. This
+// regex sweep recovers those by name. The AST pass never captures CDATA in
+// the first place, so there's no overlap — no dedup needed.
+export function findCdataElements(source: string, tagNames: readonly string[]): CdataMatch[] {
+  if (tagNames.length === 0) return [];
+  const alt = tagNames.map(escapeRegex).join("|");
+  const re = new RegExp(`<(${alt})\\b([^>]*)>\\s*<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>\\s*</\\1>`, "g");
+  const out: CdataMatch[] = [];
+  for (const m of source.matchAll(re)) {
+    if (m[3] === "") continue;
+    const offset = m.index ?? 0;
+    // Hop past `<tag attrs>` and any whitespace to find the `<![CDATA[` opener.
+    const cdataPos = m[0].indexOf(CDATA_MARKER);
+    const valueOffset = cdataPos === -1 ? offset : offset + cdataPos + CDATA_MARKER.length;
+    out.push({ tag: m[1], attrsRaw: m[2], value: m[3], offset, valueOffset });
+  }
+  return out;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/lib/src/scan/lang/extractors/yaml-i18n.test.ts
+++ b/lib/src/scan/lang/extractors/yaml-i18n.test.ts
@@ -1,0 +1,45 @@
+import { yamlI18nExtractor } from "./yaml-i18n";
+
+const extract = (source: string) => yamlI18nExtractor.extract({ source, kind: "yaml_i18n" });
+
+describe("yamlI18nExtractor", () => {
+  test("walks nested maps and emits each leaf string", async () => {
+    const source = [`en:`, `  greetings:`, `    hello: Hello`, `    bye: Goodbye`, ``].join("\n");
+    const hits = await extract(source);
+    expect(hits.map((h) => ({ v: h.value, ids: h.context.identifiers }))).toEqual([
+      { v: "Hello", ids: ["en", "greetings", "hello"] },
+      { v: "Goodbye", ids: ["en", "greetings", "bye"] },
+    ]);
+    expect(hits.every((h) => h.context.parentRole === "resource_value")).toBe(true);
+  });
+
+  test("indexes sequence items numerically", async () => {
+    const source = [`en:`, `  planets:`, `    - Mercury`, `    - Venus`, ``].join("\n");
+    const hits = await extract(source);
+    expect(hits.map((h) => h.context.identifiers)).toEqual([
+      ["en", "planets", "0"],
+      ["en", "planets", "1"],
+    ]);
+  });
+
+  test("splits `_one` / `_other` plural suffix in the trailing key", async () => {
+    const source = [`en:`, `  item_one: "1 item"`, `  item_other: "{count} items"`, ``].join("\n");
+    const hits = await extract(source);
+    expect(hits.map((h) => h.context.identifiers)).toEqual([
+      ["en", "item", "one"],
+      ["en", "item", "other"],
+    ]);
+  });
+
+  test("skips empty and non-string scalars", async () => {
+    const source = [`en:`, `  count: 5`, `  ok: true`, `  blank: " "`, `  msg: real`, ``].join("\n");
+    const hits = await extract(source);
+    expect(hits.map((h) => h.value)).toEqual(["real"]);
+  });
+
+  test("returns empty array on a YAML parse error", async () => {
+    const source = `: this is\n  : invalid\n  :: yaml`;
+    const hits = await extract(source);
+    expect(hits).toEqual([]);
+  });
+});

--- a/lib/src/scan/lang/extractors/yaml-i18n.ts
+++ b/lib/src/scan/lang/extractors/yaml-i18n.ts
@@ -1,0 +1,115 @@
+import { parseDocument } from "yaml";
+
+import type { ExtractedHit, LanguageExtractor } from "../types";
+
+// YAML i18n files — vue-i18n YAML mode, Rails `config/locales`, etc.
+// Same conventions as the JSON i18n extractor: descend into maps, emit
+// each leaf string keyed by its path. `item_one` / `item_other` style
+// plural suffixes are split into `[base, variant]`. parseDocument is
+// used (over yaml.parse) for source positions on each scalar.
+//
+// No content-shape gate — the walker only dispatches this on files the
+// LLM has already confirmed.
+export const yamlI18nExtractor: LanguageExtractor = {
+  async extract({ source }) {
+    let doc: ReturnType<typeof parseDocument>;
+    try {
+      doc = parseDocument(source);
+    } catch {
+      return [];
+    }
+    if (doc.errors && doc.errors.length > 0) return [];
+
+    const out: ExtractedHit[] = [];
+    walk(doc.contents as YamlNode | null, [], source, out);
+    return out;
+  },
+};
+
+const PLURAL_SUFFIX_RE = /^(.+)_(zero|one|two|few|many|other)$/;
+
+// Minimal shape of the `yaml` v1 nodes we touch — the package's own
+// types pull in more than we need.
+interface YamlScalar {
+  value: unknown;
+  range?: [number, number] | null;
+}
+interface YamlPair {
+  key?: YamlScalar;
+  value?: YamlNode;
+}
+interface YamlMap {
+  items: YamlPair[];
+}
+interface YamlSeq {
+  items: YamlNode[];
+}
+type YamlNode = YamlScalar | YamlMap | YamlSeq | null | undefined;
+
+function isMap(node: YamlNode): node is YamlMap {
+  return !!node && Array.isArray((node as YamlMap).items) && hasPairItems(node as YamlMap);
+}
+
+function isSeq(node: YamlNode): node is YamlSeq {
+  if (!node || !Array.isArray((node as YamlSeq).items)) return false;
+  const items = (node as YamlSeq).items;
+  if (items.length === 0) return !hasPairItems(node as unknown as YamlMap);
+  const first = items[0];
+  return !(first !== null && typeof first === "object" && "key" in first);
+}
+
+function hasPairItems(node: YamlMap): boolean {
+  // A YAMLSeq also has `.items`, but its items aren't pair-shaped.
+  return (
+    node.items.length === 0 || (node.items[0] !== null && typeof node.items[0] === "object" && "key" in node.items[0])
+  );
+}
+
+function isScalar(node: YamlNode): node is YamlScalar {
+  return !!node && typeof (node as YamlScalar).value !== "undefined" && !("items" in (node as object));
+}
+
+function walk(node: YamlNode, path: string[], source: string, out: ExtractedHit[]): void {
+  if (!node) return;
+  if (isMap(node)) {
+    for (const pair of node.items) {
+      if (!pair.key || typeof pair.key.value !== "string") continue;
+      walk(pair.value, [...path, pair.key.value], source, out);
+    }
+    return;
+  }
+  if (isSeq(node)) {
+    for (let i = 0; i < node.items.length; i++) {
+      walk(node.items[i], [...path, String(i)], source, out);
+    }
+    return;
+  }
+  if (isScalar(node) && typeof node.value === "string") {
+    if (node.value.trim().length === 0) return;
+    let identifiers = path;
+    if (path.length > 0) {
+      const m = PLURAL_SUFFIX_RE.exec(path[path.length - 1]);
+      if (m) identifiers = [...path.slice(0, -1), m[1], m[2]];
+    }
+    const start = node.range ? node.range[0] : 0;
+    out.push({
+      value: node.value,
+      location: offsetToLineCol(source, start),
+      context: { parentRole: "resource_value", identifiers },
+    });
+  }
+  // Non-string scalars: not the leaf shape we emit on.
+}
+
+function offsetToLineCol(source: string, offset: number): { line: number; column: number } {
+  let line = 1;
+  let lastNewline = -1;
+  const limit = Math.min(offset, source.length);
+  for (let i = 0; i < limit; i++) {
+    if (source.charCodeAt(i) === 10) {
+      line++;
+      lastNewline = i;
+    }
+  }
+  return { line, column: Math.max(1, offset - lastNewline) };
+}

--- a/lib/src/scan/lang/i18n-file-discovery.ts
+++ b/lib/src/scan/lang/i18n-file-discovery.ts
@@ -1,0 +1,70 @@
+import { runLlmFileTask, type LlmFileTask, type LlmFileTaskResult } from "./llm-file-discovery";
+
+const NEVER_FILENAMES: ReadonlySet<string> = new Set([
+  "package.json",
+  "package-lock.json",
+  "tsconfig.json",
+  "jsconfig.json",
+  "pnpm-lock.yaml",
+  "bun.lock",
+  "bun.lockb",
+]);
+
+const NEVER_PATTERNS: readonly RegExp[] = [/^tsconfig\.[^/]+\.json$/i, /\.schema\.json$/i, /\.lock$/i];
+
+const SYSTEM_PROMPT = `You identify internationalization (i18n) files in a codebase.
+
+An i18n file stores user-facing UI copy (button labels, error messages, headings, etc.) keyed by identifiers, intended to be read by an i18n library (i18next, react-intl, vue-i18n, Lingui, gettext, Ditto, Rails i18n, Spring/Java ResourceBundle, …). Translations of the same content in other locales also count.
+
+NOT i18n files (do not include):
+- Build / tool configs (package.json, tsconfig, eslint, prettier, babel, vite, webpack, vercel, nx, turbo)
+- Type-checker configs (pyrightconfig, mypy.ini)
+- Plugin / app manifests (plugin.json, hak.json, manifest.json, capacitor.config.json, app.json)
+- Schema files (*.schema.json, JSON Schema documents, OpenAPI / Swagger specs)
+- Database / infrastructure configs (database.yml, cable.yml, docker-compose.yml, helm Chart.yaml)
+- API request/response fixtures, test data, mock responses, eval prompts
+- LLM prompt fragments, model configs
+- CMS exports / content snapshots that happen to be all strings
+- Plain config files (auth_config.json, bruno.json, theme files)
+- API coverage reports, benchmark scenarios
+- Java/JVM application config: application.properties, log4j.properties / log4j2.properties, gradle.properties, build.properties, version.properties. These are KEY=VALUE settings (host names, ports, thread pools, log levels) — not user-facing copy
+
+Java .properties files ARE i18n when they hold UI strings keyed by message id (messages_en.properties, labels.properties, ApplicationResources_fr.properties, the content reads like sentences/labels rather than config values).
+
+Use both the file path and the content preview. The path is the strongest signal — files under \`locales/\`, \`i18n/\`, \`translations/\`, \`messages/\`, \`lang/\`, etc., or with names like \`en.json\` / \`fr.yaml\` / \`messages.en.po\` / \`messages_de.properties\`, are almost always i18n files. Custom layouts (e.g. \`<name>___<locale>.json\`) are also valid when the content matches.
+
+Return ONLY the paths that ARE i18n files.`;
+
+// All extensions the i18n discovery pass considers. The walker uses the same
+// set to decide which files are LLM-gated vs. dispatched straight to the
+// language registry, so this is the single source of truth.
+export const I18N_FILE_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".json",
+  ".yaml",
+  ".yml",
+  ".po",
+  ".properties",
+  ".arb",
+  ".xliff",
+  ".xlf",
+  ".resx",
+  ".resw",
+]);
+
+// Subset that's single-purpose enough to skip the LLM round trip.
+const AUTO_INCLUDE_EXTENSIONS: ReadonlySet<string> = new Set([".po", ".arb", ".xliff", ".xlf", ".resx", ".resw"]);
+
+export const I18N_FILES_TASK: LlmFileTask = {
+  taskName: "i18n files",
+  globs: [...I18N_FILE_EXTENSIONS].map((ext) => `**/*${ext}`),
+  preFilter: (base) => NEVER_FILENAMES.has(base) || NEVER_PATTERNS.some((re) => re.test(base)),
+  autoInclude: (relPath) => {
+    const dot = relPath.lastIndexOf(".");
+    return dot !== -1 && AUTO_INCLUDE_EXTENSIONS.has(relPath.slice(dot).toLowerCase());
+  },
+  systemPrompt: SYSTEM_PROMPT,
+};
+
+export async function findI18nFiles(rootPath: string): Promise<LlmFileTaskResult> {
+  return runLlmFileTask(rootPath, I18N_FILES_TASK);
+}

--- a/lib/src/scan/lang/llm-file-discovery.ts
+++ b/lib/src/scan/lang/llm-file-discovery.ts
@@ -1,0 +1,213 @@
+import fs from "fs/promises";
+import { globby } from "globby";
+import path from "path";
+import { z } from "zod";
+
+import { callGemini } from "../../services/gemini";
+
+// Generic LLM file classifier. Each task supplies globs + a system
+// prompt; Gemini picks the matching subset. i18n discovery is one
+// task; future passes (exclusion lists, OpenAPI specs, …) plug in the
+// same way.
+
+const DEFAULT_PREVIEW_CHARS = 400;
+const DEFAULT_MAX_FILES_PER_CALL = 250;
+
+export interface LlmFileTask {
+  taskName: string;
+  globs: string[];
+  ignore?: string[];
+  // Synchronous reject before the LLM call to save tokens.
+  preFilter?: (basename: string, relPath: string) => boolean;
+  // Confirmed without the LLM (e.g. single-purpose extensions).
+  autoInclude?: (relPath: string) => boolean;
+  systemPrompt: string;
+  previewChars?: number;
+  maxFilesPerCall?: number;
+}
+
+export interface LlmFileTaskStats {
+  task: string;
+  totalCandidates: number;
+  preFiltered: number;
+  autoIncluded: number;
+  llmConsidered: number;
+  llmConfirmed: number;
+  promptTokens: number;
+  completionTokens: number;
+  llmCalls: number;
+  elapsedMs: number;
+}
+
+export interface LlmFileTaskResult {
+  paths: Set<string>;
+  stats: LlmFileTaskStats;
+}
+
+const DEFAULT_IGNORE = [
+  "**/node_modules/**",
+  "**/.git/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/coverage/**",
+  "**/.next/**",
+  "**/.nuxt/**",
+  "**/vendor/**",
+];
+
+const ZResponse = z.object({
+  matching_paths: z.array(z.string()),
+});
+
+export async function runLlmFileTask(
+  rootPath: string,
+  task: LlmFileTask
+): Promise<LlmFileTaskResult> {
+  const t0 = Date.now();
+  const root = path.resolve(rootPath);
+  const stats: LlmFileTaskStats = {
+    task: task.taskName,
+    totalCandidates: 0,
+    preFiltered: 0,
+    autoIncluded: 0,
+    llmConsidered: 0,
+    llmConfirmed: 0,
+    promptTokens: 0,
+    completionTokens: 0,
+    llmCalls: 0,
+    elapsedMs: 0,
+  };
+
+  const allPaths = await globby(task.globs, {
+    cwd: root,
+    gitignore: true,
+    onlyFiles: true,
+    followSymbolicLinks: false,
+    suppressErrors: true,
+    ignore: [...DEFAULT_IGNORE, ...(task.ignore ?? [])],
+  });
+  stats.totalCandidates = allPaths.length;
+
+  const confirmed = new Set<string>();
+  const toAsk: string[] = [];
+
+  for (const relPath of allPaths) {
+    const base = path.basename(relPath);
+    if (task.preFilter && task.preFilter(base, relPath)) {
+      stats.preFiltered++;
+      continue;
+    }
+    if (task.autoInclude && task.autoInclude(relPath)) {
+      confirmed.add(relPath);
+      stats.autoIncluded++;
+      continue;
+    }
+    toAsk.push(relPath);
+  }
+  stats.llmConsidered = toAsk.length;
+
+  if (toAsk.length === 0) {
+    stats.elapsedMs = Date.now() - t0;
+    return { paths: confirmed, stats };
+  }
+
+  const previewChars = sanitizePositiveInt(
+    task.previewChars,
+    DEFAULT_PREVIEW_CHARS
+  );
+  const batchSize = sanitizePositiveInt(
+    task.maxFilesPerCall,
+    DEFAULT_MAX_FILES_PER_CALL
+  );
+
+  for (let i = 0; i < toAsk.length; i += batchSize) {
+    const batch = toAsk.slice(i, i + batchSize);
+    const confirmedFromBatch = await runBatch({
+      root,
+      batch,
+      systemPrompt: task.systemPrompt,
+      previewChars,
+      stats,
+    });
+    for (const p of confirmedFromBatch) confirmed.add(p);
+  }
+
+  stats.llmConfirmed = confirmed.size - stats.autoIncluded;
+  stats.elapsedMs = Date.now() - t0;
+  return { paths: confirmed, stats };
+}
+
+async function runBatch(args: {
+  root: string;
+  batch: string[];
+  systemPrompt: string;
+  previewChars: number;
+  stats: LlmFileTaskStats;
+}): Promise<string[]> {
+  const { root, batch, systemPrompt, previewChars, stats } = args;
+  const samples = await Promise.all(
+    batch.map(async (relPath) => {
+      let handle: fs.FileHandle | null = null;
+      try {
+        handle = await fs.open(path.join(root, relPath), "r");
+        // UTF-8 expansion is at most 4 bytes/char; one extra byte lets us
+        // detect overflow without rereading.
+        const buf = new Uint8Array(previewChars * 4 + 1);
+        const { bytesRead } = await handle.read(buf, 0, buf.length, 0);
+        const decoded = Buffer.from(
+          buf.buffer,
+          buf.byteOffset,
+          bytesRead
+        ).toString("utf8");
+        const preview = decoded.slice(0, previewChars);
+        const truncated =
+          decoded.length > previewChars || bytesRead === buf.length;
+        return {
+          relPath,
+          preview: preview + (truncated ? "…(truncated)" : ""),
+        };
+      } catch {
+        return null;
+      } finally {
+        await handle?.close();
+      }
+    })
+  );
+  const valid = samples.filter(
+    (s): s is { relPath: string; preview: string } => s !== null
+  );
+  if (valid.length === 0) return [];
+
+  const userPrompt = [
+    "For each of the following files, decide whether it matches the task in the system instructions.",
+    'Return ONLY the paths that match, exactly as given, in the "matching_paths" array.',
+    "",
+    ...valid.map(
+      (f, i) =>
+        `[File ${i + 1}]\npath: ${f.relPath}\npreview:\n${f.preview}\n[/File ${
+          i + 1
+        }]`
+    ),
+  ].join("\n");
+
+  stats.llmCalls++;
+  const result = await callGemini(userPrompt, ZResponse, systemPrompt);
+  if (!result) return [];
+
+  stats.promptTokens +=
+    result.metadata.geminiUsageMetadata?.promptTokenCount ?? 0;
+  stats.completionTokens +=
+    result.metadata.geminiUsageMetadata?.candidatesTokenCount ?? 0;
+
+  // Drop any path the LLM returned that wasn't in the batch.
+  const seen = new Set(valid.map((v) => v.relPath));
+  return result.data.matching_paths.filter((p) => seen.has(p));
+}
+
+function sanitizePositiveInt(
+  value: number | undefined,
+  fallback: number
+): number {
+  const n = Number(value ?? fallback);
+  return Math.max(1, Math.floor(Number.isFinite(n) ? n : fallback));
+}

--- a/lib/src/scan/lang/registry.ts
+++ b/lib/src/scan/lang/registry.ts
@@ -1,0 +1,140 @@
+import kotlin from "@ast-grep/lang-kotlin";
+import swift from "@ast-grep/lang-swift";
+import { Lang, registerDynamicLanguage } from "@ast-grep/napi";
+
+import { androidResourceExtractor } from "./extractors/android-resources";
+import { arbExtractor } from "./extractors/arb";
+import { fallbackExtractor } from "./extractors/fallback";
+import { htmlMarkupExtractor } from "./extractors/html-markup";
+import { javascriptExtractor } from "./extractors/javascript";
+import { jsonI18nExtractor } from "./extractors/json-i18n";
+import { kotlinExtractor } from "./extractors/kotlin";
+import { poExtractor } from "./extractors/po";
+import { propertiesExtractor } from "./extractors/properties";
+import { resxExtractor } from "./extractors/resx";
+import { stringsExtractor } from "./extractors/strings";
+import { stringsdictExtractor } from "./extractors/stringsdict";
+import { swiftExtractor } from "./extractors/swift";
+import { vueExtractor } from "./extractors/vue";
+import { xcstringsExtractor } from "./extractors/xcstrings";
+import { xliffExtractor } from "./extractors/xliff";
+import { yamlI18nExtractor } from "./extractors/yaml-i18n";
+import type { LanguageExtractor } from "./types";
+
+// Tree-sitter grammars for Kotlin and Swift are not bundled with
+// @ast-grep/napi; they ship as separate prebuilt parsers and get loaded
+// at module init so any consumer importing the registry has them ready.
+registerDynamicLanguage({ kotlin, swift });
+
+export interface Language {
+  id: string;
+  extensions: string[];
+  extractor: LanguageExtractor;
+  // Optional second-stage filter. When the extension matches but the
+  // pathMatches predicate rejects, this language is skipped. Used to
+  // narrow an ambiguous extension like ".xml" to Android `res/values/`.
+  // Note that iOS `.strings`/`.stringsdict` deliberately do not use a
+  // pathMatches filter — every locale flows through.
+  pathMatches?: (relPath: string) => boolean;
+}
+
+export const REGEX_FALLBACK_ID = "regex_fallback";
+
+// Source-code-like extensions handled by the regex fallback when no
+// dedicated language is defined.
+const REGEX_FALLBACK_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".py",
+  ".go",
+  ".rb",
+  ".java",
+  ".rs",
+  ".c",
+  ".h",
+  ".cc",
+  ".cpp",
+  ".hpp",
+  ".m",
+  ".mm",
+  ".cs",
+  ".php",
+  ".lua",
+  ".dart",
+  ".svelte",
+  ".astro",
+  ".hbs",
+  ".ejs",
+  ".liquid",
+  ".erb",
+]);
+
+// `res/values/` and locale-qualified `res/values-<X>/` both flow
+// through; downstream groups by resource key.
+function isAndroidResource(relPath: string): boolean {
+  return /(^|\/)res\/values(?:-[^/]+)?\/[^/]+\.xml$/i.test(relPath);
+}
+
+// Web i18n formats (.json/.yaml/.po) are gated by the LLM discovery
+// pass in `walk.ts` rather than by a path predicate here.
+
+export const LANGUAGES: readonly Language[] = [
+  { id: "typescript", extensions: [".ts", ".cts", ".mts"], extractor: javascriptExtractor(Lang.TypeScript) },
+  { id: "tsx", extensions: [".tsx"], extractor: javascriptExtractor(Lang.Tsx) },
+  { id: "javascript", extensions: [".js", ".cjs", ".mjs"], extractor: javascriptExtractor(Lang.JavaScript) },
+  // .jsx uses Tsx because ast-grep's JavaScript grammar doesn't parse JSX.
+  { id: "jsx", extensions: [".jsx"], extractor: javascriptExtractor(Lang.Tsx) },
+  { id: "html", extensions: [".html", ".htm"], extractor: htmlMarkupExtractor },
+  { id: "vue", extensions: [".vue"], extractor: vueExtractor },
+  // Kotlin grammar also handles .kts (Gradle scripts) and .ktm (Kotlin modules).
+  { id: "kotlin", extensions: [".kt", ".kts", ".ktm"], extractor: kotlinExtractor },
+  { id: "swift", extensions: [".swift"], extractor: swiftExtractor },
+  // iOS .lproj/ files — every locale flows through.
+  { id: "ios_strings", extensions: [".strings"], extractor: stringsExtractor },
+  { id: "ios_stringsdict", extensions: [".stringsdict"], extractor: stringsdictExtractor },
+  // Xcode String Catalog: every locale lives in one file; the extractor
+  // walks each locale block internally.
+  { id: "ios_xcstrings", extensions: [".xcstrings"], extractor: xcstringsExtractor },
+  {
+    id: "android_resources",
+    extensions: [".xml"],
+    extractor: androidResourceExtractor,
+    pathMatches: isAndroidResource,
+  },
+  // Bound by extension via findI18nLanguageForExt after the walker's
+  // LLM discovery pass admits the file.
+  { id: "json_i18n", extensions: [".json"], extractor: jsonI18nExtractor },
+  { id: "yaml_i18n", extensions: [".yaml", ".yml"], extractor: yamlI18nExtractor },
+  { id: "po", extensions: [".po"], extractor: poExtractor },
+  { id: "properties", extensions: [".properties"], extractor: propertiesExtractor },
+  { id: "arb", extensions: [".arb"], extractor: arbExtractor },
+  { id: "xliff", extensions: [".xliff", ".xlf"], extractor: xliffExtractor },
+  { id: "resx", extensions: [".resx", ".resw"], extractor: resxExtractor },
+];
+
+const REGEX_FALLBACK_LANGUAGE: Language = {
+  id: REGEX_FALLBACK_ID,
+  extensions: [],
+  extractor: fallbackExtractor,
+};
+
+export function findLanguageForFile({ ext, relPath }: { ext: string; relPath: string }): Language | null {
+  const lower = ext.toLowerCase();
+  for (const lang of LANGUAGES) {
+    if (!lang.extensions.includes(lower)) continue;
+    if (lang.pathMatches && !lang.pathMatches(relPath)) continue;
+    return lang;
+  }
+  return REGEX_FALLBACK_EXTENSIONS.has(lower) ? REGEX_FALLBACK_LANGUAGE : null;
+}
+
+const I18N_LANGUAGE_IDS = new Set(["json_i18n", "yaml_i18n", "po", "properties", "arb", "xliff", "resx"]);
+
+// Used by the walker once the LLM discovery pass has already admitted
+// a path — skips the normal dispatch loop's pathMatches check.
+export function findI18nLanguageForExt(ext: string): Language | null {
+  const lower = ext.toLowerCase();
+  for (const lang of LANGUAGES) {
+    if (!I18N_LANGUAGE_IDS.has(lang.id)) continue;
+    if (lang.extensions.includes(lower)) return lang;
+  }
+  return null;
+}

--- a/lib/src/scan/lang/types.ts
+++ b/lib/src/scan/lang/types.ts
@@ -1,0 +1,13 @@
+import type { DittoScanEnclosingContext } from "../types";
+
+export interface ExtractedHit {
+  value: string;
+  location: { line: number; column: number }; // 1-based
+  context: DittoScanEnclosingContext;
+}
+
+// Escape hatch for languages that don't fit the engine's spec-driven path
+// (the regex fallback and SFC formats like Vue).
+export interface LanguageExtractor {
+  extract(opts: { source: string; kind: string }): Promise<ExtractedHit[]>;
+}

--- a/lib/src/scan/preClassify.ts
+++ b/lib/src/scan/preClassify.ts
@@ -1,0 +1,50 @@
+import type { DittoScanCandidate, DittoScanResult } from "./types";
+import type { Verdict } from "./rules";
+
+export interface DittoScanPreClassifyResult {
+  // Candidates the rule classifier did not decide on. These flow to the
+  // LLM stage.
+  llmCandidates: DittoScanCandidate[];
+  // Candidates the rule classifier decided. Each is materialized as a
+  // Result with confidence=1 and decided_by="rule" so it interleaves with
+  // LLM-decided results in the final output.
+  preClassified: DittoScanResult[];
+}
+
+// Bridge between `runExtract` (which produces Candidates + Verdicts) and
+// `runClassify` (which only wants LLM-bound Candidates). Splits the
+// extract output and materializes rule-decided Results.
+export function preClassify(
+  candidates: DittoScanCandidate[],
+  verdicts: Map<string, Verdict>
+): DittoScanPreClassifyResult {
+  const llmCandidates: DittoScanCandidate[] = [];
+  const preClassified: DittoScanResult[] = [];
+
+  for (const c of candidates) {
+    const verdict = verdicts.get(c.id) ?? { kind: "llm" as const };
+    if (verdict.kind === "accept") {
+      preClassified.push({
+        ...c,
+        status: "user-facing",
+        reason: `rule:${verdict.rule}`,
+        confidence: 1,
+        info_needed: null,
+        decided_by: "rule",
+      });
+    } else if (verdict.kind === "reject") {
+      preClassified.push({
+        ...c,
+        status: "not-user-facing",
+        reason: `rule:${verdict.rule}`,
+        confidence: 1,
+        info_needed: null,
+        decided_by: "rule",
+      });
+    } else {
+      llmCandidates.push(c);
+    }
+  }
+
+  return { llmCandidates, preClassified };
+}

--- a/lib/src/scan/rules/accept/common.ts
+++ b/lib/src/scan/rules/accept/common.ts
@@ -1,0 +1,100 @@
+import type { Rule } from "../types";
+
+// HTML/JSX/Vue attribute names whose values are exclusively human-readable
+// copy. Symmetric counterpart to NON_TEXT_ATTR_NAMES in drop.ts: those are
+// always-non-text attrs (dropped); these are always-copy attrs (accepted).
+const COPY_ATTR_NAMES: ReadonlySet<string> = new Set([
+  "placeholder",
+  "alt",
+  "aria-label",
+  "aria-placeholder",
+  "aria-roledescription",
+  "aria-valuetext",
+  "title",
+  "summary",
+]);
+
+// HTML elements whose text content is unambiguously user-facing copy.
+// Allowlist (rather than denylist) so component tags like `<Foo>` and
+// generic containers like `<div>` fall through to the LLM — components
+// can have arbitrary semantics (e.g. `<Trans>` in react-i18next treats
+// children as a translation key), and `<div>` is too generic.
+//
+// `text` is included to cover two distinct cases that happen to share
+// the same lowercased tag name:
+//   - React Native's `<Text>...</Text>` (the canonical RN copy holder)
+//   - SVG's `<text>...</text>` (renders the inner text inside the SVG)
+// Both are unambiguous copy.
+const COPY_TAGS: ReadonlySet<string> = new Set([
+  // Headings + sectioning
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "p",
+  "blockquote",
+  // Lists / tables
+  "li",
+  "dd",
+  "dt",
+  "td",
+  "th",
+  "caption",
+  // Forms / interactive
+  "button",
+  "a",
+  "label",
+  "option",
+  "legend",
+  "summary",
+  // Figures
+  "figcaption",
+  // Inline phrasing
+  "span",
+  "text",
+  "em",
+  "strong",
+  "b",
+  "i",
+  "small",
+  "mark",
+  "q",
+  "cite",
+  "dfn",
+  "abbr",
+  "time",
+  "sub",
+  "sup",
+  "ins",
+  "del",
+]);
+
+export const COMMON_ACCEPT_RULES: Rule[] = [
+  {
+    name: "resource_value",
+    // Every entry in a localization resource file (.strings, .stringsdict,
+    // .xcstrings, strings.xml) is intentional product copy, including the
+    // entries the developer marked `translatable="false"`. Those are still
+    // user-facing strings (app names, brand strings, accessibility labels);
+    // the flag just opts them out of localization, not out of the UI.
+    match: ({ candidate }) => candidate.detection_kind === "resource_value",
+  },
+  {
+    name: "markup_attr_copy",
+    match: ({ candidate }) =>
+      candidate.detection_kind === "markup_attr" &&
+      candidate.context_identifiers.length > 0 &&
+      COPY_ATTR_NAMES.has(candidate.context_identifiers[0].toLowerCase()),
+  },
+  {
+    name: "markup_text_safe",
+    // JSX/Vue text content (`<button>Save</button>`, `<p>...</p>`) is
+    // unambiguous copy when the wrapping tag is a known text-bearing
+    // HTML element. Components, fragments, generic containers (`<div>`),
+    // and code-bearing tags fall through to the LLM.
+    match: ({ context }) =>
+      context.parentRole === "markup_text" && context.parentTag !== undefined && COPY_TAGS.has(context.parentTag),
+  },
+];

--- a/lib/src/scan/rules/accept/index.ts
+++ b/lib/src/scan/rules/accept/index.ts
@@ -1,0 +1,16 @@
+import type { Rule, RulesByLanguage } from "../types";
+
+import { COMMON_ACCEPT_RULES } from "./common";
+import { KOTLIN_ACCEPT_RULES } from "./kotlin";
+import { SWIFT_ACCEPT_RULES } from "./swift";
+
+// Accept rules keyed by Candidate.language. Language-specific rules run
+// before cross-language ones; the first match wins. The map is typed
+// against `RulesByLanguage` (= `{ [K in RuleLanguage]?: Rule[] }`) so an
+// unknown or misspelled key is a compile error.
+export const ACCEPT_RULES_BY_LANGUAGE: RulesByLanguage = {
+  kotlin: KOTLIN_ACCEPT_RULES,
+  swift: SWIFT_ACCEPT_RULES,
+};
+
+export const ACCEPT_RULES_COMMON: Rule[] = COMMON_ACCEPT_RULES;

--- a/lib/src/scan/rules/accept/kotlin.ts
+++ b/lib/src/scan/rules/accept/kotlin.ts
@@ -1,0 +1,45 @@
+import type { Rule } from "../types";
+
+// `(receiver, method)` pairs whose first string argument is user-facing
+// copy. These are the standard Android UI surfaces. Receiver match is
+// strict (callee + calleeMember, bare identifier) so an unrelated
+// variable named `Toast` doesn't fire. The factory signatures
+// (`Toast.makeText(ctx, text, duration)`, `Snackbar.make(view, text, duration)`)
+// place the only String-typed parameter at arg index 1, so any string
+// literal at these call sites is necessarily the message.
+const ANDROID_UI_FACTORY_CALLS: ReadonlyArray<readonly [string, string]> = [
+  ["Toast", "makeText"],
+  ["Snackbar", "make"],
+];
+
+export const KOTLIN_ACCEPT_RULES: Rule[] = [
+  {
+    name: "compose_text",
+    // Jetpack Compose's `Text(...)` composable takes a String literal that
+    // is rendered directly as UI. Unlike SwiftUI's Text (which auto-looks
+    // up against Localizable bundles via LocalizedStringKey), Compose
+    // performs no resource lookup — the literal IS the displayed copy.
+    //
+    // Gated on the `android` framework token so a non-Android Kotlin
+    // project that happens to define its own `Text(...)` function doesn't
+    // get every constructor argument auto-classified as UI copy.
+    //
+    // We match only the bare-identifier call `Text("...")`, not
+    // `Text(stringResource(...))` (which doesn't put a literal in the
+    // first arg position) and not method calls like `myWidget.Text(...)`.
+    match: ({ candidate, context }) =>
+      candidate.framework.includes("android") && context.callee === "Text" && context.calleeMember === undefined,
+  },
+  {
+    name: "android_ui_factory",
+    // `Toast.makeText(ctx, "Saved", LENGTH_SHORT)`, `Snackbar.make(view, "...", ...)`.
+    // Receiver is a bare type identifier; the method is a known factory.
+    match: ({ context }) => {
+      if (!context.callee || !context.calleeMember) return false;
+      for (const [receiver, method] of ANDROID_UI_FACTORY_CALLS) {
+        if (context.callee === receiver && context.calleeMember === method) return true;
+      }
+      return false;
+    },
+  },
+];

--- a/lib/src/scan/rules/accept/swift.ts
+++ b/lib/src/scan/rules/accept/swift.ts
@@ -1,0 +1,5 @@
+import type { Rule } from "../types";
+
+// SwiftUI string arguments are often user-facing, but can also be
+// localization keys. Keep those ambiguous cases on the LLM path.
+export const SWIFT_ACCEPT_RULES: Rule[] = [];

--- a/lib/src/scan/rules/drop.test.ts
+++ b/lib/src/scan/rules/drop.test.ts
@@ -1,0 +1,106 @@
+import type { DittoScanEnclosingContext } from "../types";
+
+import { shouldEmit } from "./drop";
+
+const other: DittoScanEnclosingContext = {
+  parentRole: "other",
+  identifiers: [],
+};
+const markupText: DittoScanEnclosingContext = {
+  parentRole: "markup_text",
+  identifiers: [],
+  parentTag: "p",
+};
+const markupAttr = (name: string): DittoScanEnclosingContext => ({
+  parentRole: "markup_attr",
+  identifiers: [name],
+});
+const role = (
+  parentRole: DittoScanEnclosingContext["parentRole"]
+): DittoScanEnclosingContext => ({ parentRole, identifiers: [] });
+
+describe("shouldEmit", () => {
+  test("accepts normal user-facing copy", () => {
+    expect(shouldEmit("Save changes", other)).toBe(true);
+    expect(shouldEmit("Welcome back", markupText)).toBe(true);
+  });
+
+  test("rejects strings shorter than the minimum length", () => {
+    expect(shouldEmit("", other)).toBe(false);
+    expect(shouldEmit("a", other)).toBe(false);
+    expect(shouldEmit("ok", other)).toBe(true);
+  });
+
+  test("strips one wrapping pair of source quotes before shape checks", () => {
+    expect(shouldEmit('"https://example.com"', other)).toBe(false);
+    expect(shouldEmit("'https://example.com'", other)).toBe(false);
+    expect(shouldEmit("`https://example.com`", other)).toBe(false);
+  });
+
+  test("rejects URLs and URI-scheme tokens", () => {
+    expect(shouldEmit("https://example.com", other)).toBe(false);
+    expect(shouldEmit("mailto:hi@example.com", other)).toBe(false);
+    expect(shouldEmit("data:image/png;base64,abc", other)).toBe(false);
+  });
+
+  test("rejects file paths", () => {
+    expect(shouldEmit("./components/button.tsx", other)).toBe(false);
+    expect(shouldEmit("../shared/utils", other)).toBe(false);
+    expect(shouldEmit("/usr/local/bin/node", other)).toBe(false);
+    expect(shouldEmit("github.com/foo/bar", other)).toBe(false);
+  });
+
+  test("rejects UUIDs, hex colors, and version strings", () => {
+    expect(shouldEmit("550e8400-e29b-41d4-a716-446655440000", other)).toBe(
+      false
+    );
+    expect(shouldEmit("#ff00aa", other)).toBe(false);
+    expect(shouldEmit("v1.2.3-beta.1", other)).toBe(false);
+  });
+
+  test("keeps short English words that happen to be hex-shaped", () => {
+    // 4-char tokens without `#` should not be filtered (else "dead", "face", "cafe" get lost).
+    expect(shouldEmit("dead", other)).toBe(true);
+    expect(shouldEmit("cafe", other)).toBe(true);
+  });
+
+  test("rejects pure punctuation/whitespace", () => {
+    expect(shouldEmit("...", other)).toBe(false);
+    expect(shouldEmit("---", other)).toBe(false);
+    expect(shouldEmit("  ", other)).toBe(false);
+  });
+
+  test("rejects format-directive-only strings but keeps copy that contains a directive", () => {
+    expect(shouldEmit("%@", other)).toBe(false);
+    expect(shouldEmit("%#@items@", other)).toBe(false);
+    expect(shouldEmit("%1$#@count@", other)).toBe(false);
+    expect(shouldEmit("%d items", other)).toBe(true);
+    expect(shouldEmit("%#@count@ remaining", other)).toBe(true);
+  });
+
+  test("rejects bare Vue/Angular interpolation but keeps interpolation with a literal fallback", () => {
+    expect(shouldEmit("{{ title }}", other)).toBe(false);
+    expect(shouldEmit("{{ user.name }}", other)).toBe(false);
+    expect(shouldEmit("{{ x ?? 'fallback text' }}", other)).toBe(true);
+  });
+
+  test("rejects parentRoles in the excluded set", () => {
+    expect(shouldEmit("foo", role("import"))).toBe(false);
+    expect(shouldEmit("foo", role("regex_pattern"))).toBe(false);
+    expect(shouldEmit("foo", role("object_key"))).toBe(false);
+    expect(shouldEmit("foo", role("index_access"))).toBe(false);
+    expect(shouldEmit("foo", role("type_tag"))).toBe(false);
+  });
+
+  test("rejects markup_attr values on structural/identifying attributes", () => {
+    expect(shouldEmit("primary", markupAttr("className"))).toBe(false);
+    expect(shouldEmit("#root", markupAttr("id"))).toBe(false);
+    expect(shouldEmit("submit", markupAttr("data-testid"))).toBe(false);
+    expect(shouldEmit("true", markupAttr("aria-hidden"))).toBe(false);
+  });
+
+  test("keeps markup_attr values on copy-bearing attributes (handled by accept rule downstream)", () => {
+    expect(shouldEmit("Email address", markupAttr("placeholder"))).toBe(true);
+    expect(shouldEmit("Close dialog", markupAttr("aria-label"))).toBe(true);
+  });
+});

--- a/lib/src/scan/rules/drop.ts
+++ b/lib/src/scan/rules/drop.ts
@@ -1,0 +1,190 @@
+import type {
+  DittoScanDetectionKind,
+  DittoScanEnclosingContext,
+} from "../types";
+
+// Unambiguous non-text value shapes. A pattern belongs here only if there
+// is effectively zero chance a real UI string could match it.
+const NON_TEXT_SHAPES: RegExp[] = [
+  /^https?:\/\//i, // URLs
+  /^(?:mailto|tel|file|ws|wss|ftp|data|blob|javascript):/i, // other URI schemes
+  /^\.{1,2}\//, // relative paths ./foo, ../bar
+  /^\/[A-Za-z0-9_\-./@]+$/, // absolute paths / URL paths
+  /^[A-Za-z0-9_\-]+(?:\.[A-Za-z0-9_\-]+)+\/[A-Za-z0-9_./\-@]+$/, // package paths: github.com/foo/bar
+  /^[A-Za-z0-9_.\-]+(?:\/[A-Za-z0-9_.\-]+){2,}$/, // 3+ slash-separated path segments
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, // uuid
+  // Hex color. Allow 3, 4, 6, or 8 digits with a leading `#`, but only 6
+  // or 8 digits without `#`, so short English words like "dead", "face",
+  // or "cafe" don't get filtered out.
+  /^(?:#[0-9a-fA-F]{3,4}|#?[0-9a-fA-F]{6}|#?[0-9a-fA-F]{8})$/,
+  /^rgba?\(/i, // rgb(...) / rgba(...)
+  /^v?\d+\.\d+(?:\.\d+)?(?:[-+][\w.]+)?$/, // version
+  /^[\s\p{P}\p{S}]+$/u, // only whitespace + punctuation/symbols
+  // Pure printf/Cocoa format directives with no surrounding readable
+  // text: `%@`, `%d`, `%#@items@`, `%1$#@count@`, `%#@a@%#@b@`. Used by
+  // iOS .stringsdict NSStringLocalizedFormatKey values (Apple's plural
+  // template syntax) and similar format-only strings.
+  //
+  // Matches an unbroken chain of directives. As soon as there's
+  // surrounding text (a space, punctuation, real word characters
+  // outside an @var@ name) the chain breaks and the string is treated
+  // as displayable copy. Examples:
+  //   "%@"                  match (drop)
+  //   "%1$#@count@"         match (drop)
+  //   "%#@a@%#@b@"          match (drop)
+  //   "%d items"            no match (real text)
+  //   "%#@count@ remaining" no match (real text)
+  /^(?:%(?:\d+\$)?(?:#?@\w+@|[hl]{0,2}[%@a-zA-Z]))+$/,
+  // Vue / Angular interpolation that resolves to a variable with no
+  // literal copy of its own: `{{ title }}`, `{{ datetime }}`,
+  // `{{ user.name }}`. Treated as not-translatable here.
+  //
+  // We require the inner expression to contain no quote characters so
+  // `{{ x ?? 'fallback text' }}` — which carries a literal fallback
+  // worth translating — is preserved.
+  /^\s*\{\{[^'"`{}]*\}\}\s*$/,
+];
+
+const EXCLUDED_KINDS: ReadonlySet<DittoScanDetectionKind> =
+  new Set<DittoScanDetectionKind>([
+    "import",
+    "regex_pattern",
+    "object_key",
+    "index_access",
+    "type_tag",
+  ]);
+
+// HTML/JSX/Vue attribute names whose value is structural, identifying, or
+// stylistic — not human-readable text. Text-bearing attrs like alt, title,
+// placeholder, aria-label, summary, value are deliberately absent.
+const NON_TEXT_ATTR_NAMES: ReadonlySet<string> = new Set([
+  "class",
+  "classname",
+  "style",
+  "href",
+  "src",
+  "srcset",
+  "action",
+  "formaction",
+  "poster",
+  "id",
+  "name",
+  "key",
+  "slot",
+  "for",
+  "htmlfor",
+  "type",
+  "role",
+  "rel",
+  "target",
+  "xmlns",
+  "lang",
+  "dir",
+  "hreflang",
+  "data-testid",
+  "data-test",
+  "data-test-id",
+  "data-cy",
+  "data-qa",
+  // SVG painting + geometry. Stroke/fill/transform/path/points are
+  // already here; these cover the remaining numeric/structural attrs
+  // commonly seen in inline icon JSX.
+  "viewbox",
+  "d",
+  "points",
+  "fill",
+  "stroke",
+  "transform",
+  "strokewidth",
+  "strokelinecap",
+  "strokelinejoin",
+  "strokemiterlimit",
+  "strokedasharray",
+  "strokedashoffset",
+  "fillopacity",
+  "fillrule",
+  "x",
+  "y",
+  "x1",
+  "y1",
+  "x2",
+  "y2",
+  "cx",
+  "cy",
+  "r",
+  "rx",
+  "ry",
+  "width",
+  "height",
+  "size",
+  "sizes",
+  // react-i18next translation key — the rendered text comes from
+  // locale tables, not this string.
+  "i18nkey",
+  // SVG masking + clipping.
+  "mask",
+  "maskunits",
+  "clippath",
+  "cliprule",
+  // ARIA state attributes with fixed value vocabularies (boolean,
+  // tri-state, or enum). `aria-label`, `aria-placeholder`,
+  // `aria-roledescription`, etc. — the ones that hold actual copy —
+  // are deliberately left for the accept rule to pick up.
+  "aria-hidden",
+  "aria-disabled",
+  "aria-expanded",
+  "aria-selected",
+  "aria-checked",
+  "aria-pressed",
+  "aria-current",
+  "aria-modal",
+  "aria-haspopup",
+  "aria-busy",
+  "aria-live",
+  "aria-atomic",
+  "aria-relevant",
+  // ARIA attributes whose value is an ID reference to another element,
+  // not displayed text. Distinct from `aria-label` (and friends) which
+  // hold actual copy.
+  "aria-labelledby",
+  "aria-describedby",
+  "aria-controls",
+  "aria-owns",
+  "aria-flowto",
+  "aria-activedescendant",
+  "aria-errormessage",
+  "aria-details",
+]);
+
+const MIN_STRING_LENGTH = 2;
+
+// JS / TS / Swift / Kotlin extractors emit `value_raw` with the source
+// quote characters preserved (`"hello"`, `'hello'`, `` `hello` ``). The
+// LLM payload wants those quotes intact, but for shape-based drop checks
+// they get in the way: `^https?://` won't match `"https://..."`. Strip a
+// single matching pair before running the shape regexes.
+function stripWrappingQuotes(value: string): string {
+  if (value.length < 2) return value;
+  const first = value[0];
+  const last = value[value.length - 1];
+  if ((first === '"' || first === "'" || first === "`") && first === last) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+export function shouldEmit(
+  value: string,
+  ctx: DittoScanEnclosingContext
+): boolean {
+  const trimmed = stripWrappingQuotes(value.trim()).trim();
+  if (trimmed.length < MIN_STRING_LENGTH) return false;
+  if (NON_TEXT_SHAPES.some((re) => re.test(trimmed))) return false;
+  if (EXCLUDED_KINDS.has(ctx.parentRole)) return false;
+  if (
+    ctx.parentRole === "markup_attr" &&
+    NON_TEXT_ATTR_NAMES.has((ctx.identifiers[0] ?? "").toLowerCase())
+  )
+    return false;
+  return true;
+}

--- a/lib/src/scan/rules/index.ts
+++ b/lib/src/scan/rules/index.ts
@@ -1,0 +1,51 @@
+import { ACCEPT_RULES_BY_LANGUAGE, ACCEPT_RULES_COMMON } from "./accept";
+import { REJECT_RULES_BY_LANGUAGE, REJECT_RULES_COMMON } from "./reject";
+import type { Rule, RuleInput, RuleLanguage, RulesByLanguage, Verdict } from "./types";
+
+export { shouldEmit } from "./drop";
+export type { Rule, RuleInput, Verdict } from "./types";
+
+// Guarded lookup for language-keyed rule maps. `candidate.language` is a
+// free-form string at runtime (the extractor emits a wider set than rules
+// dispatch on), so a value like "constructor" would otherwise surface an
+// inherited prototype property and crash the `for...of` below.
+function getLanguageRules(rules: RulesByLanguage, lang: string): Rule[] {
+  return Object.prototype.hasOwnProperty.call(rules, lang) ? rules[lang as RuleLanguage] ?? [] : [];
+}
+
+// Apply the deterministic rule classifier to a candidate that has already
+// cleared `shouldEmit`. Returns `{ kind: "llm" }` when no rule matches;
+// the caller then sends the candidate to the LLM stage.
+//
+// Dispatch order, first match wins:
+//   1. Reject before accept. A reject carve-out like Android
+//      `translatable="false"` needs to win over a broad accept rule
+//      (`resource_value`) that would otherwise fire on the same candidate.
+//   2. Within reject (and within accept): language-specific before common.
+//      Lets a per-language rule disambiguate a shape that the cross-language
+//      list would otherwise treat generically.
+//
+// The candidate's `language` is a free string at the type level (the
+// extractor emits a wider set than rules dispatch on, including
+// regex-fallback extensions). The lookups below treat any non-RuleLanguage
+// tag as "no language-specific rules", so the candidate flows naturally
+// through common-then-llm.
+export function getClassificationVerdict(input: RuleInput): Verdict {
+  const lang = input.candidate.language;
+  const rejectLangRules = getLanguageRules(REJECT_RULES_BY_LANGUAGE, lang);
+  const acceptLangRules = getLanguageRules(ACCEPT_RULES_BY_LANGUAGE, lang);
+
+  for (const rule of rejectLangRules) {
+    if (rule.match(input)) return { kind: "reject", rule: rule.name };
+  }
+  for (const rule of REJECT_RULES_COMMON) {
+    if (rule.match(input)) return { kind: "reject", rule: rule.name };
+  }
+  for (const rule of acceptLangRules) {
+    if (rule.match(input)) return { kind: "accept", rule: rule.name };
+  }
+  for (const rule of ACCEPT_RULES_COMMON) {
+    if (rule.match(input)) return { kind: "accept", rule: rule.name };
+  }
+  return { kind: "llm" };
+}

--- a/lib/src/scan/rules/reject/common.ts
+++ b/lib/src/scan/rules/reject/common.ts
@@ -1,0 +1,9 @@
+import type { Rule } from "../types";
+
+// No cross-language reject rules at present. We previously rejected
+// Android `<string translatable="false">` entries on the theory that
+// they're developer-only configuration values. In practice many of
+// those entries are real UI copy that the developer just chose not to
+// localize (app names, brand strings, accessibility labels), so they
+// flow through as `resource_value` accepts like everything else.
+export const COMMON_REJECT_RULES: Rule[] = [];

--- a/lib/src/scan/rules/reject/index.ts
+++ b/lib/src/scan/rules/reject/index.ts
@@ -1,0 +1,24 @@
+import type { Rule, RulesByLanguage } from "../types";
+
+import { COMMON_REJECT_RULES } from "./common";
+import { JAVASCRIPT_REJECT_RULES } from "./javascript";
+import { KOTLIN_REJECT_RULES } from "./kotlin";
+import { SWIFT_REJECT_RULES } from "./swift";
+
+// Reject rules keyed by Candidate.language. Language-specific rules run
+// before cross-language ones; the first match wins. The map is typed
+// against `RulesByLanguage` (= `{ [K in RuleLanguage]?: Rule[] }`) so an
+// unknown or misspelled key is a compile error.
+export const REJECT_RULES_BY_LANGUAGE: RulesByLanguage = {
+  javascript: JAVASCRIPT_REJECT_RULES,
+  typescript: JAVASCRIPT_REJECT_RULES,
+  jsx: JAVASCRIPT_REJECT_RULES,
+  tsx: JAVASCRIPT_REJECT_RULES,
+  // Vue files run their `<script>` body through the JS extractor, so
+  // candidates with language="vue" share the JS callee shapes.
+  vue: JAVASCRIPT_REJECT_RULES,
+  swift: SWIFT_REJECT_RULES,
+  kotlin: KOTLIN_REJECT_RULES,
+};
+
+export const REJECT_RULES_COMMON: Rule[] = COMMON_REJECT_RULES;

--- a/lib/src/scan/rules/reject/javascript.ts
+++ b/lib/src/scan/rules/reject/javascript.ts
@@ -1,0 +1,72 @@
+import type { Rule } from "../types";
+
+// Members of `console.*` whose string args are debug output. We list the
+// methods that take strings explicitly so we don't sweep up unrelated
+// future additions to the console API.
+const CONSOLE_METHODS: ReadonlySet<string> = new Set([
+  "log",
+  "warn",
+  "error",
+  "info",
+  "debug",
+  "trace",
+  "assert",
+  "dir",
+  "table",
+  "group",
+  "groupCollapsed",
+  "time",
+  "timeLog",
+  "timeEnd",
+  "count",
+  "countReset",
+]);
+
+// Top-level function / constructor names whose first string arg is an
+// opaque token, not user-facing copy. `URL`, `URLSearchParams`, etc. cover
+// both `new URL("...")` and the (less common) `URL("...")` call form.
+const NON_TEXT_BARE_CALLEES: ReadonlySet<string> = new Set([
+  "Symbol",
+  "BigInt",
+  "Number",
+  "Date",
+  "parseInt",
+  "parseFloat",
+  "atob",
+  "btoa",
+  "encodeURIComponent",
+  "decodeURIComponent",
+  "encodeURI",
+  "decodeURI",
+  "URL",
+  "URLSearchParams",
+]);
+
+// Member calls `Foo.method(...)` whose first string arg is a serialized
+// payload or binary token, not copy.
+const NON_TEXT_MEMBER_CALLS: ReadonlyArray<readonly [string, string]> = [
+  ["JSON", "parse"],
+  ["JSON", "stringify"],
+  ["Buffer", "from"],
+];
+
+export const JAVASCRIPT_REJECT_RULES: Rule[] = [
+  {
+    name: "logger_call",
+    match: ({ context }) =>
+      context.callee === "console" && context.calleeMember !== undefined && CONSOLE_METHODS.has(context.calleeMember),
+  },
+  {
+    name: "non_text_call",
+    match: ({ context }) => {
+      if (!context.callee) return false;
+      if (context.calleeMember === undefined) {
+        return NON_TEXT_BARE_CALLEES.has(context.callee);
+      }
+      for (const [receiver, method] of NON_TEXT_MEMBER_CALLS) {
+        if (context.callee === receiver && context.calleeMember === method) return true;
+      }
+      return false;
+    },
+  },
+];

--- a/lib/src/scan/rules/reject/kotlin.ts
+++ b/lib/src/scan/rules/reject/kotlin.ts
@@ -1,0 +1,75 @@
+import type { Rule } from "../types";
+
+// Receiver names whose methods are logging APIs. We allowlist the actual
+// log methods rather than accepting any member on Log/Timber, so a class
+// shadowing the name (or a non-logging static on the same object — e.g.
+// `Log.getStackTraceString(...)` returns a string but isn't user output)
+// doesn't get auto-rejected.
+const LOGGER_RECEIVERS: ReadonlySet<string> = new Set(["Log", "Timber"]);
+const LOGGER_RECEIVER_METHODS: ReadonlySet<string> = new Set([
+  // android.util.Log levels
+  "v",
+  "d",
+  "i",
+  "w",
+  "e",
+  "wtf",
+  // Timber API surface — same levels plus tree/tag plumbing
+  "tag",
+  "log",
+  "plant",
+  "uproot",
+]);
+
+// Bare-identifier calls whose first string arg is a debug message.
+const LOGGER_BARE_CALLEES: ReadonlySet<string> = new Set(["println", "print"]);
+
+// Bare-identifier calls whose message arg is a runtime-failure reason.
+// `check`/`require` accept a String or a String-returning lambda; we tag
+// the string literal inside either form.
+const RUNTIME_FAIL_CALLEES: ReadonlySet<string> = new Set([
+  "error",
+  "check",
+  "checkNotNull",
+  "require",
+  "requireNotNull",
+  "TODO",
+]);
+
+// Bare-identifier constructors whose first string arg is a URL or regex
+// pattern, not copy.
+const NON_TEXT_CALLEES: ReadonlySet<string> = new Set(["URL", "URI"]);
+
+// Member calls `Foo.method(...)` whose first string arg is non-text.
+const NON_TEXT_MEMBER_CALLS: ReadonlyArray<readonly [string, string]> = [["Pattern", "compile"]];
+
+export const KOTLIN_REJECT_RULES: Rule[] = [
+  {
+    name: "logger_call",
+    match: ({ context }) => {
+      if (!context.callee) return false;
+      if (context.calleeMember !== undefined) {
+        return LOGGER_RECEIVERS.has(context.callee) && LOGGER_RECEIVER_METHODS.has(context.calleeMember);
+      }
+      return LOGGER_BARE_CALLEES.has(context.callee);
+    },
+  },
+  {
+    name: "runtime_fail",
+    match: ({ context }) =>
+      context.callee !== undefined && context.calleeMember === undefined && RUNTIME_FAIL_CALLEES.has(context.callee),
+  },
+  {
+    name: "non_text_call",
+    match: ({ context }) => {
+      if (!context.callee) return false;
+      if (context.calleeMember === undefined) {
+        return NON_TEXT_CALLEES.has(context.callee);
+      }
+      for (const [receiver, method] of NON_TEXT_MEMBER_CALLS) {
+        if (context.callee === receiver && context.calleeMember === method) return true;
+      }
+      return false;
+    },
+  },
+];

--- a/lib/src/scan/rules/reject/swift.ts
+++ b/lib/src/scan/rules/reject/swift.ts
@@ -1,0 +1,37 @@
+import type { Rule } from "../types";
+
+// Top-level logging functions in Swift. Each takes a message string in
+// position 0 (or sometimes a variadic list of messages). Their content
+// is debug output, never UI.
+const LOGGER_CALLEES: ReadonlySet<string> = new Set(["print", "NSLog", "os_log", "debugPrint"]);
+
+// Runtime-failure functions. The message arg shows up only in crash logs
+// and Xcode debugger, not in normal UI. `precondition`/`assert` take the
+// condition first and the message second; both arg positions get the same
+// callee tag, so both reject.
+const RUNTIME_FAIL_CALLEES: ReadonlySet<string> = new Set([
+  "assert",
+  "assertionFailure",
+  "precondition",
+  "preconditionFailure",
+  "fatalError",
+]);
+
+// Top-level constructors / factory functions whose first string arg is a
+// URL-like token, never copy.
+const NON_TEXT_CALLEES: ReadonlySet<string> = new Set(["URL", "NSURL", "URLComponents"]);
+
+export const SWIFT_REJECT_RULES: Rule[] = [
+  {
+    name: "logger_call",
+    match: ({ context }) => (context.callee !== undefined ? LOGGER_CALLEES.has(context.callee) : false),
+  },
+  {
+    name: "runtime_fail",
+    match: ({ context }) => (context.callee !== undefined ? RUNTIME_FAIL_CALLEES.has(context.callee) : false),
+  },
+  {
+    name: "non_text_call",
+    match: ({ context }) => (context.callee !== undefined ? NON_TEXT_CALLEES.has(context.callee) : false),
+  },
+];

--- a/lib/src/scan/rules/types.ts
+++ b/lib/src/scan/rules/types.ts
@@ -1,0 +1,50 @@
+import type { DittoScanCandidate, DittoScanEnclosingContext } from "../types";
+
+// Languages the rule classifier dispatches on. The extractor layer
+// emits a wider set of `Candidate.language` values (e.g. `ios_strings`,
+// or a regex-fallback extension like `py`), but rules only branch on
+// the subset below. The BY_LANGUAGE maps in `accept/index.ts` and
+// `reject/index.ts` are typed against this set so a typo or unknown
+// key is a compile error.
+export type RuleLanguage =
+  | "javascript"
+  | "typescript"
+  | "jsx"
+  | "tsx"
+  | "vue"
+  | "kotlin"
+  | "swift";
+
+// Optional per-language rule list. Not every RuleLanguage needs an
+// entry; missing keys produce no language-specific rules and the
+// classifier falls through to common.
+export type RulesByLanguage = { [K in RuleLanguage]?: Rule[] };
+
+// Outcome of running the rule classifier on a single candidate.
+//   `drop`    Discarded by `shouldEmit`. No Result is written.
+//   `accept`  Deterministically user-facing. Pre-classify writes a Result
+//             with status="user-facing", confidence=1, decided_by="rule",
+//             reason=`rule:<rule>`. The LLM never sees it.
+//   `reject`  Deterministically not user-facing. Same as accept but with
+//             status="not-user-facing".
+//   `llm`     No deterministic verdict; falls through to the LLM stage.
+export type Verdict =
+  | { kind: "drop" }
+  | { kind: "accept"; rule: string }
+  | { kind: "reject"; rule: string }
+  | { kind: "llm" };
+
+// A single deterministic accept-or-reject rule. The classifier walks
+// language-specific rules before common ones, and rejects before accepts,
+// so the first matching rule wins. Rules see both the public Candidate
+// (the LLM-visible shape) and the internal EnclosingContext (which carries
+// callee, parentTag, methodName — fields not part of the Candidate payload).
+export interface RuleInput {
+  candidate: DittoScanCandidate;
+  context: DittoScanEnclosingContext;
+}
+
+export interface Rule {
+  name: string;
+  match(input: RuleInput): boolean;
+}

--- a/lib/src/scan/rules/verdict.test.ts
+++ b/lib/src/scan/rules/verdict.test.ts
@@ -1,0 +1,314 @@
+import type {
+  DittoScanCandidate,
+  DittoScanDetectionKind,
+  DittoScanEnclosingContext,
+} from "../types";
+
+import { getClassificationVerdict } from "./index";
+
+function buildInput(opts: {
+  language: string;
+  detectionKind?: DittoScanDetectionKind;
+  parentRole?: DittoScanEnclosingContext["parentRole"];
+  identifiers?: string[];
+  callee?: string;
+  calleeMember?: string;
+  methodName?: string;
+  parentTag?: string;
+  framework?: string[];
+  value?: string;
+}) {
+  const parentRole: DittoScanEnclosingContext["parentRole"] =
+    opts.parentRole ?? opts.detectionKind ?? "other";
+  const candidate: DittoScanCandidate = {
+    id: "test",
+    value_raw: opts.value ?? "Hello",
+    detection_kind: opts.detectionKind ?? parentRole,
+    location: { file: "x.ts", line: 1, column: 1 },
+    language: opts.language,
+    framework: opts.framework ?? [],
+    source_context: "",
+    context_identifiers: opts.identifiers ?? [],
+    usage_evidence: null,
+  };
+  const context: DittoScanEnclosingContext = {
+    parentRole,
+    identifiers: opts.identifiers ?? [],
+    callee: opts.callee,
+    calleeMember: opts.calleeMember,
+    methodName: opts.methodName,
+    parentTag: opts.parentTag,
+  };
+  return { candidate, context };
+}
+
+describe("getClassificationVerdict - common accept rules", () => {
+  test("resource_value: any localization-file entry accepts", () => {
+    const v = getClassificationVerdict(
+      buildInput({ language: "ios_strings", detectionKind: "resource_value" })
+    );
+    expect(v).toEqual({ kind: "accept", rule: "resource_value" });
+  });
+
+  test("markup_attr_copy: copy-bearing attribute accepts", () => {
+    const v = getClassificationVerdict(
+      buildInput({
+        language: "tsx",
+        detectionKind: "markup_attr",
+        identifiers: ["placeholder"],
+      })
+    );
+    expect(v).toEqual({ kind: "accept", rule: "markup_attr_copy" });
+  });
+
+  test("markup_attr_copy: aria-label accepts", () => {
+    const v = getClassificationVerdict(
+      buildInput({
+        language: "tsx",
+        detectionKind: "markup_attr",
+        identifiers: ["aria-label"],
+      })
+    );
+    expect(v).toEqual({ kind: "accept", rule: "markup_attr_copy" });
+  });
+
+  test("markup_text_safe: text inside a copy-bearing tag accepts", () => {
+    const v = getClassificationVerdict(
+      buildInput({
+        language: "tsx",
+        detectionKind: "markup_text",
+        parentTag: "button",
+      })
+    );
+    expect(v).toEqual({ kind: "accept", rule: "markup_text_safe" });
+  });
+
+  test("markup_text_safe: text without a parentTag falls through to LLM", () => {
+    const v = getClassificationVerdict(
+      buildInput({ language: "tsx", detectionKind: "markup_text" })
+    );
+    expect(v).toEqual({ kind: "llm" });
+  });
+
+  test("markup_text_safe: text inside a non-copy tag (`div`) falls through to LLM", () => {
+    const v = getClassificationVerdict(
+      buildInput({
+        language: "tsx",
+        detectionKind: "markup_text",
+        parentTag: "div",
+      })
+    );
+    expect(v).toEqual({ kind: "llm" });
+  });
+});
+
+describe("getClassificationVerdict - javascript reject rules", () => {
+  test("logger_call: console.log rejects across all JS family languages", () => {
+    for (const lang of ["javascript", "typescript", "jsx", "tsx", "vue"]) {
+      const v = getClassificationVerdict(
+        buildInput({ language: lang, callee: "console", calleeMember: "log" })
+      );
+      expect(v).toEqual({ kind: "reject", rule: "logger_call" });
+    }
+  });
+
+  test("non_text_call: bare JSON.parse / URL constructor rejects", () => {
+    expect(
+      getClassificationVerdict(buildInput({ language: "ts", callee: "URL" }))
+    ).toEqual({ kind: "llm" });
+    // `ts` isn't a registered RuleLanguage, so the JS reject rules don't fire.
+    expect(
+      getClassificationVerdict(
+        buildInput({ language: "typescript", callee: "URL" })
+      )
+    ).toEqual({
+      kind: "reject",
+      rule: "non_text_call",
+    });
+    expect(
+      getClassificationVerdict(
+        buildInput({
+          language: "typescript",
+          callee: "JSON",
+          calleeMember: "parse",
+        })
+      )
+    ).toEqual({ kind: "reject", rule: "non_text_call" });
+  });
+
+  test("unknown callee falls through to LLM", () => {
+    const v = getClassificationVerdict(
+      buildInput({ language: "typescript", callee: "someHelper" })
+    );
+    expect(v).toEqual({ kind: "llm" });
+  });
+});
+
+describe("getClassificationVerdict - kotlin rules", () => {
+  test("logger_call: Log.d rejects", () => {
+    const v = getClassificationVerdict(
+      buildInput({ language: "kotlin", callee: "Log", calleeMember: "d" })
+    );
+    expect(v).toEqual({ kind: "reject", rule: "logger_call" });
+  });
+
+  test("logger_call: bare println rejects", () => {
+    const v = getClassificationVerdict(
+      buildInput({ language: "kotlin", callee: "println" })
+    );
+    expect(v).toEqual({ kind: "reject", rule: "logger_call" });
+  });
+
+  test("runtime_fail: check(...) rejects", () => {
+    const v = getClassificationVerdict(
+      buildInput({ language: "kotlin", callee: "check" })
+    );
+    expect(v).toEqual({ kind: "reject", rule: "runtime_fail" });
+  });
+
+  test("non_text_call: Pattern.compile rejects", () => {
+    const v = getClassificationVerdict(
+      buildInput({
+        language: "kotlin",
+        callee: "Pattern",
+        calleeMember: "compile",
+      })
+    );
+    expect(v).toEqual({ kind: "reject", rule: "non_text_call" });
+  });
+
+  test('compose_text: Text("...") accepts only with android framework token', () => {
+    const withFramework = getClassificationVerdict(
+      buildInput({ language: "kotlin", callee: "Text", framework: ["android"] })
+    );
+    expect(withFramework).toEqual({ kind: "accept", rule: "compose_text" });
+
+    const withoutFramework = getClassificationVerdict(
+      buildInput({ language: "kotlin", callee: "Text" })
+    );
+    expect(withoutFramework).toEqual({ kind: "llm" });
+  });
+
+  test("android_ui_factory: Toast.makeText and Snackbar.make accept", () => {
+    const toast = getClassificationVerdict(
+      buildInput({
+        language: "kotlin",
+        callee: "Toast",
+        calleeMember: "makeText",
+      })
+    );
+    expect(toast).toEqual({ kind: "accept", rule: "android_ui_factory" });
+
+    const snack = getClassificationVerdict(
+      buildInput({
+        language: "kotlin",
+        callee: "Snackbar",
+        calleeMember: "make",
+      })
+    );
+    expect(snack).toEqual({ kind: "accept", rule: "android_ui_factory" });
+  });
+});
+
+describe("getClassificationVerdict - swift rules", () => {
+  test("logger_call: print, NSLog, os_log, debugPrint all reject", () => {
+    for (const callee of ["print", "NSLog", "os_log", "debugPrint"]) {
+      const v = getClassificationVerdict(
+        buildInput({ language: "swift", callee })
+      );
+      expect(v).toEqual({ kind: "reject", rule: "logger_call" });
+    }
+  });
+
+  test("runtime_fail: fatalError, assert, precondition reject", () => {
+    for (const callee of ["fatalError", "assert", "precondition"]) {
+      const v = getClassificationVerdict(
+        buildInput({ language: "swift", callee })
+      );
+      expect(v).toEqual({ kind: "reject", rule: "runtime_fail" });
+    }
+  });
+
+  test("non_text_call: URL/NSURL reject", () => {
+    expect(
+      getClassificationVerdict(buildInput({ language: "swift", callee: "URL" }))
+    ).toEqual({
+      kind: "reject",
+      rule: "non_text_call",
+    });
+    expect(
+      getClassificationVerdict(
+        buildInput({ language: "swift", callee: "NSURL" })
+      )
+    ).toEqual({
+      kind: "reject",
+      rule: "non_text_call",
+    });
+  });
+
+  test("Swift has no language-specific accept rules; UI calls fall through to LLM", () => {
+    const v = getClassificationVerdict(
+      buildInput({
+        language: "swift",
+        callee: "button",
+        calleeMember: "setTitle",
+      })
+    );
+    expect(v).toEqual({ kind: "llm" });
+  });
+});
+
+describe("getClassificationVerdict - dispatch ordering", () => {
+  test("reject wins over a common accept on the same candidate", () => {
+    // Forces resource_value (would accept) on a Log.d call (rejects). Reject must run first.
+    const v = getClassificationVerdict(
+      buildInput({
+        language: "kotlin",
+        detectionKind: "resource_value",
+        callee: "Log",
+        calleeMember: "d",
+      })
+    );
+    expect(v).toEqual({ kind: "reject", rule: "logger_call" });
+  });
+
+  test("language-specific reject wins over common reject (empty common is a no-op here)", () => {
+    const v = getClassificationVerdict(
+      buildInput({ language: "swift", callee: "print" })
+    );
+    expect(v.kind).toBe("reject");
+  });
+
+  test("language-specific accept wins over common accept", () => {
+    // Candidate matches both markup_text_safe (common) and compose_text (kotlin). Lang must win.
+    const v = getClassificationVerdict(
+      buildInput({
+        language: "kotlin",
+        parentRole: "markup_text",
+        parentTag: "button",
+        callee: "Text",
+        framework: ["android"],
+      })
+    );
+    expect(v).toEqual({ kind: "accept", rule: "compose_text" });
+  });
+
+  test("unknown language has no language rules; falls through to common", () => {
+    const v = getClassificationVerdict(
+      buildInput({ language: "python", detectionKind: "resource_value" })
+    );
+    expect(v).toEqual({ kind: "accept", rule: "resource_value" });
+  });
+
+  test("non-RuleLanguage key (like prototype `constructor`) does not crash and returns llm", () => {
+    const v = getClassificationVerdict(buildInput({ language: "constructor" }));
+    expect(v).toEqual({ kind: "llm" });
+  });
+
+  test("no rule matches: returns llm", () => {
+    const v = getClassificationVerdict(
+      buildInput({ language: "typescript", value: "Some plain string" })
+    );
+    expect(v).toEqual({ kind: "llm" });
+  });
+});

--- a/lib/src/scan/types.ts
+++ b/lib/src/scan/types.ts
@@ -1,0 +1,140 @@
+import { z } from "zod";
+
+// The LLM's verdict on a candidate.
+export const DittoScanStatusSchema = z.enum([
+  "user-facing",
+  "not-user-facing",
+  "unsure",
+  "error",
+]);
+export type DittoScanStatus = z.infer<typeof DittoScanStatusSchema>;
+
+// The syntactic site a string was found in. Kinds in the first group are
+// always excluded by `shouldEmit` and never appear on emitted candidates;
+// they exist so extractors and exclusion rules share a vocabulary.
+export const DittoScanDetectionKindSchema = z.enum([
+  // Excluded by `shouldEmit`
+  "import",
+  "regex_pattern",
+  "object_key",
+  "index_access",
+  "type_tag",
+
+  // Emitted
+  "markup_text", // text content of a JSX/HTML-like element
+  "markup_attr", // value of an HTML-shaped attribute
+  "resource_value", // value inside a localization resource file (strings.xml, .strings, .stringsdict, .xcstrings)
+  "other", // any other string position — the LLM reads source_context for nuance
+]);
+export type DittoScanDetectionKind = z.infer<
+  typeof DittoScanDetectionKindSchema
+>;
+
+// Produced by per-language extractors, consumed by `shouldEmit` and the
+// rule classifier. The parts the LLM phase sees are surfaced on Candidate as
+// `detection_kind` and `context_identifiers`; the optional fields are
+// internal-only hints used by the rule classifier.
+export interface DittoScanEnclosingContext {
+  parentRole: DittoScanDetectionKind;
+  // Lowercased identifiers from the wrapping construct, in source order.
+  // For `markup_attr` this is the attribute name; otherwise empty.
+  identifiers: string[];
+  // Top-level identifier of the enclosing call expression, when the receiver
+  // is a bare identifier. Examples: `console` for `console.log(...)`, `Log`
+  // for `Log.d(...)`, `print` for `print(...)`. Unset when the receiver is
+  // not a bare identifier (e.g. `this.log.warn(...)`, `Logger().info(...)`).
+  callee?: string;
+  // Method side of a member-expression call. `log` for `console.log`, `d`
+  // for `Log.d`. Unset for bare-identifier calls like `print(...)`.
+  calleeMember?: string;
+  // Final method name on the enclosing call, regardless of receiver
+  // shape. Set for chained calls where `calleeMember` would not be:
+  // `AlertDialog.Builder(ctx).setTitle("X")` -> `setTitle`,
+  // `someLabel.setText("X")` -> `setText`. Distinct from `calleeMember`
+  // so reject rules (which want certainty about the receiver) can keep
+  // using `callee`/`calleeMember` while accept rules can match the
+  // method name on broader call shapes.
+  methodName?: string;
+  // Lowercased tag name of the JSX/Vue element wrapping a `markup_text`
+  // candidate. Used by the rule classifier to apply the parent-tag denylist
+  // (`<code>`, `<pre>`, etc.).
+  parentTag?: string;
+}
+
+// One occurrence of the candidate string somewhere else in the codebase. Used
+// when the literal is declared as a constant and referenced from elsewhere, so
+// the LLM can see how it's actually used. Not populated by the current extract
+// pass; reserved for a future constant-reference resolver.
+export const DittoScanUsageEvidenceSchema = z.object({
+  file: z.string(),
+  line: z.number().int().positive(),
+  excerpt: z.string(),
+});
+export type DittoScanUsageEvidence = z.infer<
+  typeof DittoScanUsageEvidenceSchema
+>;
+
+// A single string literal found in the source, with some context to help the
+// LLM decide whether it's user-facing.
+export const DittoScanCandidateSchema = z.object({
+  id: z.string(),
+  value_raw: z.string(),
+  detection_kind: DittoScanDetectionKindSchema,
+  location: z.object({
+    file: z.string(),
+    line: z.number().int().positive(),
+    column: z.number().int().positive(),
+  }),
+  language: z.string(),
+  // Framework signals derived from the input project's package.json
+  // (e.g., ["react", "next"] or ["vue"]). Same for every candidate in a run.
+  framework: z.array(z.string()),
+  // N surrounding lines with `line: ` prefixes.
+  source_context: z.string(),
+  context_identifiers: z.array(z.string()),
+  usage_evidence: z.array(DittoScanUsageEvidenceSchema).nullable().optional(),
+});
+export type DittoScanCandidate = z.infer<typeof DittoScanCandidateSchema>;
+
+// A candidate plus the verdict on it. This is what ends up in the output
+// file. `decided_by` distinguishes deterministic rule verdicts (`"rule"`,
+// `confidence: 1`, `reason: "rule:<name>"`) from LLM verdicts (`"llm"`).
+export const DittoScanResultSchema = DittoScanCandidateSchema.extend({
+  status: DittoScanStatusSchema,
+  reason: z.string(),
+  confidence: z.number().min(0).max(1),
+  info_needed: z.string().nullable(),
+  decided_by: z.enum(["rule", "llm"]),
+});
+export type DittoScanResult = z.infer<typeof DittoScanResultSchema>;
+
+// Top-level info about a run.
+export const DittoScanSummarySchema = z.object({
+  run_id: z.string(),
+  started_at: z.string(),
+  finished_at: z.string(),
+  model: z.string(),
+  prompt_hash: z.string(),
+  candidate_total: z.number().int().nonnegative(),
+  by_status: z.partialRecord(
+    DittoScanStatusSchema,
+    z.number().int().nonnegative()
+  ),
+  num_results_to_manually_verify: z.number().int().nonnegative(),
+  pct_results_needing_manual_verification: z.number().min(0).max(100),
+  llm_calls: z.number().int().nonnegative(),
+  llm_tokens_in: z.number().int().nonnegative(),
+  llm_tokens_out: z.number().int().nonnegative(),
+  // Breakdown of who decided each result. Rule-decided ones never call
+  // the LLM, so llm_calls / llm_tokens_* count only the LLM-decided slice.
+  decided_by: z
+    .object({
+      rule: z.number().int().nonnegative(),
+      llm: z.number().int().nonnegative(),
+    })
+    .optional(),
+  // Counts per rule name (e.g. "rule:resource_value": 113). Helps audit
+  // which rules are doing the most work and spot rule misbehavior.
+  by_rule: z.record(z.string(), z.number().int().nonnegative()).optional(),
+});
+export type DittoScanSummary = z.infer<typeof DittoScanSummarySchema>;

--- a/lib/src/scan/walk.ts
+++ b/lib/src/scan/walk.ts
@@ -1,0 +1,189 @@
+import fs from "fs/promises";
+import { globby } from "globby";
+import path from "path";
+
+import {
+  findI18nFiles,
+  I18N_FILE_EXTENSIONS,
+} from "./lang/i18n-file-discovery";
+import type { LlmFileTaskStats } from "./lang/llm-file-discovery";
+import {
+  findI18nLanguageForExt,
+  findLanguageForFile,
+  REGEX_FALLBACK_ID,
+  type Language,
+} from "./lang/registry";
+
+// Paths we never scan regardless of .gitignore: build artifacts, vendored
+// dependencies, minified bundles, and test/fixture/story trees.
+const HARDCODED_IGNORES = [
+  "**/node_modules/**",
+  "**/.git/**",
+  "**/dist/**",
+  "**/dist-*/**",
+  "**/build/**",
+  "**/.next/**",
+  "**/.nuxt/**",
+  "**/.svelte-kit/**",
+  "**/coverage/**",
+  "**/out/**",
+  "**/.turbo/**",
+  "**/.cache/**",
+  "**/vendor/**",
+  "**/vendored/**",
+  "**/third_party/**",
+  "**/third-party/**",
+  "**/*.min.js",
+  "**/*.min.css",
+  "**/*.bundle.js",
+  "**/__tests__/**",
+  "**/__mocks__/**",
+  "**/__snapshots__/**",
+  "**/test/**",
+  "**/tests/**",
+  "**/androidTest/**",
+  "**/androidTest*/**",
+  "**/UnitTests/**",
+  "**/spec/**",
+  "**/e2e/**",
+  "**/cypress/**",
+  "**/playwright/**",
+  "**/*.test.*",
+  "**/*.spec.*",
+  "**/*Test.kt",
+  "**/*Tests.kt",
+  "**/*Test.swift",
+  "**/*Tests.swift",
+  "**/*.stories.*",
+  "**/*_test.go",
+  "**/*_test.py",
+  "**/test_*.py",
+  "**/*_spec.rb",
+  // Generated test/fixture / benchmark / evaluation data that often
+  // contains all-strings JSON shapes (n8n's per-node `__schema__/`,
+  // evaluation prompts, benchmark scenarios) which would otherwise be
+  // misread as i18n catalogs.
+  "**/__schema__/**",
+  "**/__fixtures__/**",
+  "**/benchmark/**",
+  "**/benchmarks/**",
+  "**/evaluations/**",
+  "**/evals/**",
+];
+
+// Files whose mean line length exceeds this are treated as minified/bundled
+// output and skipped wholesale.
+const MAX_MEAN_LINE_LENGTH = 500;
+
+export interface DiscoveredFile {
+  absPath: string;
+  relPath: string;
+  language: Language;
+  source: string;
+  languageLabel: string;
+}
+
+export interface WalkResult {
+  files: DiscoveredFile[];
+  filesSkippedMinified: number;
+  i18nFileDiscovery: LlmFileTaskStats | null;
+}
+
+export async function walkCodebase(rootPath: string): Promise<WalkResult> {
+  const resolved = path.resolve(rootPath);
+
+  const [paths, i18nFileResult] = await Promise.all([
+    globby(["**/*"], {
+      cwd: resolved,
+      gitignore: true,
+      absolute: true,
+      onlyFiles: true,
+      ignore: HARDCODED_IGNORES,
+      followSymbolicLinks: false,
+      suppressErrors: true,
+    }),
+    runI18nFileDiscovery(resolved),
+  ]);
+
+  const files: DiscoveredFile[] = [];
+  let filesSkippedMinified = 0;
+
+  for (const absPath of paths) {
+    const ext = path.extname(absPath).toLowerCase();
+    // i18nFileResult.paths comes from globby (always POSIX) so normalize
+    // path.relative output, which uses path.sep, before lookup.
+    const relPath = path.relative(resolved, absPath).split(path.sep).join("/");
+
+    let language: Language | null;
+    if (I18N_FILE_EXTENSIONS.has(ext)) {
+      // Skip i18n-shaped extensions when the LLM didn't confirm the
+      // file. If discovery itself was skipped (no API key) the set is
+      // null and we drop everything in this branch.
+      if (!i18nFileResult || !i18nFileResult.paths.has(relPath)) continue;
+      language = findI18nLanguageForExt(ext);
+      if (!language) continue;
+    } else {
+      const found = findLanguageForFile({ ext, relPath });
+      if (!found) continue;
+      language = found;
+    }
+
+    let source: string;
+    try {
+      source = await fs.readFile(absPath, "utf8");
+    } catch {
+      continue;
+    }
+    if (looksMinified(source)) {
+      filesSkippedMinified++;
+      continue;
+    }
+
+    files.push({
+      absPath,
+      relPath,
+      language,
+      source,
+      languageLabel: labelFor(language, ext),
+    });
+  }
+
+  return {
+    files,
+    filesSkippedMinified,
+    i18nFileDiscovery: i18nFileResult?.stats ?? null,
+  };
+}
+
+async function runI18nFileDiscovery(
+  resolved: string
+): Promise<{ paths: Set<string>; stats: LlmFileTaskStats } | null> {
+  if (!process.env.GEMINI_API_KEY) {
+    process.stderr.write(
+      "[ptd extract] GEMINI_API_KEY not set — skipping LLM i18n-file discovery; no JSON/YAML/PO/properties/ARB/XLIFF/RESX i18n files will be extracted.\n"
+    );
+    return null;
+  }
+  try {
+    return await findI18nFiles(resolved);
+  } catch (e) {
+    process.stderr.write(
+      `[ptd extract] i18n-file discovery failed: ${(e as Error).message}\n`
+    );
+    return null;
+  }
+}
+
+function labelFor(language: Language, ext: string): string {
+  if (language.id !== REGEX_FALLBACK_ID) return language.id;
+  return ext.slice(1) || "unknown";
+}
+
+function looksMinified(source: string): boolean {
+  if (source.length < 1024) return false;
+  let newlines = 0;
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) === 10) newlines++;
+  }
+  return source.length / (newlines + 1) > MAX_MEAN_LINE_LENGTH;
+}

--- a/lib/src/services/apiToken/promptForApiToken.ts
+++ b/lib/src/services/apiToken/promptForApiToken.ts
@@ -14,12 +14,11 @@ export const validate = async (token: string) => {
  * @returns The collected token
  */
 export default async function promptForApiToken() {
-  // @ts-expect-error - Enquirer types are not updated for the validate function
   const response = await prompt<{ token: string }>({
     type: "input",
     name: "token",
     message: "What is your API key?",
-    validate,
+    validate: validate as any,
   });
 
   return response;

--- a/lib/src/services/gemini.ts
+++ b/lib/src/services/gemini.ts
@@ -1,0 +1,373 @@
+import {
+  Content,
+  ContentListUnion,
+  ContentUnion,
+  FinishReason,
+  FunctionDeclaration,
+  GenerateContentConfig,
+  GenerateContentResponse,
+  GenerateContentResponseUsageMetadata,
+  GoogleGenAI,
+} from "@google/genai";
+import logger from "../utils/logger";
+import { z } from "zod";
+import { ZodStandardJSONSchemaPayload } from "zod/v4/core";
+import DittoError, { ErrorType } from "../utils/DittoError";
+
+const DEFAULT_GEMINI_MODEL = "gemini-2.5-flash";
+
+interface GeminiCallMetadata {
+  requestTimeMs: number;
+  apiResponse?: GenerateContentResponse;
+  geminiUsageMetadata?: GenerateContentResponseUsageMetadata;
+  error?: string;
+}
+export interface GeminiCallResult<T extends z.ZodType> {
+  data: z.infer<T>;
+  metadata: GeminiCallMetadata;
+}
+export type IGeminiCallResult<T> = {
+  data: T;
+  metadata: GeminiCallMetadata;
+};
+
+/**
+ * Calls the Gemini API with the given prompt and response schema.
+ * @param prompt The prompt to send to the Gemini API.
+ * @param responseSchema The schema to parse the response from the Gemini API. We'll submit this schema to Gemini,
+ * so that it should return a JSON object that matches the shape, then use Zod to make certain it's valid.
+ * @returns The response from the Gemini API.
+ */
+export async function callGemini<T extends z.ZodType>(
+  contents: ContentListUnion,
+  ZResponseSchema: T,
+  systemInstruction: ContentUnion,
+  config?: GenerateContentConfig,
+  model?: string
+): Promise<GeminiCallResult<T> | null> {
+  const geminiCallMetadata = await callGeminiDirect(
+    contents,
+    systemInstruction,
+    config ?? {},
+    ZResponseSchema,
+    model
+  );
+  if (geminiCallMetadata === null) {
+    return null;
+  }
+  try {
+    const generateContentResponse = geminiCallMetadata.data;
+    if (geminiCallMetadata.metadata.error || !generateContentResponse?.text) {
+      throw new Error(
+        `No response text from Gemini API error: ${
+          geminiCallMetadata.metadata.error ?? "unknown"
+        }`
+      );
+    }
+
+    // Parse the structured response
+    const responseData = JSON.parse(generateContentResponse.text);
+    const zParsedResponseData = ZResponseSchema.parse(responseData);
+    return {
+      data: zParsedResponseData,
+      metadata: geminiCallMetadata.metadata,
+    };
+  } catch (e: any) {
+    logger.errorText(`Error calling Gemini API: ${e.message}`);
+  }
+  return null;
+}
+
+/**
+ * Calls the Gemini API with the given prompt and response schema.
+ * @param prompt The prompt to send to the Gemini API.
+ * @param responseSchema The schema to parse the response from the Gemini API. We'll submit this schema to Gemini,
+ * so that it should return a JSON object that matches the shape, then use Zod to make certain it's valid.
+ * @returns The response from the Gemini API.
+ */
+export async function callGeminiDirect<T extends z.ZodType>(
+  contents: ContentListUnion,
+  systemInstruction: ContentUnion,
+  config: GenerateContentConfig,
+  ZResponseSchema?: T,
+  model: string = DEFAULT_GEMINI_MODEL
+) {
+  return callGeminiDirectWithJsonSchema(
+    contents,
+    systemInstruction,
+    config,
+    ZResponseSchema?.toJSONSchema(),
+    model
+  );
+}
+
+/**
+ * Calls the Gemini API with the given prompt and response JsonSchema.
+ * @param prompt The prompt to send to the Gemini API.
+ * @param responseJsonSchema The Json schema to parse the response from the Gemini API. We'll submit this schema to Gemini,
+ * so that it should return a JSON object that matches the shape, then use Zod to make certain it's valid.
+ * @returns The response from the Gemini API.
+ */
+export async function callGeminiDirectWithJsonSchema<T>(
+  contents: ContentListUnion,
+  systemInstruction: ContentUnion,
+  config: GenerateContentConfig,
+  responseJsonSchema?: ZodStandardJSONSchemaPayload<T>,
+  model: string = DEFAULT_GEMINI_MODEL
+): Promise<IGeminiCallResult<GenerateContentResponse> | null> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error("Server configuration error. Gemini API key not found.");
+  }
+  const maxRetries = 3;
+  const initialDelay = 1000; // 1 second
+  const maxDelay = 10000; // 10 seconds
+  let error;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const ai = new GoogleGenAI({ apiKey });
+
+      const startTime = Date.now();
+      const generateContentResponse = await ai.models.generateContent({
+        model,
+        contents: contents,
+        config: {
+          ...config,
+          systemInstruction: systemInstruction,
+          ...(responseJsonSchema !== undefined
+            ? { responseJsonSchema, responseMimeType: "application/json" }
+            : {}),
+          thinkingConfig: {
+            thinkingBudget: 0,
+            ...config.thinkingConfig,
+          },
+        },
+      });
+      const endTime = Date.now();
+      const errorCandidate = generateContentResponse.candidates?.find(
+        (resp) => resp.finishReason !== FinishReason.STOP
+      );
+      if (errorCandidate) {
+        return {
+          data: generateContentResponse,
+          metadata: {
+            error: `Finish reason is not expected: ${errorCandidate.finishReason}`,
+            requestTimeMs: Math.round(endTime - startTime),
+            geminiUsageMetadata: generateContentResponse.usageMetadata,
+          },
+        };
+      }
+      return {
+        data: generateContentResponse,
+        metadata: {
+          requestTimeMs: Math.round(endTime - startTime),
+          geminiUsageMetadata: generateContentResponse.usageMetadata,
+        },
+      };
+    } catch (e: any) {
+      // Don't retry or log as error if the request was intentionally aborted
+      if (e.name === "AbortError" || config.abortSignal?.aborted) {
+        throw e;
+      }
+      const isRetryable = e.status === 503 || e instanceof SyntaxError;
+      if (isRetryable && attempt < maxRetries - 1) {
+        // Exponential backoff: Starting at 1 second, doubling each time, capped at 10 seconds
+        const delay = Math.min(initialDelay * Math.pow(2, attempt), maxDelay);
+        const reason =
+          e instanceof SyntaxError
+            ? "malformed JSON response"
+            : "503 (Service Unavailable)";
+        logger.warnText(
+          `Gemini API error: ${reason}, retrying attempt ${
+            attempt + 1
+          } in ${delay}ms...`
+        );
+        error = { statusCode: 500, message: e.message };
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+      logger.errorText(`Error calling Gemini API: ${e.message}`);
+      if (error) {
+        throw new DittoError({
+          type: ErrorType.GeminiError,
+          data: { rawErrorMessage: error.message },
+          message: "Error calling Gemini API",
+        });
+      }
+    }
+  }
+  return null;
+}
+
+export async function getEmbedding(
+  text: string
+): Promise<number[] | undefined> {
+  const embeddings = await getEmbeddings([text]);
+  return embeddings ? embeddings[0] : embeddings;
+}
+
+export async function getEmbeddings(
+  texts: string[]
+): Promise<number[][] | undefined> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error("Server configuration error. Gemini API key not found.");
+  }
+  const ai = new GoogleGenAI({ apiKey });
+  let retryCount = 0;
+  while (retryCount < 3) {
+    try {
+      const response = await ai.models.embedContent({
+        model: "gemini-embedding-001",
+        contents: texts,
+        config: { taskType: "SEMANTIC_SIMILARITY" },
+      });
+
+      return response.embeddings?.map((embed) => embed.values ?? []);
+    } catch (error) {
+      retryCount++;
+      console.log(error);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  logger.errorText(
+    `Gemini embedding request failed after all retries; textCount: ${texts.length}`
+  );
+  throw new DittoError({
+    type: ErrorType.GeminiError,
+    data: { rawErrorMessage: "Error while creating embeddings" },
+    message: "Error while creating embeddings",
+  });
+}
+
+type ToolCallResult<T> =
+  | { done: true; result: T }
+  | {
+      done: false;
+      response: {
+        functionResponse: { name: string; response: Record<string, unknown> };
+      };
+    };
+
+export type ToolHandler<T> = (
+  toolName: string,
+  args: Record<string, unknown>
+) => Promise<ToolCallResult<T>>;
+
+/**
+ * Runs an agentic Gemini tool-calling loop. Repeatedly calls Gemini and dispatches
+ * function calls via {@link handleToolCall} until a terminal tool returns a result
+ * or the iteration limit is reached.
+ */
+export async function runGeminiToolLoop<T>(args: {
+  systemInstruction: string;
+  tools: FunctionDeclaration[];
+  initialContents: Content[];
+  handleToolCall: ToolHandler<T>;
+  label: string;
+  maxIterations?: number;
+  defaultResult: T;
+}): Promise<T> {
+  const {
+    systemInstruction,
+    tools,
+    initialContents,
+    handleToolCall,
+    label,
+    defaultResult,
+  } = args;
+  const maxIterations = args.maxIterations ?? 10;
+
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error("GEMINI_API_KEY not configured");
+  }
+
+  const ai = new GoogleGenAI({ apiKey });
+  const contents: Content[] = [...initialContents];
+  const maxRetries = 3;
+  const initialDelay = 1000;
+  const maxDelay = 10000;
+
+  for (let i = 0; i < maxIterations; i++) {
+    let response: GenerateContentResponse | undefined;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        response = await ai.models.generateContent({
+          model: "gemini-3-flash-preview",
+          contents,
+          config: {
+            systemInstruction,
+            tools: [{ functionDeclarations: tools }],
+          },
+        });
+        break;
+      } catch (e: any) {
+        const isRetryable =
+          [429, 503].includes(e.status) ||
+          e instanceof SyntaxError ||
+          e.code === "ECONNRESET";
+        if (isRetryable && attempt < maxRetries - 1) {
+          const delay =
+            Math.min(initialDelay * Math.pow(2, attempt), maxDelay) +
+            Math.floor(Math.random() * 200);
+          const reason =
+            e instanceof SyntaxError
+              ? "malformed JSON response"
+              : `${e.status ?? e.code}`;
+          logger.warnText(
+            `Gemini API error: ${reason}, retrying attempt ${
+              attempt + 1
+            } in ${delay}ms...`
+          );
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+        throw e;
+      }
+    }
+    if (!response) {
+      logger.warnText(
+        `${label}: generateContent returned no response after retries, stopping`
+      );
+      break;
+    }
+
+    const functionCalls = response.functionCalls ?? [];
+    if (functionCalls.length === 0) {
+      logger.warnText(
+        `${label}: agent finished without calling a terminal tool`
+      );
+      break;
+    }
+
+    const responseParts: {
+      functionResponse: { name: string; response: Record<string, unknown> };
+    }[] = [];
+
+    for (const call of functionCalls) {
+      const callArgs = (call.args ?? {}) as Record<string, unknown>;
+      logger.info(`${label}: agent calling tool ${call.name}`);
+
+      const result = await handleToolCall(call.name!, callArgs);
+      if (result.done) {
+        return result.result;
+      }
+      responseParts.push(result.response);
+    }
+
+    const modelParts = response.candidates?.[0]?.content?.parts;
+    if (!modelParts) {
+      logger.warnText(`${label}: empty response from Gemini, stopping`);
+      break;
+    }
+    contents.push({ role: "model", parts: modelParts });
+    contents.push({ role: "user", parts: responseParts });
+  }
+
+  logger.warnText(
+    `${label}: exhausted ${maxIterations} iterations, returning default`
+  );
+  return defaultResult;
+}

--- a/lib/src/utils/DittoError.ts
+++ b/lib/src/utils/DittoError.ts
@@ -50,6 +50,8 @@ export default class DittoError<T extends ErrorType> extends Error {
 export enum ErrorType {
   ConfigYamlLoadError = "ConfigYamlLoadError",
   ConfigParseError = "ConfigParseError",
+  GeminiError = "GeminiError",
+  ScanError = "ScanError",
 }
 
 /**
@@ -59,6 +61,8 @@ export enum ErrorType {
 type ErrorDataMap = {
   [ErrorType.ConfigYamlLoadError]: ConfigYamlLoadErrorData;
   [ErrorType.ConfigParseError]: ConfigParseErrorData;
+  [ErrorType.GeminiError]: GeminiErrorData;
+  [ErrorType.ScanError]: ScanErrorData;
 };
 
 type ConfigYamlLoadErrorData = {
@@ -68,6 +72,14 @@ type ConfigYamlLoadErrorData = {
 type ConfigParseErrorData = {
   formattedError: string;
   messagePrefix: string;
+};
+
+type GeminiErrorData = {
+  rawErrorMessage: string;
+};
+
+type ScanErrorData = {
+  rawErrorMessage: string;
 };
 
 export function isDittoError(error: unknown): error is DittoError<ErrorType> {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "bin/ditto.js",
   "scripts": {
+    "build": "node esbuild.mjs",
     "prepublishOnly": "ENV=production node esbuild.mjs && sentry-cli sourcemaps inject ./bin && npx sentry-cli sourcemaps upload ./bin --release=\"$(cat package.json | jq -r '.version')\"",
     "prepare": "husky install",
     "scan": "node esbuild.mjs && node --enable-source-maps --require dotenv/config bin/ditto.js scan",
@@ -42,6 +43,12 @@
     "README.md",
     "LICENSE"
   ],
+  "exports": {
+    ".": {
+      "types": "./bin/ditto.d.ts",
+      "default": "./bin/ditto.js"
+    }
+  },
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.18.6",
@@ -53,6 +60,7 @@
     "@types/node": "^18.0.0",
     "babel-jest": "^29.3.1",
     "dotenv": "^16.3.1",
+    "dts-bundle-generator": "^9.5.1",
     "esbuild": "^0.25.2",
     "husky": "^7.0.4",
     "jest": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "prepublishOnly": "ENV=production node esbuild.mjs && sentry-cli sourcemaps inject ./bin && npx sentry-cli sourcemaps upload ./bin --release=\"$(cat package.json | jq -r '.version')\"",
     "prepare": "husky install",
+    "scan": "node esbuild.mjs && node --enable-source-maps --require dotenv/config bin/ditto.js scan",
     "start": "node esbuild.mjs && node --enable-source-maps --require dotenv/config bin/ditto.js",
     "sync": "node esbuild.mjs && node --enable-source-maps --require dotenv/config bin/ditto.js pull",
     "test": "jest",
@@ -47,7 +48,7 @@
     "@jest/globals": "^29.7.0",
     "@sentry/cli": "^2.20.5",
     "@tsconfig/node16": "^1.0.3",
-    "@types/jest": "^26.0.9",
+    "@types/jest": "^29.5.0",
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^18.0.0",
     "babel-jest": "^29.3.1",
@@ -56,7 +57,7 @@
     "husky": "^7.0.4",
     "jest": "^29.3.1",
     "lint-staged": "^11.2.4",
-    "prettier": "2.4.1",
+    "prettier": "^2.8.0",
     "rewire": "^6.0.0",
     "source-map": "^0.7.3",
     "tempy": "^0.6.0",
@@ -64,10 +65,14 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "@ast-grep/lang-kotlin": "^0.0.7",
+    "@ast-grep/lang-swift": "^0.0.8",
+    "@ast-grep/napi": "^0.43.0",
     "@babel/core": "^7.11.4",
     "@babel/parser": "^7.21.4",
     "@babel/traverse": "^7.21.4",
     "@babel/types": "^7.21.4",
+    "@google/genai": "^2.7.0",
     "@sentry/node": "^7.64.0",
     "@types/babel-traverse": "^6.25.7",
     "axios": "^1.6.0",
@@ -78,9 +83,12 @@
     "faker": "^5.1.0",
     "form-data": "^4.0.0",
     "glob": "^9.3.4",
+    "globby": "^16.2.0",
+    "ignore": "^7.0.5",
     "js-yaml": "^4.1.0",
     "memfs": "^4.7.7",
     "ora": "^5.0.0",
+    "yaml": "^2.9.0",
     "zod": "^4.0.0"
   },
   "lint-staged": {

--- a/tsconfig.declarations.json
+++ b/tsconfig.declarations.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "es2020"
+  }
+}

--- a/tsconfig.declarations.json
+++ b/tsconfig.declarations.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "es2020"
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
     "module": "commonjs",
     "target": "es2019",
-    "declaration": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,19 +3,20 @@
     "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
     "module": "commonjs",
     "target": "es2019",
-
+    "declaration": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowJs": false,
     "outDir": "bin",
     "resolveJsonModule": true,
     "sourceMap": true,
     // Set `sourceRoot` to  "/" to strip the build path prefix from
     // generated source code references. This will improve issue grouping in Sentry.
-    "sourceRoot": "/"
+    "sourceRoot": "/",
+    "types": ["node", "jest"]
   },
   "include": ["lib/**/*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2625,6 +2625,14 @@ dotenv@^16.3.1:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
+dts-bundle-generator@^9.5.1:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/dts-bundle-generator/-/dts-bundle-generator-9.5.1.tgz#7eac7f47a2d5b51bdaf581843e7f969b88bfc225"
+  integrity sha512-DxpJOb2FNnEyOzMkG11sxO2dmxPjthoVWxfKqWYJ/bI/rT1rvTMktF5EKjAYrRZu6Z6t3NhOUZ0sZ5ZXevOfbA==
+  dependencies:
+    typescript ">=5.0.2"
+    yargs "^17.6.0"
+
 ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
@@ -4885,6 +4893,11 @@ type-fest@^0.21.3:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+typescript@>=5.0.2:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
+
 typescript@^5.8.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
@@ -5080,6 +5093,19 @@ yargs@^17.3.1:
   version "17.6.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
   integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yargs@^17.6.0:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,85 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@ast-grep/lang-kotlin@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@ast-grep/lang-kotlin/-/lang-kotlin-0.0.7.tgz#aa32c8f7c7b79d9255f007334066b2f5d03b3c3b"
+  integrity sha512-+rXVbmESlE5c3QQGl/si0BRj/aC/v6P8Tw//8UxojoqlfZDISG95bHeVRZxb4NuEkt0kFFRn7Lbi9DsHXn8MbA==
+  dependencies:
+    "@ast-grep/setup-lang" "0.0.6"
+
+"@ast-grep/lang-swift@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@ast-grep/lang-swift/-/lang-swift-0.0.8.tgz#05511ed2aae15cbd366c975d941d18cbc6c9cf00"
+  integrity sha512-v+pLafFzXQJ/yTgmOclSzBDX+actORUqrAL0+fJkHlvnbYARxXXKoo4bonuWlzLjp+gOLP/Liuvhb4FlWgPFXA==
+  dependencies:
+    "@ast-grep/setup-lang" "0.0.6"
+
+"@ast-grep/napi-darwin-arm64@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-darwin-arm64/-/napi-darwin-arm64-0.43.0.tgz#52ba09d0a97ead292505d6e40e17ae55811055d3"
+  integrity sha512-JBWYRNJsQ/8yfcMDARFxcl1fVZ6+kv3sHB+ClKgSCe9DNoLvGQfqGr9UGRrNOModvXY6cX+c87iAPqPGftUUiw==
+
+"@ast-grep/napi-darwin-x64@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-darwin-x64/-/napi-darwin-x64-0.43.0.tgz#04dbc2d01dda9c7ca6c8e06087f405fdca587c33"
+  integrity sha512-oqE/bC/uAEctnAbzqobplidExsPym4CQq7JDVD9HpkHpDHzMzPBF69whv/Qu0ZwrkXr48GCMKO5G6p+OB5n+kQ==
+
+"@ast-grep/napi-linux-arm64-gnu@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-linux-arm64-gnu/-/napi-linux-arm64-gnu-0.43.0.tgz#4420984f018b43418666fb82854a1f61f2e9b0b5"
+  integrity sha512-yJSRPxwwrvVW94J2rtaatcixSAGWcSaHNbAh6soXD6HXgq6I7uMc+cyMnJstFL789yd6Pu3QIhTlpD9VY0oYhw==
+
+"@ast-grep/napi-linux-arm64-musl@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-linux-arm64-musl/-/napi-linux-arm64-musl-0.43.0.tgz#5b5b2fd16706f7d65b92bfb2d1425acc36e299b1"
+  integrity sha512-mknXLDsf66HvT/JEl18ZQSvR7/qWgWfqh3eHuVRqD2lE6cKBDXRnAzx9ZNZkUnL2Z5ph54Yk8dKVu09k45cegA==
+
+"@ast-grep/napi-linux-x64-gnu@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.43.0.tgz#d4e5a5eb7e2debdacf1b2b551b90ab0357664874"
+  integrity sha512-KM6M5KKFsHG9Y7VKCKnMsWQQ1sYwj/SPdyr91SKp66AeFJ5xMtXb13WVQ3Joe9NEsi84dzzOBIJgMddz+UMvQw==
+
+"@ast-grep/napi-linux-x64-musl@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-linux-x64-musl/-/napi-linux-x64-musl-0.43.0.tgz#f9496d64ebfdbc5be95c69a0efe3f81c7acfcb6e"
+  integrity sha512-NfjI74m7CEEOsLi7ZkYwcxY10CfKIHPHRrr9aqMulmnrC4FGvxQMk1qpDrTqkjmEd8LdZt3PsPrmBa8AZCErew==
+
+"@ast-grep/napi-win32-arm64-msvc@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.43.0.tgz#9e28ec99d035065b3dabf64fb8486c009d460b91"
+  integrity sha512-8qwXz3oogh834bXmNLtgsQYsuQi4ZDu4e1He/q+ENhVfjIr4IZRAUc1CoKZgWn+ZSE+B0NJJIxT8Vre2l0Q1Lg==
+
+"@ast-grep/napi-win32-ia32-msvc@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-win32-ia32-msvc/-/napi-win32-ia32-msvc-0.43.0.tgz#c8a0697c46f2810618e2dc70f87aec797be323d7"
+  integrity sha512-wUI/B9QNPzi0K7LlyO7eWvwhqFChM6+O4r5dfBfnOlkP1s/AZ04FdYaC9KAZiODE4FCWbeHbfO03RYOdWeF6eg==
+
+"@ast-grep/napi-win32-x64-msvc@0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-win32-x64-msvc/-/napi-win32-x64-msvc-0.43.0.tgz#dc2dd66c1d67fe0c7d7729e47513eb23670a9004"
+  integrity sha512-GsGIwYiThKiK9XPGBEguZAs4aIBgv6+DgosBs6ve2a3L390AaLqitoc+bbRz4Eu51URlFKmNP7TtvnAJbMi8QQ==
+
+"@ast-grep/napi@^0.43.0":
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi/-/napi-0.43.0.tgz#dc9425129796366fe630fe61caeaccdb0d316bd7"
+  integrity sha512-dPugC04xwgk3gJl17jJvTjVjx1IXtWI9EcEQ0szlh0jg1UfvGDdZJo9/S9Pk7gzGBNd2bW8hIL3dG6K4T8PEJA==
+  optionalDependencies:
+    "@ast-grep/napi-darwin-arm64" "0.43.0"
+    "@ast-grep/napi-darwin-x64" "0.43.0"
+    "@ast-grep/napi-linux-arm64-gnu" "0.43.0"
+    "@ast-grep/napi-linux-arm64-musl" "0.43.0"
+    "@ast-grep/napi-linux-x64-gnu" "0.43.0"
+    "@ast-grep/napi-linux-x64-musl" "0.43.0"
+    "@ast-grep/napi-win32-arm64-msvc" "0.43.0"
+    "@ast-grep/napi-win32-ia32-msvc" "0.43.0"
+    "@ast-grep/napi-win32-x64-msvc" "0.43.0"
+
+"@ast-grep/setup-lang@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@ast-grep/setup-lang/-/setup-lang-0.0.6.tgz#9f6f80592367c0d0a2cc7441af9a9d003472df10"
+  integrity sha512-aSYZNF5nGQMxnwiA3Lcc8zi0AtpGlug47ADgqCgP/2n7p922FbnW7vo1rbW4kKjW72B/3mDdN7uvYidv8JnPnw==
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -1220,6 +1299,16 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@google/genai@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@google/genai/-/genai-2.7.0.tgz#8259b66b83d3576cb1d604fa44a0a267558c3f84"
+  integrity sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g==
+  dependencies:
+    google-auth-library "^10.3.0"
+    p-retry "^4.6.2"
+    protobufjs "^7.5.4"
+    ws "^8.18.0"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -1505,16 +1594,6 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
-"@jest/types@^25.5.0":
-  version "25.5.0"
-  resolved "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz"
-  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^15.0.0"
-    chalk "^3.0.0"
-
 "@jest/types@^29.3.1":
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.3.1.tgz#7c5a80777cb13e703aeec6788d044150341147e3"
@@ -1605,6 +1684,79 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@nodelib/fs.scandir@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.5"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.5"
+    fastq "^1.6.0"
+
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
+  integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
+
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
+
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
+
+"@protobufjs/inquire@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.2.tgz#ae64fbc014ff44c8bfad03dd4c93cd2d6a4c82db"
+  integrity sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
+
+"@protobufjs/utf8@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
+  integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
+
 "@sentry-internal/tracing@7.64.0":
   version "7.64.0"
   resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.64.0.tgz#3e110473b8edf805b799cc91d6ee592830237bb4"
@@ -1671,6 +1823,11 @@
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+
+"@sindresorhus/merge-streams@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz#abb11d99aeb6d27f1b563c38147a72d50058e339"
+  integrity sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.5"
@@ -1796,14 +1953,6 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
-"@types/istanbul-reports@^1.1.1":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz"
-  integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "*"
-    "@types/istanbul-lib-report" "*"
-
 "@types/istanbul-reports@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz#9153fe98bba2bd565a63add9436d6f0d7f8468ff"
@@ -1811,13 +1960,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.9":
-  version "26.0.9"
-  resolved "https://registry.npmjs.org/@types/jest/-/jest-26.0.9.tgz"
-  integrity sha512-k4qFfJ5AUKrWok5KYXp2EPm89b0P/KZpl7Vg4XuOTVVQEhLDBDBU3iBFrjjdgd8fLw96aAtmnwhXHl63bWeBQQ==
+"@types/jest@^29.5.0":
+  version "29.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
+  integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==
   dependencies:
-    jest-diff "^25.2.1"
-    pretty-format "^25.2.1"
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
 
 "@types/js-yaml@^4.0.5":
   version "4.0.5"
@@ -1829,6 +1978,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
+"@types/node@>=13.7.0":
+  version "25.9.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.1.tgz#3bda556db500ae4319c08e7fc9ab94f19013ba0b"
+  integrity sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==
+  dependencies:
+    undici-types ">=7.24.0 <7.24.7"
+
 "@types/node@^18.0.0":
   version "18.0.0"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz"
@@ -1839,6 +1995,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.1.tgz#dfd20e2dc35f027cdd6c1908e80a5ddc7499670e"
   integrity sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==
 
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
@@ -1848,13 +2009,6 @@
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
   integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
-
-"@types/yargs@^15.0.0":
-  version "15.0.5"
-  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz"
-  integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^17.0.8":
   version "17.0.13"
@@ -1889,6 +2043,11 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -1947,7 +2106,7 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -2104,6 +2263,16 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bignumber.js@^9.0.0:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.1.tgz#759c5aaddf2ffdc4f154f7b493e1c8770f88c4d7"
+  integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
+
 boxen@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.1.2.tgz#788cb686fc83c1f486dfa8a40c68fc2b831d2b50"
@@ -2127,9 +2296,9 @@ brace-expansion@^1.1.7:
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
+  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -2139,6 +2308,13 @@ braces@^3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+braces@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
 
 browserslist@^4.21.3, browserslist@^4.21.4:
   version "4.21.4"
@@ -2156,6 +2332,11 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
+
+buffer-equal-constant-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -2190,14 +2371,6 @@ chalk@^2.0.0, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 chalk@^4.0.0:
   version "4.1.2"
@@ -2381,6 +2554,11 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -2420,11 +2598,6 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-diff-sequences@^25.2.6:
-  version "25.2.6"
-  resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz"
-  integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
-
 diff-sequences@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.3.1.tgz#104b5b95fe725932421a9c6e5b4bef84c3f2249e"
@@ -2451,6 +2624,13 @@ dotenv@^16.3.1:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
+ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 electron-to-chromium@^1.4.251:
   version "1.4.284"
@@ -2671,6 +2851,17 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
+expect@^29.0.0, expect@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
+  integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
+  dependencies:
+    "@jest/expect-utils" "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+
 expect@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.3.1.tgz#92877aad3f7deefc2e3f6430dd195b92295554a6"
@@ -2682,16 +2873,10 @@ expect@^29.3.1:
     jest-message-util "^29.3.1"
     jest-util "^29.3.1"
 
-expect@^29.7.0:
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
-  integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
-  dependencies:
-    "@jest/expect-utils" "^29.7.0"
-    jest-get-type "^29.6.3"
-    jest-matcher-utils "^29.7.0"
-    jest-message-util "^29.7.0"
-    jest-util "^29.7.0"
+extend@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 faker@^5.1.0:
   version "5.1.0"
@@ -2703,6 +2888,17 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-glob@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
+
 fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -2713,12 +2909,27 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fastq@^1.6.0:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.20.1.tgz#ca750a10dc925bc8b18839fd203e3ef4b3ced675"
+  integrity sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==
+  dependencies:
+    reusify "^1.0.4"
+
 fb-watchman@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.2.tgz#e9524ee6b5c77e9e5001af0f85f3adbb8623255c"
   integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
   dependencies:
     bser "2.1.1"
+
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -2731,6 +2942,13 @@ fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
@@ -2769,6 +2987,13 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2788,6 +3013,24 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+gaxios@^7.0.0, gaxios@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.1.4.tgz#33a5b78e2c5c01cf5a5d17f58dd188839867fc9c"
+  integrity sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+
+gcp-metadata@8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz#e62e3373ddf41fc727ccc31c55c687b798bee898"
+  integrity sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==
+  dependencies:
+    gaxios "^7.0.0"
+    google-logging-utils "^1.0.0"
+    json-bigint "^1.0.0"
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -2834,9 +3077,9 @@ glob@^7.1.3, glob@^7.1.4:
     path-is-absolute "^1.0.0"
 
 glob@^9.3.4:
-  version "9.3.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-9.3.4.tgz#e75dee24891a80c25cc7ee1dd327e126b98679af"
-  integrity sha512-qaSc49hojMOv1EPM4EuyITjDSgSKI0rthoHnvE81tcOi1SCVndHko7auqxdQ14eiQG2NDBJBE86+2xIrbIvrbA==
+  version "9.3.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-9.3.5.tgz#ca2ed8ca452781a3009685607fdf025a899dfe21"
+  integrity sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==
   dependencies:
     fs.realpath "^1.0.0"
     minimatch "^8.0.2"
@@ -2854,6 +3097,35 @@ globals@^13.6.0, globals@^13.9.0:
   integrity sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==
   dependencies:
     type-fest "^0.20.2"
+
+globby@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-16.2.0.tgz#6ab1351fbac1d9b9e47ed423814c2ad41af308ea"
+  integrity sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==
+  dependencies:
+    "@sindresorhus/merge-streams" "^4.0.0"
+    fast-glob "^3.3.3"
+    ignore "^7.0.5"
+    is-path-inside "^4.0.0"
+    slash "^5.1.0"
+    unicorn-magic "^0.4.0"
+
+google-auth-library@^10.3.0:
+  version "10.6.2"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.6.2.tgz#44557c536aec626b7cda48a85b5d026e2c9b74c4"
+  integrity sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^7.1.4"
+    gcp-metadata "8.1.2"
+    google-logging-utils "1.1.3"
+    jws "^4.0.0"
+
+google-logging-utils@1.1.3, google-logging-utils@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
+  integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
 
 graceful-fs@^4.2.9:
   version "4.2.10"
@@ -2890,6 +3162,14 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+https-proxy-agent@^7.0.1:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -2904,6 +3184,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
+  integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
 import-fresh@^3.0.0:
   version "3.2.1"
@@ -3000,6 +3285,11 @@ is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
+is-path-inside@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-4.0.0.tgz#805aeb62c47c1b12fc3fd13bfb3ed1e7430071db"
+  integrity sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==
 
 is-regexp@^1.0.0:
   version "1.0.0"
@@ -3137,16 +3427,6 @@ jest-config@^29.3.1:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^25.2.1:
-  version "25.5.0"
-  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz"
-  integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
-  dependencies:
-    chalk "^3.0.0"
-    diff-sequences "^25.2.6"
-    jest-get-type "^25.2.6"
-    pretty-format "^25.5.0"
-
 jest-diff@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.3.1.tgz#d8215b72fed8f1e647aed2cae6c752a89e757527"
@@ -3196,11 +3476,6 @@ jest-environment-node@^29.3.1:
     "@types/node" "*"
     jest-mock "^29.3.1"
     jest-util "^29.3.1"
-
-jest-get-type@^25.2.6:
-  version "25.2.6"
-  resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz"
-  integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
 
 jest-get-type@^29.2.0:
   version "29.2.0"
@@ -3585,6 +3860,13 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
 
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
+
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
@@ -3609,6 +3891,23 @@ json5@^2.2.1, json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+jwa@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.1.tgz#bf8176d1ad0cd72e0f3f58338595a13e110bc804"
+  integrity sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==
+  dependencies:
+    buffer-equal-constant-time "^1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.1.tgz#07edc1be8fac20e677b283ece261498bd38f0690"
+  integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
+  dependencies:
+    jwa "^2.0.1"
+    safe-buffer "^5.0.1"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -3711,6 +4010,16 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+long@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
+
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -3724,11 +4033,6 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
-
-lru-cache@^7.14.1:
-  version "7.18.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
-  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
 lru_map@^0.3.3:
   version "0.3.3"
@@ -3766,12 +4070,25 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
 micromatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
   dependencies:
     braces "^3.0.2"
+    picomatch "^2.3.1"
+
+micromatch@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
     picomatch "^2.3.1"
 
 mime-db@1.44.0:
@@ -3799,16 +4116,21 @@ minimatch@^3.0.4, minimatch@^3.1.1:
     brace-expansion "^1.1.7"
 
 minimatch@^8.0.2:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.3.tgz#0415cb9bb0c1d8ac758c8a673eb1d288e13f5e75"
-  integrity sha512-tEEvU9TkZgnFDCtpnrEYnPsjT7iUx42aXfs4bzmQ5sMA09/6hZY0jeZcGkXyDagiBOvkUjNo8Viom+Me6+2x7g==
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.7.tgz#954766e22da88a3e0a17ad93b58c15c9d8a579de"
+  integrity sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==
   dependencies:
     brace-expansion "^2.0.1"
 
-minipass@^4.0.2, minipass@^4.2.4:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.5.tgz#9e0e5256f1e3513f8c34691dd68549e85b2c8ceb"
-  integrity sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==
+minipass@^4.2.4:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
+  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 ms@2.1.2:
   version "2.1.2"
@@ -3825,12 +4147,26 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@^2.6.7:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.12.tgz#02eb8e22074018e3d5a83016649d04df0e348fba"
   integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3922,6 +4258,14 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-retry@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+  dependencies:
+    "@types/retry" "0.12.0"
+    retry "^0.13.1"
+
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
@@ -3965,12 +4309,12 @@ path-parse@^1.0.7:
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-scurry@^1.6.1:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.6.3.tgz#4eba7183d64ef88b63c7d330bddc3ba279dc6c40"
-  integrity sha512-RAmB+n30SlN+HnNx6EbcpoDy9nwdpcGPnEKrJnu6GZoDWBdIjo1UQMVtW2ybtC7LC2oKLcMq8y5g8WnKLiod9g==
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
   dependencies:
-    lru-cache "^7.14.1"
-    minipass "^4.0.2"
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -4006,20 +4350,19 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+prettier@^2.8.0:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
-pretty-format@^25.2.1, pretty-format@^25.5.0:
-  version "25.5.0"
-  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz"
-  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+pretty-format@^29.0.0, pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
   dependencies:
-    "@jest/types" "^25.5.0"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
 
 pretty-format@^29.3.1:
   version "29.3.1"
@@ -4027,15 +4370,6 @@ pretty-format@^29.3.1:
   integrity sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==
   dependencies:
     "@jest/schemas" "^29.0.0"
-    ansi-styles "^5.0.0"
-    react-is "^18.0.0"
-
-pretty-format@^29.7.0:
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
-  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
-  dependencies:
-    "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
@@ -4052,6 +4386,24 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+protobufjs@^7.5.4:
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.2.tgz#2659f77bd8d54778814c274dc0df808f54c88918"
+  integrity sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.2"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.1"
+    "@types/node" ">=13.7.0"
+    long "^5.3.2"
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
@@ -4062,10 +4414,10 @@ punycode@^2.1.0:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-react-is@^16.12.0:
-  version "16.13.1"
-  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+queue-microtask@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 react-is@^18.0.0:
   version "18.2.0"
@@ -4174,6 +4526,16 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
+reusify@^1.0.4:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
+  integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
+
 rewire@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/rewire/-/rewire-6.0.0.tgz#54f4fcda4df9928d28af1eb54a318bc51ca9aa99"
@@ -4188,12 +4550,24 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+run-parallel@^1.1.9:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+  dependencies:
+    queue-microtask "^1.2.2"
+
 rxjs@^6.6.7:
   version "6.6.7"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
+
+safe-buffer@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 semver-compare@^1.0.0:
   version "1.0.0"
@@ -4250,6 +4624,11 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slash@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-5.1.0.tgz#be3adddcdf09ac38eebe8dcdc7b1a57a75b095ce"
+  integrity sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==
 
 slice-ansi@^3.0.0:
   version "3.0.0"
@@ -4511,6 +4890,11 @@ typescript@^5.8.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
   integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
+
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
@@ -4533,6 +4917,11 @@ unicode-property-aliases-ecmascript@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
+
+unicorn-magic@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.4.0.tgz#78c6a090fd6d07abd2468b83b385603e00dfdb24"
+  integrity sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==
 
 unique-string@^2.0.0:
   version "2.0.0"
@@ -4588,6 +4977,11 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
@@ -4652,6 +5046,11 @@ write-file-atomic@^4.0.1, write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
+ws@^8.18.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -4666,6 +5065,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
## Overview

Implement baseline 'scan' command

## Context

We are experimenting with scanning a repository to find all of the user-facing text.

## Test Plan

Testing successfully completed in <env> via:

- [ ] `yarn scan ~/Projects/ditto-pay-demo --out-dir ~/ptd-output/ditto-pay-demo` (pointing to your ditto-pay-demo) should successfully run scan
- [ ] `yarn test` still passes
