### PR TITLE
[DIT-12111] Improve error messages, particularly for errors from the Ditto API

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -13,7 +13,7 @@ import appContext from "./utils/appContext";
 import { ErrorType, isDittoError, isDittoErrorType } from "./utils/DittoError";
 import processCommandMetaFlag from "./utils/processCommandMetaFlag";
 
-const handleCommandError = async (error: unknown) => {
+const handleCommandError = async (error: any) => {
   if (process.env.DEBUG === "true") {
     console.error(logger.info("Development stack trace:\n"), error);
   }
@@ -21,6 +21,7 @@ const handleCommandError = async (error: unknown) => {
   let sentryOptions = undefined;
   let exitCode = undefined;
   let errorText =
+    error.message ||
     "Something went wrong. Please contact support or try again later.";
 
   if (isDittoError(error)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
   "main": "bin/ditto.js",


### PR DESCRIPTION
## Overview

This PR improves error messages, particularly for errors from the Ditto API.

## Context

Previously any errors from the Ditto API would have logged out a generic error message, now it will instead log whatever error message is returned from the API.

## Screenshots

Before:
<img width="599" height="68" alt="ditto-cli-project-error-before" src="https://github.com/user-attachments/assets/58484f84-e9aa-48e5-aded-5e058f9011b1" />

After:
<img width="550" height="71" alt="ditto-cli-project-error-after" src="https://github.com/user-attachments/assets/2d93ed09-97ba-43eb-a7a9-abfbe87e7c04" />


## Test Plan

Testing successfully completed in dev/local via:

- [ ] Add an invalid project ID to your ditto/config.yml such as `id: "invalid-project-id"`
- [ ] Run the `pull` command (or you can use `yarn sync` if running directly from this repo)
- [ ] You should now see an error message that mentions you have an invalid project ID, like you can see in the "After" screenshot above. Previously this would have been the generic error you see in the "Before" screenshot above.
