### PR TITLE
[DIT-13467]: send git metadata with post v2scan

### DIFF
--- a/lib/src/commands/scan.ts
+++ b/lib/src/commands/scan.ts
@@ -162,8 +162,10 @@ export const scan = async (
   });
 
   if (candidates.length === 0) {
-    logger.warnText(
-      `[ditto scan] no candidates extracted; writing empty classify output\n`
+    logger.writeLine(
+      logger.warnText(
+        `[ditto scan] no candidates extracted; writing empty classify output\n`
+      )
     );
   }
 

--- a/lib/src/commands/scan.ts
+++ b/lib/src/commands/scan.ts
@@ -4,15 +4,12 @@ import path from "path";
 import { prompt } from "enquirer";
 import open from "open";
 
-import logger from "../utils/logger";
 import {
   DittoScanCandidate,
   DittoScanExtractSummary,
   runExtract,
 } from "@dittowords/text-extract";
-import { quit } from "../utils/quit";
-import initAPIToken from "../services/apiToken/initAPIToken";
-import appContext from "../utils/appContext";
+import chalk from "chalk";
 import {
   asScanLimitInfo,
   initiateClassify,
@@ -25,8 +22,12 @@ import {
   formatDirectoryBreakdown,
   formatOverLimitMessage,
 } from "../scan/analyzeDirectories";
+import { readGitContext } from "../scan/git";
+import initAPIToken from "../services/apiToken/initAPIToken";
+import appContext from "../utils/appContext";
 import DittoError, { ErrorType } from "../utils/DittoError";
-import chalk from "chalk";
+import logger from "../utils/logger";
+import { quit } from "../utils/quit";
 
 // Yarn sets INIT_CWD to the directory the user invoked yarn from, which
 // matters when we proxy via `cd product-text-detection && yarn ptd`.
@@ -188,13 +189,31 @@ export const scan = async (
     await writeCandidatesNdjson(candidates, candidatesPath);
     logExtractSummary(extractSummary, candidatesPath);
   } else {
+    const gitContext = await readGitContext(resolvedInput);
+    if (!gitContext) {
+      logger.writeLine(
+        logger.warnText(
+          "[ditto scan] not a git repository - this scan can be imported but not re-synced\n"
+        )
+      );
+    } else if (gitContext.dirty) {
+      logger.writeLine(
+        logger.warnText(
+          `[ditto scan] uncommitted changes present; recording ${gitContext.commitSha.slice(
+            0,
+            7
+          )} as an approximate commit\n`
+        )
+      );
+    }
+
     const token = await initAPIToken();
     appContext.setAuthToken(token);
     const {
       candidatesSignedS3Url,
       record: { _id: recordId },
       planLimit,
-    } = await initiateScan(resolvedInput);
+    } = await initiateScan(resolvedInput, gitContext);
 
     // Fail before the wasted upload when the candidates we already extracted exceed it.
     if (

--- a/lib/src/http/scan.test.ts
+++ b/lib/src/http/scan.test.ts
@@ -15,35 +15,55 @@ describe("buildInitiateScanBody", () => {
     expect(buildInitiateScanBody("/repo", null)).toEqual({ path: "/repo" });
   });
 
-  test("sends repo, sha and branch when there is", () => {
-    expect(buildInitiateScanBody("/repo", context)).toEqual({
-      path: "/repo",
+  test("sends repo, sha, branch and repo-relative root when there is", () => {
+    expect(buildInitiateScanBody("/Users/laura/cli/lib/src", context)).toEqual({
+      path: "/Users/laura/cli/lib/src",
       repoKey: "github.com/dittowords/cli",
       gitCommitSha: "d3c1a8148580e1869c91ee6caadda17165ceb0ea",
       gitBranch: "master",
+      repoRelativeRoot: "lib/src",
     });
   });
 
+  test("sends an empty repo-relative root when scanning the repo root", () => {
+    const body = buildInitiateScanBody("/Users/laura/cli", context);
+    expect(body.repoRelativeRoot).toBe("");
+  });
+
+  test("omits the repo-relative root when the path is outside the repo", () => {
+    const body = buildInitiateScanBody("/elsewhere/src", context);
+    expect(body).not.toHaveProperty("repoRelativeRoot");
+  });
+
   test("sends a null branch on a detached HEAD", () => {
-    const body = buildInitiateScanBody("/repo", { ...context, branch: null });
+    const body = buildInitiateScanBody("/Users/laura/cli", {
+      ...context,
+      branch: null,
+    });
     expect(body.gitBranch).toBeNull();
     expect(body.gitCommitSha).toBe(context.commitSha);
   });
 
   test("never sends repoRoot or dirty", () => {
-    const body = buildInitiateScanBody("/repo", { ...context, dirty: true });
+    const body = buildInitiateScanBody("/Users/laura/cli/lib", {
+      ...context,
+      dirty: true,
+    });
     expect(Object.keys(body).sort()).toEqual([
       "gitBranch",
       "gitCommitSha",
       "path",
       "repoKey",
+      "repoRelativeRoot",
     ]);
   });
 
   test("every body satisfies the request schema", () => {
     for (const c of [null, context, { ...context, branch: null }]) {
       expect(() =>
-        ZInitiateScanBodySchema.parse(buildInitiateScanBody("/repo", c))
+        ZInitiateScanBodySchema.parse(
+          buildInitiateScanBody("/Users/laura/cli/lib", c)
+        )
       ).not.toThrow();
     }
   });

--- a/lib/src/http/scan.test.ts
+++ b/lib/src/http/scan.test.ts
@@ -1,0 +1,50 @@
+import { GitContext } from "../scan/git";
+import { buildInitiateScanBody } from "./scan";
+import { ZInitiateScanBodySchema } from "./types";
+
+const context: GitContext = {
+  repoKey: "github.com/dittowords/cli",
+  repoRoot: "/Users/laura/cli",
+  commitSha: "d3c1a8148580e1869c91ee6caadda17165ceb0ea",
+  branch: "master",
+  dirty: false,
+};
+
+describe("buildInitiateScanBody", () => {
+  test("sends only path when there is no git context", () => {
+    expect(buildInitiateScanBody("/repo", null)).toEqual({ path: "/repo" });
+  });
+
+  test("sends repo, sha and branch when there is", () => {
+    expect(buildInitiateScanBody("/repo", context)).toEqual({
+      path: "/repo",
+      repoKey: "github.com/dittowords/cli",
+      gitCommitSha: "d3c1a8148580e1869c91ee6caadda17165ceb0ea",
+      gitBranch: "master",
+    });
+  });
+
+  test("sends a null branch on a detached HEAD", () => {
+    const body = buildInitiateScanBody("/repo", { ...context, branch: null });
+    expect(body.gitBranch).toBeNull();
+    expect(body.gitCommitSha).toBe(context.commitSha);
+  });
+
+  test("never sends repoRoot or dirty", () => {
+    const body = buildInitiateScanBody("/repo", { ...context, dirty: true });
+    expect(Object.keys(body).sort()).toEqual([
+      "gitBranch",
+      "gitCommitSha",
+      "path",
+      "repoKey",
+    ]);
+  });
+
+  test("every body satisfies the request schema", () => {
+    for (const c of [null, context, { ...context, branch: null }]) {
+      expect(() =>
+        ZInitiateScanBodySchema.parse(buildInitiateScanBody("/repo", c))
+      ).not.toThrow();
+    }
+  });
+});

--- a/lib/src/http/scan.ts
+++ b/lib/src/http/scan.ts
@@ -1,6 +1,7 @@
 import { DittoScanCandidate } from "@dittowords/text-extract";
 import axios, { AxiosError } from "axios";
 import { Blob } from "buffer";
+import { relative, sep } from "node:path";
 import { GitContext } from "../scan/git";
 import DittoError, { ErrorType } from "../utils/DittoError";
 import getHttpClient from "./client";
@@ -74,6 +75,22 @@ export function scanLimitError(
 }
 
 /**
+ * Where the scanned directory sits inside the repo, as a forward-slash path the
+ * server prefixes onto candidate paths to build code links (`toRepoRelativePath`
+ * in ditto-app `services/ai/productTextDetection/codeLinks.ts`). `""` when the
+ * scan is the repo root, and `undefined` when the scanned path is somehow
+ * outside the repo, so a bad value never becomes a wrong link.
+ */
+function repoRelativeRoot(
+  scannedPath: string,
+  repoRoot: string
+): string | undefined {
+  const rel = relative(repoRoot, scannedPath);
+  if (rel.startsWith("..")) return undefined;
+  return sep === "/" ? rel : rel.split(sep).join("/");
+}
+
+/**
  * Builds the `POST /v2/scan` body. Without git context the body is exactly what
  * the CLI has always sent, so a scan outside a repo is unaffected.
  */
@@ -82,11 +99,13 @@ export function buildInitiateScanBody(
   gitContext?: GitContext | null
 ): IInitiateScanBody {
   if (!gitContext) return { path };
+  const root = repoRelativeRoot(path, gitContext.repoRoot);
   return {
     path,
     repoKey: gitContext.repoKey,
     gitCommitSha: gitContext.commitSha,
     gitBranch: gitContext.branch,
+    ...(root === undefined ? {} : { repoRelativeRoot: root }),
   };
 }
 

--- a/lib/src/http/scan.ts
+++ b/lib/src/http/scan.ts
@@ -1,9 +1,14 @@
-import axios, { AxiosError } from "axios";
-import getHttpClient from "./client";
-import { IInitiateScanResponse, ZInitiateScanResponse } from "./types";
 import { DittoScanCandidate } from "@dittowords/text-extract";
-import DittoError, { ErrorType } from "../utils/DittoError";
+import axios, { AxiosError } from "axios";
 import { Blob } from "buffer";
+import { GitContext } from "../scan/git";
+import DittoError, { ErrorType } from "../utils/DittoError";
+import getHttpClient from "./client";
+import {
+  IInitiateScanBody,
+  IInitiateScanResponse,
+  ZInitiateScanResponse,
+} from "./types";
 
 // Structured details from the classify step's SCAN_CANDIDATE_LIMIT_EXCEEDED
 // response.
@@ -68,12 +73,32 @@ export function scanLimitError(
   });
 }
 
+/**
+ * Builds the `POST /v2/scan` body. Without git context the body is exactly what
+ * the CLI has always sent, so a scan outside a repo is unaffected.
+ */
+export function buildInitiateScanBody(
+  path: string,
+  gitContext?: GitContext | null
+): IInitiateScanBody {
+  if (!gitContext) return { path };
+  return {
+    path,
+    repoKey: gitContext.repoKey,
+    gitCommitSha: gitContext.commitSha,
+    gitBranch: gitContext.branch,
+  };
+}
+
 export async function initiateScan(
-  path: string
+  path: string,
+  gitContext?: GitContext | null
 ): Promise<IInitiateScanResponse> {
+  const body = buildInitiateScanBody(path, gitContext);
+
   try {
     const httpClient = getHttpClient({});
-    const response = await httpClient.post("/v2/scan", { path });
+    const response = await httpClient.post("/v2/scan", body);
     return ZInitiateScanResponse.parse(response.data);
   } catch (e) {
     if (!(e instanceof AxiosError)) {

--- a/lib/src/http/types.ts
+++ b/lib/src/http/types.ts
@@ -183,6 +183,7 @@ export const ZInitiateScanBodySchema = z.object({
   repoKey: z.string().optional(),
   gitCommitSha: z.string().optional(),
   gitBranch: z.string().nullable().optional(),
+  repoRelativeRoot: z.string().optional(),
 });
 export type IInitiateScanBody = z.infer<typeof ZInitiateScanBodySchema>;
 export const ZInitiateScanResponse = z.object({

--- a/lib/src/http/types.ts
+++ b/lib/src/http/types.ts
@@ -180,7 +180,11 @@ export type IExportSwiftFileRequest = z.infer<typeof ZExportSwiftFileRequest>;
 
 export const ZInitiateScanBodySchema = z.object({
   path: z.string(),
+  repoKey: z.string().optional(),
+  gitCommitSha: z.string().optional(),
+  gitBranch: z.string().nullable().optional(),
 });
+export type IInitiateScanBody = z.infer<typeof ZInitiateScanBodySchema>;
 export const ZInitiateScanResponse = z.object({
   record: z.object({ _id: z.string() }),
   candidatesSignedS3Url: z.string(),


### PR DESCRIPTION
## Overview

Stacked on #154 — this diff is only the wiring.

`ditto scan` now tells the server which repo and commit it scanned, so a later scan can be matched against this one instead of importing every string again.

What `POST /v2/scan` sends:

```diff
  {
    "path": "/Users/laura/Desktop/Ditto/cli/lib/src/scan",
+   "repoKey": "github.com/dittowords/cli",
+   "gitCommitSha": "d3c1a8148580e1869c91ee6caadda17165ceb0ea",
+   "gitBranch": "laura/dit-13467-send-git-metadata-with-post-v2scan",
+   "repoRelativeRoot": "lib/src/scan"
  }
```

`repoRelativeRoot` is where the scan started inside the repo. Candidate paths come out relative to
the scanned directory, so ditto-app #9367 prefixes this root to build a repo-root-relative code link
path. `""` when the scan is the repo root, and omitted if the scanned path somehow sits outside the
repo, so a bad value never becomes a wrong link.

Outside a git repo the body is unchanged from today, and the scan still runs:

```
[ditto scan] not a git repository - this scan can be imported but not re-synced
```

With uncommitted changes it runs too, with a note that the commit is approximate.

Safe to merge before the server reads any of this — zod strips unknown keys, so `/v2/scan` ignores the new fields today.

## Context

- [DIT-13467](https://linear.app/dittowords/issue/DIT-13467/send-git-metadata-with-post-v2scan). Blocked by DIT-13461 (#154).
- `repoRelativeRoot` is the first of [DIT-13468](https://linear.app/dittowords/issue/DIT-13468)'s fields, pulled forward so #9367 has its prefix. `scannedPaths` and `scannedAllPaths` stay in that ticket.
- `repoRoot` and `dirty` are read but not sent: `repoRoot` is local-only — it only derives `repoRelativeRoot` — and `dirty` is a warning, not a field.

## Test Plan

- [ ] `yarn test` passes — `buildInitiateScanBody` covers the payload with and without git context, at the repo root, and outside the repo
- [ ] `ditto scan` inside a repo completes as before
- [ ] `ditto scan` in a directory that isn't a repo prints the warning and still completes

