### PR TITLE
[DIT-13328] Add better handling of limits for scan

### DIFF
--- a/lib/src/commands/scan.ts
+++ b/lib/src/commands/scan.ts
@@ -11,10 +11,18 @@ import { quit } from "../utils/quit";
 import initAPIToken from "../services/apiToken/initAPIToken";
 import appContext from "../utils/appContext";
 import {
+  asScanLimitInfo,
   initiateClassify,
   initiateScan,
+  scanLimitError,
   uploadCandidatesToS3,
 } from "../http/scan";
+import {
+  analyzeDirectories,
+  formatDirectoryBreakdown,
+  formatOverLimitMessage,
+} from "../scan/analyzeDirectories";
+import DittoError, { ErrorType } from "../utils/DittoError";
 import chalk from "chalk";
 
 // Yarn sets INIT_CWD to the directory the user invoked yarn from, which
@@ -93,16 +101,41 @@ function logExtractSummary(
   }
 }
 
+function buildOverLimitError(args: {
+  candidates: DittoScanCandidate[];
+  originalPath: string;
+  limit: number;
+  plan?: string;
+}): DittoError<ErrorType.ScanError> {
+  const analysis = analyzeDirectories(
+    args.candidates.map((c) => c.location.file),
+    args.limit
+  );
+  return new DittoError({
+    type: ErrorType.ScanError,
+    message: formatOverLimitMessage(analysis, {
+      plan: args.plan,
+      originalPath: args.originalPath,
+    }),
+    exitCode: 1,
+    expected: true,
+    data: {
+      rawErrorMessage: `scan candidate limit exceeded (${analysis.total} > ${args.limit})`,
+    },
+  });
+}
+
 interface ISyncOptions {
   local: boolean;
   outDir?: string;
   prefix?: string;
+  listDirectories?: boolean;
 }
 export const scan = async (
   path: string,
-  { local, outDir = "", prefix = "" }: ISyncOptions
+  { local, outDir = "", prefix = "", listDirectories = false }: ISyncOptions
 ) => {
-  if (local && !outDir) {
+  if (local && !outDir && !listDirectories) {
     return await quit(
       logger.errorText(
         "Must specify --out-dir if outputting candidates locally"
@@ -123,6 +156,16 @@ export const scan = async (
     );
   }
 
+  if (listDirectories) {
+    logger.writeLine(
+      formatDirectoryBreakdown(
+        candidates.map((c) => c.location.file),
+        path
+      )
+    );
+    return await quit(null, 0);
+  }
+
   if (local) {
     const resolvedOutDir = resolveUserPath(outDir);
     await fs.mkdir(resolvedOutDir, { recursive: true });
@@ -140,9 +183,44 @@ export const scan = async (
     const {
       candidatesSignedS3Url,
       record: { _id: recordId },
+      planLimit,
     } = await initiateScan(resolvedInput);
+
+    // Fail before the wasted upload when the candidates we already extracted exceed it.
+    if (
+      planLimit &&
+      candidates.length > planLimit.candidateLimit - planLimit.candidatesUsed
+    ) {
+      throw buildOverLimitError({
+        candidates,
+        originalPath: path,
+        limit: planLimit.candidateLimit - planLimit.candidatesUsed,
+        plan: planLimit.plan,
+      });
+    }
+
     await uploadCandidatesToS3(candidates, candidatesSignedS3Url);
-    await initiateClassify(recordId);
+    try {
+      await initiateClassify(recordId);
+    } catch (e) {
+      // Turn the classify step's plan-limit response into concrete
+      // subdirectory suggestions built from the candidates in memory.
+      const info = asScanLimitInfo(e);
+      if (info) {
+        if (info.limit != null) {
+          throw buildOverLimitError({
+            candidates,
+            originalPath: path,
+            limit: info.limit - (info.used ?? 0),
+            plan: info.plan,
+          });
+        }
+        throw scanLimitError(
+          info.message ?? "This scan exceeds your plan's limit."
+        );
+      }
+      throw e;
+    }
     logExtractSummary(extractSummary);
     const url = `https://app.dittowords.com/scan/${recordId}`;
     console.log(

--- a/lib/src/commands/scan.ts
+++ b/lib/src/commands/scan.ts
@@ -222,7 +222,7 @@ export const scan = async (
       throw e;
     }
     logExtractSummary(extractSummary);
-    const url = `https://app.dittowords.com/scan/${recordId}`;
+    const url = `${appContext.appHost}/scan/${recordId}`;
     console.log(
       `Scan initiated! Visit ${chalk.blueBright.underline(
         url

--- a/lib/src/http/scan.ts
+++ b/lib/src/http/scan.ts
@@ -1,31 +1,62 @@
 import axios, { AxiosError } from "axios";
-import chalk from "chalk";
 import getHttpClient from "./client";
 import { IInitiateScanResponse, ZInitiateScanResponse } from "./types";
 import { DittoScanCandidate } from "../scan/types";
 import DittoError, { ErrorType } from "../utils/DittoError";
 import { Blob } from "buffer";
 
-// Deep-links to the home page with the billing/upgrade modal open.
-const BILLING_URL = "https://app.dittowords.com/home?openBillingModal=true";
+// Structured details from the classify step's SCAN_CANDIDATE_LIMIT_EXCEEDED
+// response.
+export class ScanLimitExceededError extends Error {
+  candidateCount?: number;
+  limit?: number;
+  used?: number;
+  plan?: string;
 
-// OSC 8 hyperlink: renders `label` as a clickable link to `href` in terminals
-// that support it.
-function terminalLink(label: string, href: string): string {
-  const OSC = "\u001B]8;;";
-  const BEL = "\u0007";
-  return `${OSC}${href}${BEL}${chalk.blueBright.underline(label)}${OSC}${BEL}`;
+  constructor(details: {
+    candidateCount?: number;
+    limit?: number;
+    plan?: string;
+    used?: number;
+    message?: string;
+  }) {
+    super(details.message ?? "Scan candidate limit exceeded");
+    this.name = "ScanLimitExceededError";
+    this.candidateCount = details.candidateCount;
+    this.limit = details.limit;
+    this.plan = details.plan;
+    this.used = details.used;
+  }
 }
 
-// Turns the server's plan-limit response into a message with concrete next
-// steps: upgrade, or scan a smaller path.
-function scanLimitError(serverMessage: string): DittoError<ErrorType.ScanError> {
+export interface ScanLimitInfo {
+  candidateCount?: number;
+  used: number | null;
+  limit: number | null;
+  plan?: string;
+  message?: string;
+}
+
+export function asScanLimitInfo(e: unknown): ScanLimitInfo | null {
+  if (!(e instanceof ScanLimitExceededError)) return null;
+  return {
+    candidateCount: e.candidateCount,
+    limit: e.limit ?? null,
+    plan: e.plan,
+    used: e.used ?? null,
+    message: e.message,
+  };
+}
+
+// Fallback message used only when we know the scan is over the limit but the
+// server gave no numeric limit to analyze against.
+export function scanLimitError(
+  serverMessage: string
+): DittoError<ErrorType.ScanError> {
   const message = [
     serverMessage,
     "",
-    "To scan more strings, you can either:",
-    `  • Upgrade your plan at ${terminalLink("app.dittowords.com", BILLING_URL)}`,
-    "  • Scan a smaller subdirectory, e.g. `npx @dittowords/cli scan ./src`",
+    "Scan a smaller subdirectory, e.g. `npx @dittowords/cli scan ./src`.",
   ].join("\n");
 
   return new DittoError({
@@ -67,7 +98,16 @@ export async function initiateClassify(scanId: string): Promise<void> {
 
     const data = e.response?.data;
     if (data?.code === "SCAN_CANDIDATE_LIMIT_EXCEEDED") {
-      throw scanLimitError(data.message);
+      throw new ScanLimitExceededError({
+        candidateCount:
+          typeof data.candidateCount === "number"
+            ? data.candidateCount
+            : undefined,
+        limit: typeof data.limit === "number" ? data.limit : undefined,
+        plan: typeof data.plan === "string" ? data.plan : undefined,
+        used: typeof data.used === "number" ? data.used : undefined,
+        message: typeof data.message === "string" ? data.message : undefined,
+      });
     }
     if (data?.message) throw new Error(data.message);
     throw e;

--- a/lib/src/http/types.ts
+++ b/lib/src/http/types.ts
@@ -184,5 +184,13 @@ export const ZInitiateScanBodySchema = z.object({
 export const ZInitiateScanResponse = z.object({
   record: z.object({ _id: z.string() }),
   candidatesSignedS3Url: z.string(),
+  // Null when there is no limit.
+  planLimit: z
+    .object({
+      plan: z.string(),
+      candidateLimit: z.number(),
+      candidatesUsed: z.number(),
+    })
+    .nullish(),
 });
 export type IInitiateScanResponse = z.infer<typeof ZInitiateScanResponse>;

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -88,10 +88,20 @@ const appEntry = async () => {
     )
     .option("--out-dir <dir>", "output directory", "")
     .option("--prefix <prefix>", "prefix for output files", "")
+    .option(
+      "--list-directories",
+      "print the number of candidate strings per directory and exit, without uploading",
+      false
+    )
     .action(
       async (
         inputPath: string | undefined,
-        opts: { local: boolean; outDir: string; prefix?: string }
+        opts: {
+          local: boolean;
+          outDir: string;
+          prefix?: string;
+          listDirectories?: boolean;
+        }
       ) => {
         try {
           return await scan(inputPath ?? ".", opts);

--- a/lib/src/scan/analyzeDirectories.test.ts
+++ b/lib/src/scan/analyzeDirectories.test.ts
@@ -154,15 +154,6 @@ describe("formatOverLimitMessage", () => {
     expect(msg).toContain("--list-directories");
     expect(msg).not.toMatch(/upgrade/i);
   });
-
-  test("names the blocker when nothing fits", () => {
-    const msg = formatOverLimitMessage(
-      analyzeDirectories(files({ "src/generated/a.ts": 5000 }), 1000),
-      { plan: "trial", originalPath: "." }
-    );
-    expect(msg).toContain("`src/generated` alone has 5,000 strings");
-    expect(msg).not.toMatch(/upgrade/i);
-  });
 });
 
 describe("formatDirectoryBreakdown", () => {

--- a/lib/src/scan/analyzeDirectories.test.ts
+++ b/lib/src/scan/analyzeDirectories.test.ts
@@ -1,0 +1,182 @@
+import {
+  analyzeDirectories,
+  rollupCandidateCountsToParentPaths,
+  joinDisplayPath,
+  formatOverLimitMessage,
+  formatDirectoryBreakdown,
+} from "./analyzeDirectories";
+
+// Expands a { path: count } spec into the flat file-path list analyzeDirectories
+// consumes (one entry per candidate).
+function files(spec: Record<string, number>): string[] {
+  const out: string[] = [];
+  for (const [file, n] of Object.entries(spec)) {
+    for (let i = 0; i < n; i++) out.push(file);
+  }
+  return out;
+}
+
+describe("analyzeDirectories", () => {
+  test("returns the largest fitting subtrees, sorted by count desc", () => {
+    const analysis = analyzeDirectories(
+      files({
+        "src/components/a.ts": 842,
+        "src/screens/a.ts": 610,
+        "src/features/onboarding/a.ts": 512,
+        "server/api/a.ts": 400,
+        "server/db/a.ts": 300,
+      }),
+      1000
+    );
+
+    expect(analysis.total).toBe(2664);
+    expect(analysis.suggestions).toEqual([
+      { dir: "src/components", count: 842 },
+      { dir: "server", count: 700 },
+      { dir: "src/screens", count: 610 },
+      { dir: "src/features", count: 512 },
+    ]);
+  });
+
+  test("prefers the child when the parent is over the limit", () => {
+    const analysis = analyzeDirectories(
+      files({ "a/b/x.ts": 500, "a/c.ts": 800 }),
+      1000
+    );
+    expect(analysis.suggestions).toEqual([{ dir: "a/b", count: 500 }]);
+  });
+
+  test("descends to a grandchild when parent and child are both over", () => {
+    const analysis = analyzeDirectories(
+      files({ "a/b/c/x.ts": 900, "a/b/d.ts": 500, "a/e.ts": 700 }),
+      1000
+    );
+    expect(analysis.suggestions).toEqual([{ dir: "a/b/c", count: 900 }]);
+  });
+
+  test("frontier directories are disjoint (none is an ancestor of another)", () => {
+    const analysis = analyzeDirectories(
+      files({
+        "src/components/a.ts": 842,
+        "src/screens/a.ts": 610,
+        "src/features/onboarding/a.ts": 512,
+        "server/api/a.ts": 400,
+        "server/db/a.ts": 300,
+      }),
+      1000
+    );
+    const dirs = analysis.suggestions.map((s) => s.dir);
+    for (const a of dirs) {
+      for (const b of dirs) {
+        if (a === b) continue;
+        expect(b.startsWith(`${a}/`)).toBe(false);
+      }
+    }
+  });
+
+  test("caps suggestions and reports the omitted count and coverage", () => {
+    const spec: Record<string, number> = {};
+    for (let i = 1; i <= 12; i++) {
+      spec[`d${String(i).padStart(2, "0")}/a.ts`] = 100;
+    }
+    const analysis = analyzeDirectories(files(spec), 150);
+
+    expect(analysis.total).toBe(1200);
+    expect(analysis.suggestions).toHaveLength(10);
+    expect(analysis.omittedFittingCount).toBe(2);
+    // Equal counts tie-break alphabetically → d01..d10 shown.
+    expect(analysis.suggestions.map((s) => s.dir)).toEqual([
+      "d01",
+      "d02",
+      "d03",
+      "d04",
+      "d05",
+      "d06",
+      "d07",
+      "d08",
+      "d09",
+      "d10",
+    ]);
+  });
+
+  test("all strings at top level → no suggestions, root blocker", () => {
+    const analysis = analyzeDirectories(
+      files({ "a.ts": 1500, "b.ts": 700 }),
+      1000
+    );
+    expect(analysis.suggestions).toEqual([]);
+  });
+
+  test("single over-limit leaf directory is named as the blocker", () => {
+    const analysis = analyzeDirectories(
+      files({ "src/generated/a.ts": 5000 }),
+      1000
+    );
+    expect(analysis.suggestions).toEqual([]);
+  });
+});
+
+describe("rollupByDirectory", () => {
+  test("root count equals total and ancestors sum correctly", () => {
+    const subtree = rollupCandidateCountsToParentPaths(
+      files({ "a/b/c.ts": 2, "a/d.ts": 3 })
+    );
+    expect(subtree.get("")).toBe(5);
+    expect(subtree.get("a")).toBe(5);
+    expect(subtree.get("a/b")).toBe(2);
+  });
+});
+
+describe("joinDisplayPath", () => {
+  test("joins the original path arg with a relative dir", () => {
+    expect(joinDisplayPath(".", "src")).toBe("src");
+    expect(joinDisplayPath("frontend", "src/x")).toBe("frontend/src/x");
+    expect(joinDisplayPath("./frontend", "src")).toBe("frontend/src");
+    expect(joinDisplayPath("frontend/", "src")).toBe("frontend/src");
+    expect(joinDisplayPath("/abs", "src")).toBe("/abs/src");
+  });
+});
+
+describe("formatOverLimitMessage", () => {
+  const base = files({
+    "src/components/a.ts": 842,
+    "src/screens/a.ts": 610,
+    "server/api/a.ts": 700,
+  });
+
+  test("renders ranked commands rooted at the original path", () => {
+    const msg = formatOverLimitMessage(analyzeDirectories(base, 1000), {
+      plan: "free",
+      originalPath: "frontend",
+    });
+    expect(msg).toContain("2,152 strings, but your free plan allows 1,000");
+    expect(msg).toContain("npx @dittowords/cli scan frontend/src/components");
+    expect(msg).toContain("--list-directories");
+    expect(msg).not.toMatch(/upgrade/i);
+  });
+
+  test("names the blocker when nothing fits", () => {
+    const msg = formatOverLimitMessage(
+      analyzeDirectories(files({ "src/generated/a.ts": 5000 }), 1000),
+      { plan: "trial", originalPath: "." }
+    );
+    expect(msg).toContain("`src/generated` alone has 5,000 strings");
+    expect(msg).not.toMatch(/upgrade/i);
+  });
+});
+
+describe("formatDirectoryBreakdown", () => {
+  test("prints every rolled-up directory in tree order", () => {
+    const out = formatDirectoryBreakdown(
+      files({ "src/components/a.ts": 2, "src/screens/a.ts": 1 }),
+      "frontend"
+    );
+    const lines = out.split("\n");
+    expect(lines[0]).toBe("Strings by directory (rolled up), under frontend:");
+    // ROOT first, then src, then its children alphabetically.
+    const dirRows = lines.filter((l) => /\d/.test(l));
+    expect(dirRows[0]).toContain("(whole scan)");
+    expect(out).toContain("src/components");
+    expect(out).toContain("src/screens");
+  });
+});

--- a/lib/src/scan/analyzeDirectories.ts
+++ b/lib/src/scan/analyzeDirectories.ts
@@ -1,0 +1,184 @@
+import path from "path";
+
+// The rollup key for the input root. Candidate file paths are POSIX and
+// relative to the scanned root, so the root itself is the empty prefix.
+const ROOT = "";
+
+// The literal we suggest users run.
+const CLI_INVOCATION = "npx @dittowords/cli scan";
+
+export interface DirectorySuggestion {
+  dir: string;
+  count: number;
+}
+
+export interface DirectoryAnalysis {
+  total: number;
+  limit: number;
+  // Largest subtrees that each fit under the limit, sorted by descending count
+  // (tie-break: directory name ascending), capped.
+  suggestions: DirectorySuggestion[];
+  // Number of fitting subtrees beyond the cap.
+  omittedFittingCount: number;
+}
+
+export function analyzeDirectories(
+  filePaths: string[],
+  limit: number,
+  cap = 10
+): DirectoryAnalysis {
+  const total = filePaths.length;
+  const subtree = rollupCandidateCountsToParentPaths(filePaths);
+
+  // A directory fits (<= limit) and its parent does not.
+  // ROOT never qualifies because we only get here when total > limit.
+  const suggestedPaths: DirectorySuggestion[] = [];
+  for (const [dir, count] of subtree) {
+    if (dir === ROOT || count > limit) continue;
+    const parent = parentDirName(dir);
+    const parentCount = parent === null ? total : subtree.get(parent) ?? total;
+    if (parentCount > limit) suggestedPaths.push({ dir, count });
+  }
+
+  // Sort by descending count, tie-break by directory name; cap.
+  suggestedPaths.sort((a, b) => b.count - a.count || (a.dir < b.dir ? -1 : 1));
+  const cappedSuggestedPaths = suggestedPaths.slice(0, cap);
+  const omittedFittingCount =
+    suggestedPaths.length - cappedSuggestedPaths.length;
+  return {
+    total,
+    limit,
+    suggestions: cappedSuggestedPaths,
+    omittedFittingCount,
+  };
+}
+
+// Given a list of candidate file paths, returns a map of paths to the sum of candidates
+// in that path and any sub directories under that path.
+export function rollupCandidateCountsToParentPaths(
+  filePaths: string[]
+): Map<string, number> {
+  const candidateCountByPath = new Map<string, number>();
+  for (const path of filePaths) {
+    for (const dependentDir of parentDirsOf(path)) {
+      candidateCountByPath.set(
+        dependentDir,
+        (candidateCountByPath.get(dependentDir) ?? 0) + 1
+      );
+    }
+  }
+  return candidateCountByPath;
+}
+
+// "a/b/c" -> "a/b" ; "a" -> ROOT ; ROOT -> null
+function parentDirName(dir: string): string | null {
+  if (dir === ROOT) return null;
+  const i = dir.lastIndexOf("/");
+  return i === -1 ? ROOT : dir.slice(0, i);
+}
+
+// "a/b/c.ts" -> ["a/b", "a", ROOT] (directories only, nearest first)
+function parentDirsOf(file: string): string[] {
+  const parents: string[] = [];
+  for (let d = parentDirName(file); d !== null; d = parentDirName(d))
+    parents.push(d);
+  return parents;
+}
+
+// Builds the user-facing message shown when a scan exceeds the plan limit.
+// `originalPath` is the path argument as the user typed it.
+export function formatOverLimitMessage(
+  analysis: DirectoryAnalysis,
+  opts: { plan?: string; originalPath: string }
+): string {
+  const { total, limit, suggestions, omittedFittingCount } = analysis;
+  const root = displayRoot(opts.originalPath);
+
+  const header = `This scan found ${fmtCount(
+    total
+  )} strings, but your ${planLabel(opts.plan)} allows ${fmtCount(
+    limit
+  )} per scan.`;
+
+  if (suggestions.length === 0) {
+    return [
+      header,
+      "",
+      `There's no subdirectory small enough to scan on its own — all ${fmtCount(
+        total
+      )} strings are in files at the top level of \`${root}\`. Point the scan at a narrower path to stay under the limit.`,
+    ].join("\n");
+  }
+
+  const commands = suggestions.map(
+    (s) => `${CLI_INVOCATION} ${joinDisplayPath(opts.originalPath, s.dir)}`
+  );
+  const width = Math.max(...commands.map((c) => c.length));
+  const lines = suggestions.map(
+    (s, i) => `  ${commands[i].padEnd(width)}   (${fmtCount(s.count)} strings)`
+  );
+  if (omittedFittingCount > 0) {
+    lines.push(`  … and ${fmtCount(omittedFittingCount)} more`);
+  }
+
+  return [
+    header,
+    "",
+    "Scan one of these subdirectories instead. Each fits within your plan:",
+    "",
+    ...lines,
+    "",
+    `Run \`${CLI_INVOCATION} ${root} --list-directories\` for the full breakdown.`,
+  ].join("\n");
+}
+
+// Full rolled-up per-directory breakdown for the --list-directories flag.
+// Directories are printed in tree order (a parent precedes its children,
+// siblings alphabetical), which plain lexicographic sort of POSIX paths yields.
+export function formatDirectoryBreakdown(
+  filePaths: string[],
+  originalPath: string
+): string {
+  const subtree = rollupCandidateCountsToParentPaths(filePaths);
+  if (!subtree.has(ROOT)) subtree.set(ROOT, 0);
+
+  const dirs = [...subtree.keys()].sort();
+  const width = Math.max(
+    ...dirs.map((d) => fmtCount(subtree.get(d) ?? 0).length)
+  );
+
+  const root = displayRoot(originalPath);
+  const rows = dirs.map((dir) => {
+    const count = fmtCount(subtree.get(dir) ?? 0).padStart(width);
+    const depth = dir === ROOT ? 0 : dir.split("/").length - 1;
+    const label = dir === ROOT ? ".  (whole scan)" : dir;
+    return `  ${count}  ${"  ".repeat(depth)}${label}`;
+  });
+
+  return [`Strings by directory (rolled up), under ${root}:`, "", ...rows].join(
+    "\n"
+  );
+}
+
+// Joins the user's original (as-typed) path argument with a suggested relative
+// directory to produce a ready-to-run command path. Normalizes to POSIX and
+// collapses "./" and trailing slashes so the printed command is clean.
+export function joinDisplayPath(originalInput: string, relDir: string): string {
+  const base = originalInput.replace(/\\/g, "/");
+  return path.posix.join(base, relDir);
+}
+
+// The root path as the user typed it, normalized for display.
+// Empty input renders as ".".
+function displayRoot(originalInput: string): string {
+  const normalized = path.posix.join(originalInput.replace(/\\/g, "/"), ".");
+  return normalized === "" ? "." : normalized;
+}
+
+function planLabel(plan?: string): string {
+  return plan ? `${plan} plan` : "plan";
+}
+
+function fmtCount(n: number): string {
+  return n.toLocaleString("en-US");
+}

--- a/lib/src/scan/analyzeDirectories.ts
+++ b/lib/src/scan/analyzeDirectories.ts
@@ -98,15 +98,13 @@ export function formatOverLimitMessage(
     total
   )} strings, but your ${planLabel(opts.plan)} allows ${fmtCount(
     limit
-  )} per scan.`;
+  )} scanned strings.`;
 
   if (suggestions.length === 0) {
     return [
       header,
       "",
-      `There's no subdirectory small enough to scan on its own — all ${fmtCount(
-        total
-      )} strings are in files at the top level of \`${root}\`. Point the scan at a narrower path to stay under the limit.`,
+      `There's no subdirectory small enough to scan on its own.`,
     ].join("\n");
   }
 

--- a/lib/src/utils/appContext.ts
+++ b/lib/src/utils/appContext.ts
@@ -6,12 +6,16 @@ import {
   ProjectConfigYAML,
 } from "../services/projectConfig";
 
+const DEFAULT_API_HOST = "https://api.dittowords.com";
+const DEFAULT_APP_HOST = "https://app.dittowords.com";
+
 /**
  * This class is used to store the global CLI context. It is preserved across all methods
  * and is used to store the running state of the CLI.
  */
 class AppContext {
   #apiHost: string;
+  #appHost: string;
   #apiToken: string | undefined;
   #configFile: string;
   #projectConfigDir: string;
@@ -20,7 +24,8 @@ class AppContext {
   #projectConfig: ProjectConfigYAML;
   #outDir: string;
   constructor() {
-    this.#apiHost = process.env.DITTO_API_HOST || "https://api.dittowords.com";
+    this.#apiHost = process.env.DITTO_API_HOST || DEFAULT_API_HOST;
+    this.#appHost = process.env.DITTO_APP_HOST || DEFAULT_APP_HOST;
     this.#apiToken = process.env.DITTO_TOKEN;
     this.#configFile =
       process.env.DITTO_CONFIG_FILE || path.join(homedir(), ".config", "ditto");
@@ -37,6 +42,10 @@ class AppContext {
 
   get apiHost() {
     return this.#apiHost;
+  }
+
+  get appHost() {
+    return this.#appHost;
   }
 
   set apiHost(value: string) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
   "main": "bin/ditto.js",


### PR DESCRIPTION
## Overview
 Better handle cases where the `scan` command hits workspace limits around string classification. 

Upon initial scan the api returns the plan's limit, currently used budget, and plan name. This is used to help identify if the scan that is about to be done is possible within the workspace's limits. If it is not (or if it is run and we get back an error from the backend that a limit is reached) we will provide suggestions for directories that fit within the limit. 

The logic used for the directory suggestion is: 
* the directory's count of candidates, which is the sum of it's candidates and any of its sub directories, is less than the limit.
* the directory's parent directory is the root directory or another directory whose candidate count is > limit.
* sorted by candidate count desc for the matched directories, limited to a max of 10 suggestions.

There is also a `--list-directories` flag that will show the count of the candidates in every directories and its sub directories in lexicographical order to help with directory selection. 

Bump the cli version to reflect this change which is a minor update that does not influence the functionality, it just helps better shows the impact of the backend filtering.  

## Screenshots

<img width="789" height="560" alt="Screenshot 2026-07-27 at 5 47 24 PM" src="https://github.com/user-attachments/assets/7fb10a51-95a9-4c20-b645-3afd9faa9b42" />
<img width="1003" height="416" alt="Screenshot 2026-07-27 at 5 47 44 PM" src="https://github.com/user-attachments/assets/2d2edf55-c82b-47a1-8eed-ade0dad18d21" />
<img width="853" height="641" alt="Screenshot 2026-07-27 at 5 48 13 PM" src="https://github.com/user-attachments/assets/79d0b600-2c4c-49f7-8523-54ad39fa8b88" />
<img width="796" height="546" alt="Screenshot 2026-07-27 at 5 58 18 PM" src="https://github.com/user-attachments/assets/23ab6246-45bf-4013-a6dd-97eb792f5397" />


## Test Plan

Testing successfully completed locally with:

- [x] Run ditto scan locally `DITTO_API_HOST=http://localhost:3001 DITTO_APP_HOST=http://localhost:3000 \
DITTO_TOKEN=$(curl -s "http://localhost:3001/trusted/token?email=<env>" | jq -r .token) \
yarn scan <path> --list-directories`
- [x] counts of the number of strings in each directory should be shown. 
- [x] Re-run with a small directory (count <1000) and no `--list-directories` flag in an non-limited org.
- [x] Follow the url to allow for the job to summarize.
- [x] Re-run with a small directory (count >1000) and no `--list-directories` flag in a limited org
- [x] There should be an error message with potential smaller directories to scan
- [x] Re-run with a small directory (count <1000) and no `--list-directories` flag in a limited org
- [x] Follow the url to allow for the job to summarize. Wait for it to finish
- [x] Re-run with a small directory (count <1000) and no `--list-directories` flag in a limited org
- [x] The new limit should be reflect based on the previous job's used limit. 