### PR TITLE
[DIT-13468]: Send scanned path scope in the CLI scan

### DIFF
--- a/lib/src/http/scan.test.ts
+++ b/lib/src/http/scan.test.ts
@@ -4,7 +4,7 @@ import { ZInitiateScanBodySchema } from "./types";
 
 const context: GitContext = {
   repoKey: "github.com/dittowords/cli",
-  repoRoot: "/Users/laura/cli",
+  repoRoot: "/Users/dev/cli",
   commitSha: "d3c1a8148580e1869c91ee6caadda17165ceb0ea",
   branch: "master",
   dirty: false,
@@ -16,8 +16,8 @@ describe("buildInitiateScanBody", () => {
   });
 
   test("sends repo, sha, branch and repo-relative root when there is", () => {
-    expect(buildInitiateScanBody("/Users/laura/cli/lib/src", context)).toEqual({
-      path: "/Users/laura/cli/lib/src",
+    expect(buildInitiateScanBody("/Users/dev/cli/lib/src", context)).toEqual({
+      path: "/Users/dev/cli/lib/src",
       repoKey: "github.com/dittowords/cli",
       gitCommitSha: "d3c1a8148580e1869c91ee6caadda17165ceb0ea",
       gitBranch: "master",
@@ -28,7 +28,7 @@ describe("buildInitiateScanBody", () => {
   });
 
   test("scanning the repo root covers every path, with no path list", () => {
-    const body = buildInitiateScanBody("/Users/laura/cli", context);
+    const body = buildInitiateScanBody("/Users/dev/cli", context);
     expect(body.repoRelativeRoot).toBe("");
     expect(body.scannedAllPaths).toBe(true);
     expect(body).not.toHaveProperty("scannedPaths");
@@ -42,12 +42,12 @@ describe("buildInitiateScanBody", () => {
   });
 
   test("scanned paths are relative to the repo root, not the scanned root", () => {
-    const body = buildInitiateScanBody("/Users/laura/cli/lib/src", context);
+    const body = buildInitiateScanBody("/Users/dev/cli/lib/src", context);
     expect(body.scannedPaths).toEqual([body.repoRelativeRoot]);
   });
 
   test("sends a null branch on a detached HEAD", () => {
-    const body = buildInitiateScanBody("/Users/laura/cli", {
+    const body = buildInitiateScanBody("/Users/dev/cli", {
       ...context,
       branch: null,
     });
@@ -56,7 +56,7 @@ describe("buildInitiateScanBody", () => {
   });
 
   test("never sends repoRoot or dirty", () => {
-    const body = buildInitiateScanBody("/Users/laura/cli/lib", {
+    const body = buildInitiateScanBody("/Users/dev/cli/lib", {
       ...context,
       dirty: true,
     });
@@ -75,7 +75,7 @@ describe("buildInitiateScanBody", () => {
     for (const c of [null, context, { ...context, branch: null }]) {
       expect(() =>
         ZInitiateScanBodySchema.parse(
-          buildInitiateScanBody("/Users/laura/cli/lib", c)
+          buildInitiateScanBody("/Users/dev/cli/lib", c)
         )
       ).not.toThrow();
     }

--- a/lib/src/http/scan.test.ts
+++ b/lib/src/http/scan.test.ts
@@ -22,17 +22,28 @@ describe("buildInitiateScanBody", () => {
       gitCommitSha: "d3c1a8148580e1869c91ee6caadda17165ceb0ea",
       gitBranch: "master",
       repoRelativeRoot: "lib/src",
+      scannedAllPaths: false,
+      scannedPaths: ["lib/src"],
     });
   });
 
-  test("sends an empty repo-relative root when scanning the repo root", () => {
+  test("scanning the repo root covers every path, with no path list", () => {
     const body = buildInitiateScanBody("/Users/laura/cli", context);
     expect(body.repoRelativeRoot).toBe("");
+    expect(body.scannedAllPaths).toBe(true);
+    expect(body).not.toHaveProperty("scannedPaths");
   });
 
-  test("omits the repo-relative root when the path is outside the repo", () => {
+  test("omits the whole scope when the path is outside the repo", () => {
     const body = buildInitiateScanBody("/elsewhere/src", context);
     expect(body).not.toHaveProperty("repoRelativeRoot");
+    expect(body).not.toHaveProperty("scannedAllPaths");
+    expect(body).not.toHaveProperty("scannedPaths");
+  });
+
+  test("scanned paths are relative to the repo root, not the scanned root", () => {
+    const body = buildInitiateScanBody("/Users/laura/cli/lib/src", context);
+    expect(body.scannedPaths).toEqual([body.repoRelativeRoot]);
   });
 
   test("sends a null branch on a detached HEAD", () => {
@@ -55,6 +66,8 @@ describe("buildInitiateScanBody", () => {
       "path",
       "repoKey",
       "repoRelativeRoot",
+      "scannedAllPaths",
+      "scannedPaths",
     ]);
   });
 

--- a/lib/src/http/scan.ts
+++ b/lib/src/http/scan.ts
@@ -91,6 +91,22 @@ function repoRelativeRoot(
 }
 
 /**
+ * What the scan looked at, so the server only marks a code link removed where we
+ * actually looked. `scannedAllPaths` means the whole repo. Otherwise it's the one
+ * directory we scanned. Empty when the path is outside the repo, which the server
+ * treats as "looked nowhere".
+ */
+function scannedScope(root: string | undefined) {
+  if (root === undefined) return {};
+  if (root === "") return { repoRelativeRoot: root, scannedAllPaths: true };
+  return {
+    repoRelativeRoot: root,
+    scannedAllPaths: false,
+    scannedPaths: [root],
+  };
+}
+
+/**
  * Builds the `POST /v2/scan` body. Without git context the body is exactly what
  * the CLI has always sent, so a scan outside a repo is unaffected.
  */
@@ -105,7 +121,7 @@ export function buildInitiateScanBody(
     repoKey: gitContext.repoKey,
     gitCommitSha: gitContext.commitSha,
     gitBranch: gitContext.branch,
-    ...(root === undefined ? {} : { repoRelativeRoot: root }),
+    ...scannedScope(root),
   };
 }
 

--- a/lib/src/http/types.ts
+++ b/lib/src/http/types.ts
@@ -183,6 +183,8 @@ export const ZInitiateScanBodySchema = z.object({
   repoKey: z.string().optional(),
   gitCommitSha: z.string().optional(),
   gitBranch: z.string().nullable().optional(),
+  scannedAllPaths: z.boolean().optional(),
+  scannedPaths: z.array(z.string()).optional(),
   repoRelativeRoot: z.string().optional(),
 });
 export type IInitiateScanBody = z.infer<typeof ZInitiateScanBodySchema>;

--- a/lib/src/scan/git.test.ts
+++ b/lib/src/scan/git.test.ts
@@ -27,8 +27,8 @@ describe("normalizeRepoKey", () => {
       "https://gitlab.com/group/sub/deeper/app.git",
       "gitlab.com/group/sub/deeper/app",
     ],
-    ["/Users/laura/Desktop/Ditto/cli", null],
-    ["file:///Users/laura/Desktop/Ditto/cli", null],
+    ["/Users/dev/Desktop/Ditto/cli", null],
+    ["file:///Users/dev/Desktop/Ditto/cli", null],
     ["https://github.com/app", null],
     ["", null],
   ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dittowords/cli",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "description": "Command Line Interface for Ditto (dittowords.com).",
   "license": "MIT",
   "main": "bin/ditto.js",


### PR DESCRIPTION
## Overview

`ditto scan` now tells the server *where it looked*, so a later scan only reconciles code links inside the scanned scope instead of assuming everything it didn't see was deleted.

Two fields on `POST /v2/scan`, alongside the `repoRelativeRoot` that shipped in #155:

| scan target | `repoRelativeRoot` | `scannedAllPaths` | `scannedPaths` |
|---|---|---|---|
| repo root | `""` | `true` | omitted |
| subdirectory `src` | `"src"` | `false` | `["src"]` |
| not a git repo | omitted | omitted | omitted |

`scannedPaths` entries are relative to the repo root, matching what ditto-app #9391 validates. Where the scope is omitted, the server's `scannedAllPaths: false` default applies, so such a scan can never mark a code link removed.

`ditto scan` takes one path, so `scannedPaths` is always a one-element list restating `repoRelativeRoot`. Sent anyway so DIT-13449's reconcile has one shape to code against.

Bumps the package to 5.8.1 — nothing user-visible changes.

## Context

- [DIT-13468](https://linear.app/dittowords/issue/DIT-13468)
- Needs ditto-app #9391 to verify — until it merges, zod strips both fields at the API boundary. Safe to merge before that; the server just ignores them.

## Test Plan

Against a local app on the #9391 branch. Records checked in Compass: `ditto_db_v2` → `producttextdetections`, filter `{ repoKey: { $exists: true } }`.

- [x] `yarn test lib/src/http/scan.test.ts`
- [x] `yarn scan ~/Desktop/Ditto/v0-demo` → `repoRelativeRoot: ""`, `scannedAllPaths: true`, no `scannedPaths`
- [x] `yarn scan ~/Desktop/Ditto/v0-demo/src` → `repoRelativeRoot: "src"`, `scannedAllPaths: false`, `scannedPaths: ["src"]`
- [x] `yarn scan /tmp/not-a-repo` → no git fields on the record

