### PR TITLE
[DIT-13463]: Stable occurrence index on scan candidates

### DIFF
--- a/lib/src/scan/extract.test.ts
+++ b/lib/src/scan/extract.test.ts
@@ -1,0 +1,47 @@
+import { assignOccurrenceIndexes } from "./extract";
+
+const hit = (value: string, line: number, column = 1) => ({
+  value,
+  location: { line, column },
+});
+
+describe("assignOccurrenceIndexes", () => {
+  test("numbers repeats in source order", () => {
+    const hits = [hit("Save", 40, 8), hit("Cancel", 12), hit("Save", 9)];
+
+    expect(assignOccurrenceIndexes(hits)).toEqual([1, 0, 0]);
+  });
+
+  test("numbers repeats regardless of the order hits arrive in", () => {
+    const sourceOrder = [hit("Save", 9), hit("Save", 22), hit("Save", 40)];
+    const kindGrouped = [hit("Save", 40), hit("Save", 9), hit("Save", 22)];
+
+    expect(assignOccurrenceIndexes(sourceOrder)).toEqual([0, 1, 2]);
+    expect(assignOccurrenceIndexes(kindGrouped)).toEqual([2, 0, 1]);
+  });
+
+  test("is stable when lines shift", () => {
+    const before = [hit("Save", 9), hit("Save", 40, 8)];
+    const after = [hit("Save", 11), hit("Save", 42, 8)];
+
+    expect(assignOccurrenceIndexes(after)).toEqual(
+      assignOccurrenceIndexes(before)
+    );
+  });
+
+  test("counts each distinct value separately", () => {
+    const hits = [hit("Save", 1), hit("Cancel", 2), hit("Save", 3)];
+
+    expect(assignOccurrenceIndexes(hits)).toEqual([0, 0, 1]);
+  });
+
+  test("orders hits on the same line by column", () => {
+    const hits = [hit("Save", 5, 30), hit("Save", 5, 10)];
+
+    expect(assignOccurrenceIndexes(hits)).toEqual([1, 0]);
+  });
+
+  test("returns an empty result for no hits", () => {
+    expect(assignOccurrenceIndexes([])).toEqual([]);
+  });
+});

--- a/lib/src/scan/extract.ts
+++ b/lib/src/scan/extract.ts
@@ -2,14 +2,15 @@ import fs from "fs/promises";
 import { globby } from "globby";
 import path from "path";
 
+import { createHash } from "crypto";
+import type { FileDiscoveryStats } from "./lang/file-discovery";
+import type { ExtractedHit } from "./lang/types";
+import { shouldEmit } from "./rules";
 import {
   DittoScanDetectionKindSchema,
   type DittoScanCandidate,
   type DittoScanDetectionKind,
 } from "./types";
-import { createHash } from "crypto";
-import type { FileDiscoveryStats } from "./lang/file-discovery";
-import { shouldEmit } from "./rules";
 import { walkCodebase } from "./walk";
 
 export interface DittoScanExtractOptions {
@@ -231,6 +232,29 @@ export function makeCandidateId(
     .slice(0, 12);
 }
 
+export function assignOccurrenceIndexes(
+  hits: readonly Pick<ExtractedHit, "value" | "location">[]
+): number[] {
+  const sourceOrder = hits
+    .map((_, index) => index)
+    .sort((a, b) => {
+      const left = hits[a].location;
+      const right = hits[b].location;
+      return left.line - right.line || left.column - right.column || a - b;
+    });
+
+  const seen = new Map<string, number>();
+  const indexes = new Array<number>(hits.length);
+
+  for (const index of sourceOrder) {
+    const count = seen.get(hits[index].value) ?? 0;
+    indexes[index] = count;
+    seen.set(hits[index].value, count + 1);
+  }
+
+  return indexes;
+}
+
 export async function runExtract(
   opts: DittoScanExtractOptions
 ): Promise<DittoScanExtractResult> {
@@ -266,8 +290,10 @@ export async function runExtract(
 
     const lines = file.source.split(/\r?\n/);
 
-    for (const hit of hits) {
-      if (!shouldEmit(hit.value, hit.context)) continue;
+    const emitted = hits.filter((hit) => shouldEmit(hit.value, hit.context));
+    const occurrenceIndexes = assignOccurrenceIndexes(emitted);
+
+    for (const [index, hit] of emitted.entries()) {
       const candidate: DittoScanCandidate = {
         id: makeCandidateId(
           file.relPath,
@@ -282,6 +308,7 @@ export async function runExtract(
           line: hit.location.line,
           column: hit.location.column,
         },
+        occurrence_index: occurrenceIndexes[index],
         language: file.languageLabel,
         locale_key: hit.localeKey ?? file.localeKey,
         i18n_key: hit.i18nKey ?? null,

--- a/lib/src/scan/types.ts
+++ b/lib/src/scan/types.ts
@@ -85,6 +85,7 @@ export const DittoScanCandidateSchema = z.object({
     line: z.number().int().positive(),
     column: z.number().int().positive(),
   }),
+  occurrence_index: z.number().int().nonnegative(),
   language: z.string(),
   // Locale key derived from the file's path when the candidate comes from a
   // per-locale i18n resource file admitted by i18n file discovery (e.g. "en"


### PR DESCRIPTION
## Overview

Adds `occurrence_index` to scan candidates: which repeat this string is within its file, counting from 0 in source order.

If a file has three `"Save"` strings, only the line number tells them apart today — and line numbers move whenever someone adds an import. The index doesn't, so a code link can still say which occurrence it points at after the file shifts.

- New `assignOccurrenceIndexes(hits)` in `lib/src/scan/extract.ts`, exported so it can be unit tested.
- **It sorts by `(line, column)` first, which is the point of the PR.** The JS extractor emits hits grouped by node kind (`lang/extractors/javascript.ts:37`), not source order, so counting them as they arrive gives an index that changes between runs of an unmodified file. Sorting happens on indices internally, so emitted candidate order is unchanged.
- `occurrence_index` added to `DittoScanCandidateSchema`.

Nothing server-side is needed to merge — zod strips unknown keys, so the field is ignored on arrival for now. A ditto-app follow-up adds it to `PtdCandidateSchema`, where the code link write will read it.

## Context

[DIT-13463](https://linear.app/dittowords/issue/DIT-13463/stable-occurrence-index-on-scan-candidates), part of [DIT-13405](https://linear.app/dittowords/issue/DIT-13405).

A code link identifies a hardcoded string by (file, value, occurrence index) — never by line number, which is display-only. This is the last of those three fields. [Schema design](https://app.notion.com/p/dittov3/CodeLink-schema-design-3bbcc8865c7a8172910edee6747d0fe0).

## Screenshots

None — extraction output only.

## Test Plan

Testing successfully completed locally via:

- [ ] `yarn test lib/src/scan` — 136 tests pass, 6 new
- [ ] Scan twice across an edit, below

Scan `v0-demo`, edit it, scan again. `--local` skips auth, upload and classification, so no server or token needed.

```bash
yarn scan ../v0-demo --local --out-dir /tmp/a
```

In `v0-demo/src/features/payments/SendMoney.tsx`, add an import and a const above the component so every line shifts down, then add one more `t("send.title")` below the two already there.

```bash
yarn scan ../v0-demo --local --out-dir /tmp/b

for f in a b; do
  jq -r 'select(.location.file | test("SendMoney")) | select(.value_raw | test("send\\.")) | "\(.location.line)  #\(.occurrence_index)  \(.value_raw)"' /tmp/$f/candidates.ndjson
done
```

```
before                          after
14  #0  "send.title"            17  #0  "send.title"
19  #0  "send.recipientLabel"   22  #0  "send.recipientLabel"
32  #1  "send.title"            35  #1  "send.title"
40  #1  "send.recipientLabel"   43  #1  "send.recipientLabel"
                                62  #2  "send.title"     ← the added one
```

**Every line moved by 3. Every index stayed.** The new occurrence is `#2` because it comes after the others in the file.

**Known limit:** add that third `t("send.title")` *above* the existing two instead and it becomes `#0`, renumbering the rest. Keyed strings survive that via `i18nKey`; hardcoded ones fall through to the value-in-file rung during reconciliation. The index only has to be stable against edits elsewhere in the file, not against inserting a new copy of itself.
