### PR TITLE
Remove 'dotenv' dev dependency from scan production code

### DIFF
--- a/lib/src/commands/scan.ts
+++ b/lib/src/commands/scan.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import fs from "fs/promises";
 import path from "path";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
   "main": "bin/ditto.js",


### PR DESCRIPTION
## Overview

Remove dev dependency from scan production code

## Context

When `ditto scan` was added we had dotenv included directly in the scan code. Since this is only a dev dependency, it breaks the production build.

## Test Plan

Testing successfully completed in local via:

- [ ] can still kick off a `scan` and a `sync`
