### PR TITLE
Fix Auth0 config prod domain

### DIFF
--- a/lib/src/services/auth/auth0Config.test.ts
+++ b/lib/src/services/auth/auth0Config.test.ts
@@ -26,7 +26,7 @@ describe("getAuth0Config", () => {
   // An unfilled PROD block throws the missing-config error at every user.
   it("configures production from source with nothing in the environment", () => {
     expect(getAuth0Config("https://api.dittowords.com")).toEqual({
-      domain: expect.stringContaining("auth0.com"),
+      domain: "login.dittowords.com",
       clientId: expect.stringMatching(/.+/),
       audience: expect.stringMatching(/^https:\/\/.+/),
     });

--- a/lib/src/services/auth/auth0Config.ts
+++ b/lib/src/services/auth/auth0Config.ts
@@ -14,7 +14,7 @@ const PROD_API_HOSTNAME = "api.dittowords.com";
  * Public identifier information for production instance of Auth0
  */
 const PROD: Auth0Config = {
-  domain: "ditto-app.auth0.com",
+  domain: "login.dittowords.com",
   clientId: "8KEhl0kyB5nEMBUdYUwnGPw74AodU4tu",
   audience: "https://api.dittowords.com",
 };


### PR DESCRIPTION
## Overview

<!--- What does this PR do? --->
In the previous PR there was a misconfiguration with the prod Auth0 tenant that was missed. This patches the issue

<img width="508" height="188" alt="image" src="https://github.com/user-attachments/assets/4fbae67a-1f30-46d8-aceb-ecf73cfed08c" />


## Test Plan

Testing successfully completed in <env> via:

- [ ] ensure unit tests pass
- [ ] build and run `node bin/ditto.js login` against the production instance, and ensure logging in is successful
