### PR TITLE
Add a login command, and stop the CLI hanging when there is no terminal to prompt in

### DIFF
--- a/__mocks__/open.js
+++ b/__mocks__/open.js
@@ -1,0 +1,6 @@
+// `open` ships as ESM only, which jest can't transform. Any suite that reaches
+// it — directly or through a module that launches a browser — gets this stub.
+const open = jest.fn(() => Promise.resolve());
+
+module.exports = open;
+module.exports.default = open;

--- a/lib/src/commands/login.test.ts
+++ b/lib/src/commands/login.test.ts
@@ -1,0 +1,69 @@
+import { login } from "./login";
+import * as InitAPIToken from "../services/apiToken/initAPIToken";
+import * as Quit from "../utils/quit";
+import appContext from "../utils/appContext";
+import logger from "../utils/logger";
+
+describe("login", () => {
+  let initAPITokenSpy: jest.SpiedFunction<typeof InitAPIToken.default>;
+  let quitSpy: jest.SpiedFunction<typeof Quit.quit>;
+  let written: string[];
+
+  const token = "a-valid-key";
+
+  beforeEach(() => {
+    written = [];
+
+    logger.info = jest.fn((msg: string) => msg);
+    logger.success = jest.fn((msg: string) => msg);
+    logger.writeLine = jest.fn((msg: string) => {
+      written.push(msg);
+    });
+
+    initAPITokenSpy = jest
+      .spyOn(InitAPIToken, "default")
+      .mockResolvedValue(token);
+
+    quitSpy = jest.spyOn(Quit, "quit").mockResolvedValue(undefined as never);
+
+    delete process.env.DITTO_TOKEN;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("resolves a token and exits 0", async () => {
+    await login();
+
+    expect(initAPITokenSpy).toHaveBeenCalled();
+    expect(quitSpy).toHaveBeenCalledWith(null, 0);
+  });
+
+  it("says where the key was saved", async () => {
+    await login();
+
+    expect(written.join("\n")).toContain(appContext.configFile);
+  });
+
+  it("credits DITTO_TOKEN when that's where the key came from", async () => {
+    process.env.DITTO_TOKEN = token;
+
+    await login();
+
+    const output = written.join("\n");
+    expect(output).toContain("DITTO_TOKEN");
+    expect(output).not.toContain(appContext.configFile);
+  });
+
+  it("stays quiet when there was no terminal to prompt in", async () => {
+    // collectToken quits and returns "" in that case; login must not then
+    // claim success on top of the message explaining what to do.
+    initAPITokenSpy.mockResolvedValue("");
+
+    await login();
+
+    expect(written).toHaveLength(0);
+    expect(quitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/lib/src/commands/login.ts
+++ b/lib/src/commands/login.ts
@@ -1,0 +1,27 @@
+import initAPIToken from "../services/apiToken/initAPIToken";
+import appContext from "../utils/appContext";
+import logger from "../utils/logger";
+import { quit } from "../utils/quit";
+
+/**
+ * Saves an API key and does nothing else, so it can be handed to someone who
+ * only needs to get authenticated — pull and scan both have side effects
+ * (project config, file writes, uploading a scan) that would surprise them.
+ */
+export const login = async () => {
+  const token = await initAPIToken();
+
+  // collectToken exits on its own when there's no terminal to prompt in.
+  if (!token) return;
+
+  const usingEnvironmentVariable = token === process.env.DITTO_TOKEN;
+
+  logger.writeLine(
+    logger.success("\nYou're all set — Ditto can reach your workspace.") +
+      (usingEnvironmentVariable
+        ? `\nUsing the key in ${logger.info("DITTO_TOKEN")}.`
+        : `\nYour key is saved in ${logger.info(appContext.configFile)}.`)
+  );
+
+  await quit(null, 0);
+};

--- a/lib/src/commands/scan.ts
+++ b/lib/src/commands/scan.ts
@@ -228,13 +228,18 @@ export const scan = async (
         url
       )} to view progress and see results.`
     );
-    const { openUrl } = await prompt<{ openUrl: boolean }>({
-      type: "confirm",
-      name: "openUrl",
-      message: "Open in browser?",
-      initial: true,
-    });
-    if (openUrl) await open(url);
+    // The scan itself is done by this point, so a non-interactive caller — an
+    // agent running scan in a tool call — should get the URL and exit rather
+    // than wait on a confirm nobody can answer.
+    if (process.stdin.isTTY) {
+      const { openUrl } = await prompt<{ openUrl: boolean }>({
+        type: "confirm",
+        name: "openUrl",
+        message: "Open in browser?",
+        initial: true,
+      });
+      if (openUrl) await open(url);
+    }
     await quit(null, 0);
   }
 };

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -2,6 +2,7 @@
 // This is the main entry point for the ditto-cli command.
 import * as Sentry from "@sentry/node";
 import { program } from "commander";
+import { login } from "./commands/login";
 import { pull } from "./commands/pull";
 import { scan } from "./commands/scan";
 import { quit } from "./utils/quit";
@@ -50,6 +51,18 @@ const handleCommandError = async (error: any) => {
 
 const appEntry = async () => {
   program.name("ditto-cli");
+
+  // ditto login
+  program
+    .command("login")
+    .description("Save your Ditto API key on this computer")
+    .action(async () => {
+      try {
+        return await login();
+      } catch (error) {
+        handleCommandError(error);
+      }
+    });
 
   // ditto pull
   program

--- a/lib/src/services/apiToken/collectToken.test.ts
+++ b/lib/src/services/apiToken/collectToken.test.ts
@@ -97,7 +97,7 @@ describe("collectToken", () => {
       expect(message).toContain("password");
     });
 
-    it("restates the command to rerun, for a reader who never saw it", async () => {
+    it("names the login command, not whatever command was actually run", async () => {
       const argv = process.argv;
       process.argv = ["node", "ditto-cli", "scan", "./src"];
 
@@ -108,21 +108,8 @@ describe("collectToken", () => {
       }
 
       const message = quitSpy.mock.calls[0][0] as string;
-      expect(message).toContain("npx -y @dittowords/cli@latest scan ./src");
-    });
-
-    it("quotes arguments containing spaces so the command can be pasted", async () => {
-      const argv = process.argv;
-      process.argv = ["node", "ditto-cli", "scan", "./my source"];
-
-      try {
-        await collectToken();
-      } finally {
-        process.argv = argv;
-      }
-
-      const message = quitSpy.mock.calls[0][0] as string;
-      expect(message).toContain('scan "./my source"');
+      expect(message).toContain("npx -y @dittowords/cli@latest login");
+      expect(message).not.toContain("scan");
     });
 
     it("does not open a browser nobody is watching", async () => {

--- a/lib/src/services/apiToken/collectToken.test.ts
+++ b/lib/src/services/apiToken/collectToken.test.ts
@@ -1,26 +1,50 @@
+import open from "open";
+
 import collectToken from "./collectToken";
 import * as PromptForApiToken from "./promptForApiToken";
+import * as Quit from "../../utils/quit";
 import logger from "../../utils/logger";
+
+jest.mock("open");
 
 describe("collectToken", () => {
   let promptForApiTokenSpy: jest.SpiedFunction<
     typeof PromptForApiToken.default
   >;
+  let quitSpy: jest.SpiedFunction<typeof Quit.quit>;
 
   const token = "token";
+  const isTTY = process.stdin.isTTY;
+
+  const setTTY = (value: boolean) => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value,
+      configurable: true,
+    });
+  };
 
   beforeEach(() => {
     logger.url = jest.fn((msg: string) => msg);
     logger.bold = jest.fn((msg: string) => msg);
     logger.info = jest.fn((msg: string) => msg);
+    logger.warnText = jest.fn((msg: string) => msg);
     logger.writeLine = jest.fn((msg: string) => {});
 
     promptForApiTokenSpy = jest
       .spyOn(PromptForApiToken, "default")
       .mockResolvedValue({ token });
+
+    // quit() calls process.exit, which would take the test runner with it.
+    quitSpy = jest.spyOn(Quit, "quit").mockResolvedValue(undefined as never);
+
+    // Manual mock, so call history survives restoreMocks between tests.
+    (open as unknown as jest.Mock).mockReset();
+    (open as unknown as jest.Mock).mockResolvedValue(undefined);
+    setTTY(true);
   });
 
   afterEach(() => {
+    setTTY(isTTY as boolean);
     jest.restoreAllMocks();
   });
 
@@ -30,5 +54,45 @@ describe("collectToken", () => {
     expect(logger.url).toHaveBeenCalled();
     expect(logger.writeLine).toHaveBeenCalled();
     expect(promptForApiTokenSpy).toHaveBeenCalled();
+  });
+
+  it("opens the API keys page in the browser", async () => {
+    await collectToken();
+    expect(open).toHaveBeenCalledWith(
+      expect.stringContaining("/developers/api-keys")
+    );
+  });
+
+  it("still prompts when the browser can't be opened", async () => {
+    (open as unknown as jest.Mock).mockRejectedValue(new Error("no browser"));
+
+    const response = await collectToken();
+    expect(response).toBe(token);
+    expect(promptForApiTokenSpy).toHaveBeenCalled();
+  });
+
+  describe("without a TTY", () => {
+    beforeEach(() => setTTY(false));
+
+    it("quits instead of prompting, so a non-interactive caller can't hang", async () => {
+      await collectToken();
+
+      expect(promptForApiTokenSpy).not.toHaveBeenCalled();
+      expect(quitSpy).toHaveBeenCalled();
+    });
+
+    it("explains how to save a key out of band", async () => {
+      await collectToken();
+
+      const message = quitSpy.mock.calls[0][0] as string;
+      expect(message).toContain("/developers/api-keys");
+      expect(message).toContain("DITTO_TOKEN");
+      expect(message).toContain("your own terminal");
+    });
+
+    it("does not open a browser nobody is watching", async () => {
+      await collectToken();
+      expect(open).not.toHaveBeenCalled();
+    });
   });
 });

--- a/lib/src/services/apiToken/collectToken.test.ts
+++ b/lib/src/services/apiToken/collectToken.test.ts
@@ -87,7 +87,14 @@ describe("collectToken", () => {
       const message = quitSpy.mock.calls[0][0] as string;
       expect(message).toContain("/developers/api-keys");
       expect(message).toContain("DITTO_TOKEN");
-      expect(message).toContain("your own terminal");
+      expect(message).toContain("in a terminal");
+    });
+
+    it("says what an API key is, for readers who won't already know", async () => {
+      await collectToken();
+
+      const message = quitSpy.mock.calls[0][0] as string;
+      expect(message).toContain("password");
     });
 
     it("does not open a browser nobody is watching", async () => {

--- a/lib/src/services/apiToken/collectToken.test.ts
+++ b/lib/src/services/apiToken/collectToken.test.ts
@@ -87,7 +87,7 @@ describe("collectToken", () => {
       const message = quitSpy.mock.calls[0][0] as string;
       expect(message).toContain("/developers/api-keys");
       expect(message).toContain("DITTO_TOKEN");
-      expect(message).toContain("in a terminal");
+      expect(message).toContain("Open a terminal");
     });
 
     it("says what an API key is, for readers who won't already know", async () => {
@@ -95,6 +95,34 @@ describe("collectToken", () => {
 
       const message = quitSpy.mock.calls[0][0] as string;
       expect(message).toContain("password");
+    });
+
+    it("restates the command to rerun, for a reader who never saw it", async () => {
+      const argv = process.argv;
+      process.argv = ["node", "ditto-cli", "scan", "./src"];
+
+      try {
+        await collectToken();
+      } finally {
+        process.argv = argv;
+      }
+
+      const message = quitSpy.mock.calls[0][0] as string;
+      expect(message).toContain("npx -y @dittowords/cli@latest scan ./src");
+    });
+
+    it("quotes arguments containing spaces so the command can be pasted", async () => {
+      const argv = process.argv;
+      process.argv = ["node", "ditto-cli", "scan", "./my source"];
+
+      try {
+        await collectToken();
+      } finally {
+        process.argv = argv;
+      }
+
+      const message = quitSpy.mock.calls[0][0] as string;
+      expect(message).toContain('scan "./my source"');
     });
 
     it("does not open a browser nobody is watching", async () => {

--- a/lib/src/services/apiToken/collectToken.ts
+++ b/lib/src/services/apiToken/collectToken.ts
@@ -12,6 +12,15 @@ import promptForApiToken from "./promptForApiToken";
 export default async function collectToken() {
   const apiKeysUrl = `${appContext.appHost}/developers/api-keys`;
 
+  // Restated in full rather than as "this command", because whoever reads the
+  // non-interactive message below often never saw it run — an agent invoked it
+  // for them. `-y` matters for the same reason the guard does: without it npx
+  // can stop on its own install prompt.
+  const commandToRerun = ["npx", "-y", "@dittowords/cli@latest"]
+    .concat(process.argv.slice(2))
+    .map((arg) => (/\s/.test(arg) ? `"${arg}"` : arg))
+    .join(" ");
+
   // Every command needing a token funnels through here, so this is the one place
   // that has to cope with nobody being there to ask: run from an agent's tool
   // call, enquirer has no TTY and waits forever. Stopping also keeps the key out
@@ -23,7 +32,9 @@ export default async function collectToken() {
       ) +
         `\n\nTo set it up:\n` +
         `  1. Create a key at ${logger.url(apiKeysUrl)}\n` +
-        `  2. Run this same command yourself, in a terminal — the app on your computer where you type commands. It'll ask for the key and remember it, so this is a one-time step.\n` +
+        `  2. Open a terminal — the app on your computer where you type commands — and run:\n\n` +
+        `       ${logger.info(commandToRerun)}\n\n` +
+        `     It'll ask for the key and remember it, so this is a one-time step.\n` +
         `\nSetting Ditto up for automation instead? Save your key as ${logger.info(
           "DITTO_TOKEN"
         )} and Ditto will use that.`

--- a/lib/src/services/apiToken/collectToken.ts
+++ b/lib/src/services/apiToken/collectToken.ts
@@ -19,13 +19,14 @@ export default async function collectToken() {
   if (!process.stdin.isTTY) {
     await quit(
       logger.warnText(
-        "Ditto needs an API key, and there's no terminal here to type it into."
+        "Ditto needs an API key — a password that lets Ditto reach your workspace. There's no way to type one in here."
       ) +
-        `\n\nCreate a key at ${logger.url(
-          apiKeysUrl
-        )}, then run this command again in your own terminal — or set ${logger.info(
+        `\n\nTo set it up:\n` +
+        `  1. Create a key at ${logger.url(apiKeysUrl)}\n` +
+        `  2. Run this same command yourself, in a terminal — the app on your computer where you type commands. It'll ask for the key and remember it, so this is a one-time step.\n` +
+        `\nSetting Ditto up for automation instead? Save your key as ${logger.info(
           "DITTO_TOKEN"
-        )} in your environment.`
+        )} and Ditto will use that.`
     );
     return "";
   }

--- a/lib/src/services/apiToken/collectToken.ts
+++ b/lib/src/services/apiToken/collectToken.ts
@@ -12,14 +12,11 @@ import promptForApiToken from "./promptForApiToken";
 export default async function collectToken() {
   const apiKeysUrl = `${appContext.appHost}/developers/api-keys`;
 
-  // Restated in full rather than as "this command", because whoever reads the
-  // non-interactive message below often never saw it run — an agent invoked it
-  // for them. `-y` matters for the same reason the guard does: without it npx
-  // can stop on its own install prompt.
-  const commandToRerun = ["npx", "-y", "@dittowords/cli@latest"]
-    .concat(process.argv.slice(2))
-    .map((arg) => (/\s/.test(arg) ? `"${arg}"` : arg))
-    .join(" ");
+  // Points at login rather than at whatever command was actually run, because
+  // login is the only one that does nothing but save the key — and because the
+  // agent can retry the real work itself afterwards. `-y` matters for the same
+  // reason the guard does: without it npx can stop on its own install prompt.
+  const loginCommand = "npx -y @dittowords/cli@latest login";
 
   // Every command needing a token funnels through here, so this is the one place
   // that has to cope with nobody being there to ask: run from an agent's tool
@@ -33,7 +30,7 @@ export default async function collectToken() {
         `\n\nTo set it up:\n` +
         `  1. Create a key at ${logger.url(apiKeysUrl)}\n` +
         `  2. Open a terminal — the app on your computer where you type commands — and run:\n\n` +
-        `       ${logger.info(commandToRerun)}\n\n` +
+        `       ${logger.info(loginCommand)}\n\n` +
         `     It'll ask for the key and remember it, so this is a one-time step.\n` +
         `\nSetting Ditto up for automation instead? Save your key as ${logger.info(
           "DITTO_TOKEN"

--- a/lib/src/services/apiToken/collectToken.ts
+++ b/lib/src/services/apiToken/collectToken.ts
@@ -1,4 +1,8 @@
+import open from "open";
+
+import appContext from "../../utils/appContext";
 import logger from "../../utils/logger";
+import { quit } from "../../utils/quit";
 import promptForApiToken from "./promptForApiToken";
 
 /**
@@ -6,10 +10,34 @@ import promptForApiToken from "./promptForApiToken";
  * @returns The collected token
  */
 export default async function collectToken() {
-  const apiUrl = logger.url("https://app.dittowords.com/developers/api-keys");
-  const tokenDescription = `To get started, you'll need your Ditto API key. You can find this at: ${apiUrl}.`;
+  const apiKeysUrl = `${appContext.appHost}/developers/api-keys`;
 
-  logger.writeLine(tokenDescription);
+  // Every command needing a token funnels through here, so this is the one place
+  // that has to cope with nobody being there to ask: run from an agent's tool
+  // call, enquirer has no TTY and waits forever. Stopping also keeps the key out
+  // of the agent's transcript, because the person types it somewhere else.
+  if (!process.stdin.isTTY) {
+    await quit(
+      logger.warnText(
+        "Ditto needs an API key, and there's no terminal here to type it into."
+      ) +
+        `\n\nCreate a key at ${logger.url(
+          apiKeysUrl
+        )}, then run this command again in your own terminal — or set ${logger.info(
+          "DITTO_TOKEN"
+        )} in your environment.`
+    );
+    return "";
+  }
+
+  logger.writeLine(
+    `To get started, you'll need your Ditto API key. We'll open ${logger.url(
+      apiKeysUrl
+    )} so you can create one.`
+  );
+
+  // Best effort: the URL is already on screen if the browser won't open.
+  await open(apiKeysUrl).catch(() => {});
 
   const response = await promptForApiToken();
   return response.token;

--- a/lib/src/services/apiToken/promptForAPIToken.test.ts
+++ b/lib/src/services/apiToken/promptForAPIToken.test.ts
@@ -18,7 +18,7 @@ describe("promptForApiToken", () => {
     const response = await promptForApiToken();
     expect(response).toEqual(mockResponse);
     expect(promptSpy).toHaveBeenCalledWith({
-      type: "input",
+      type: "password",
       name: "token",
       message: "What is your API key?",
       validate: expect.any(Function),

--- a/lib/src/services/apiToken/promptForApiToken.ts
+++ b/lib/src/services/apiToken/promptForApiToken.ts
@@ -15,7 +15,9 @@ export const validate = async (token: string) => {
  */
 export default async function promptForApiToken() {
   const response = await prompt<{ token: string }>({
-    type: "input",
+    // Masked so the key isn't left echoed in the user's scrollback, or captured
+    // by anything recording the terminal.
+    type: "password",
     name: "token",
     message: "What is your API key?",
     validate: validate as any,


### PR DESCRIPTION
## Overview

Adds a `login` command, and stops the CLI hanging when there's nobody there to answer a prompt.

**`ditto-cli login`** — saves an API key and does nothing else:

```
npx -y @dittowords/cli@latest login
```

Onboarding needs a command it can hand to a person who only needs to get authenticated, and neither existing command works for that. `pull` follows the token with `initProjectConfig` and then writes files into the repo; `scan` uploads a whole codebase scan. Told "this just saves your key," someone running either gets an error about a missing `ditto/config.yml`, or side effects they didn't ask for.

`login` resolves a token through the existing `initAPIToken` path — validating one that's already saved, or collecting and saving a new one — reports where it ended up, and exits. Safe to rerun, so an agent can send someone to it without risking a clobber.

**Non-interactive hangs.** Two enquirer prompts had no non-interactive path, so running the CLI where nobody can type — an agent's tool call, CI — hung forever instead of ending:

1. `collectToken`, reached by `pull` and `scan` whenever no key is saved
2. the `Open in browser?` confirm after a successful `scan`

Both now check `process.stdin.isTTY`. The token prompt exits pointing at `login`; the scan confirm is skipped, so the run finishes right after printing the scan URL.

Three smaller fixes in the same path:

- **Mask the key prompt** (`type: "input"` → `"password"`). The key was being echoed into the user's scrollback.
- **Open the API keys page** instead of only printing it, using the `open` dependency `scan` already uses.
- **Build the URL from `appContext.appHost`** instead of a hardcoded `https://app.dittowords.com`, so `DITTO_APP_HOST` no longer sends people to production.

`__mocks__/open.js` is new because `open` is ESM-only and jest can't transform it — four suites that transitively import `collectToken` fail without it.

## Context

Came out of reviewing dittowords/ditto-app#9270, which rewrites the onboarding setup prompts to walk an agent through installing the MCP server and running a scan. A lot of that prompt exists to work around the hang: it appends `< /dev/null` to the scan command, and reads the API key out of the clipboard rather than letting the CLI ask for it, because the CLI's own prompt can't be answered from a tool call.

That workaround puts a credential one stray `echo` away from the agent's transcript, and it's enforced only by prose instructions telling the model not to print things. Handling the non-interactive case here removes the need for both, and `login` gives that prompt a single step to hand the person instead.

Before, with no key saved:

```
$ DITTO_CONFIG_FILE=/tmp/nope node bin/ditto.js pull < /dev/null
To get started, you'll need your Ditto API key. You can find this at: https://app.dittowords.com/developers/api-keys.
? What is your API key? ›
    (hangs indefinitely)
```

After:

```
$ DITTO_CONFIG_FILE=/tmp/nope node bin/ditto.js pull < /dev/null
Ditto needs an API key — a password that lets Ditto reach your workspace. There's no way to type one in here.

To set it up:
  1. Create a key at https://app.dittowords.com/developers/api-keys
  2. Open a terminal — the app on your computer where you type commands — and run:

       npx -y @dittowords/cli@latest login

     It'll ask for the key and remember it, so this is a one-time step.

Setting Ditto up for automation instead? Save your key as DITTO_TOKEN and Ditto will use that.

$ echo $?
2
```

The wording assumes as little as possible: it says what an API key is on first use, explains "terminal" inline, and puts `DITTO_TOKEN` behind an "if you're automating this" framing so it reads as not-for-you to everyone else.

## Screenshots

n/a — terminal output is quoted above.

## Test Plan

Testing successfully completed locally via:

- [x] `yarn test` — 49 suites, 352 tests pass
- [x] `yarn build` succeeds
- [x] `--help` lists `login` with its description
- [x] New `login` unit tests: exits 0, says where the key was saved, credits `DITTO_TOKEN` when the key came from there, stays quiet when there was no terminal
- [x] New `collectToken` unit tests, non-TTY path: quits without prompting, doesn't launch a browser, names the `login` command rather than whatever was run
- [x] New `collectToken` unit tests, TTY path: opens the keys page, still prompts when the browser can't be opened
- [x] `pull` with `< /dev/null` and no saved key — hangs on `master`, exits 2 with instructions on this branch (both runs quoted above)
- [x] `login` in a real terminal (driven through a pty) — key prompt is masked, a bad key is rejected live by `/token-check`, and no config file is written
- [ ] `login` in a real terminal with a **valid** key — saves to `~/.config/ditto`; rerunning validates the saved key and confirms without prompting again
- [ ] `scan` in a real terminal — `Open in browser?` still appears and still opens
- [ ] `scan` with `< /dev/null` and a valid `DITTO_TOKEN` — prints the scan URL and exits 0 without waiting

The last three need a real API key, so I haven't run them. The `scan` confirm guard in particular is only verified by reading and by the build — worth someone exercising it before this merges.

## Follow-ups, not in this PR

- **Auth0 loopback flow.** `login` is where it'd go. The MCP OAuth work (ditto-app `d305ef9931`) advertises Auth0 as the authorization server, and Auth0 already supports authorization code + PKCE against a `127.0.0.1` redirect — so the person could click Authorize and never handle the key at all. The blocker is that `/token-check` and `/v1/*` accept only `Authorization: token <static-key>`, not a bearer, so those routes need bearer support first.
- **`DITTO_TOKEN` vs `DITTO_API_KEY`.** `appContext` reads `DITTO_TOKEN`; the legacy `getTokenFromEnv` reads `DITTO_API_KEY`. Worth confirming that split is deliberate.

Note: `npx tsc --noEmit` fails on `tsconfig.json(10,25)` with `TS5095`. That's pre-existing on `master`, unrelated to this change.
